### PR TITLE
Additional fix for #8

### DIFF
--- a/dynamic/binary.go
+++ b/dynamic/binary.go
@@ -585,9 +585,9 @@ func (m *Message) unmarshalKnownField(fd *desc.FieldDescriptor, encoding int8, b
 		if t.Kind() == reflect.Slice && t != typeOfBytes {
 			// append slices if we unmarshalled a packed repeated field
 			sl := val.([]interface{})
-			m.values[fd.GetNumber()] = append(existing, sl...)
+			m.internalSetField(fd, append(existing, sl...))
 		} else {
-			m.values[fd.GetNumber()] = append(existing, val)
+			m.internalSetField(fd, append(existing, val))
 		}
 	} else {
 		m.internalSetField(fd, val)


### PR DESCRIPTION
 Previously this code path caused an `assignment to entry in nil map` `panic` for the `m.values` field if the first invocation for the `Message` is a `packed` `repeated` field.

To fix this, I call `internalSetField` which lazily initializes this field.