### PR TITLE
MarshalJSONWithOptions

### DIFF
--- a/dynamic/dynamic_message.go
+++ b/dynamic/dynamic_message.go
@@ -1583,7 +1583,7 @@ func (m *Message) knownFieldTags() []int {
 // allKnownFieldTags return tags of present and recognized fields, including those that are unset, in sorted order.
 func (m *Message) allKnownFieldTags() []int {
 	fds := m.md.GetFields()
-	keys := make([]int, 0, len(fds))
+	keys := make([]int, len(fds))
 
 	i := 0
 	for _, fd := range fds {

--- a/dynamic/dynamic_message.go
+++ b/dynamic/dynamic_message.go
@@ -1585,10 +1585,8 @@ func (m *Message) allKnownFieldTags() []int {
 	fds := m.md.GetFields()
 	keys := make([]int, len(fds))
 
-	i := 0
-	for _, fd := range fds {
+	for i, fd := range fds {
 		keys[i] = int(fd.GetNumber())
-		i++
 	}
 
 	for _, fd := range m.extraFields {

--- a/dynamic/dynamic_message.go
+++ b/dynamic/dynamic_message.go
@@ -1568,12 +1568,35 @@ func (m *Message) knownFieldTags() []int {
 	if len(m.values) == 0 {
 		return []int(nil)
 	}
+
 	keys := make([]int, len(m.values))
 	i := 0
 	for k := range m.values {
 		keys[i] = int(k)
 		i++
 	}
+
+	sort.Ints(keys)
+	return keys
+}
+
+// allKnownFieldTags return tags of present and recognized fields, including those that are unset, in sorted order.
+func (m *Message) allKnownFieldTags() []int {
+	fds := m.md.GetFields()
+	keys := make([]int, 0, len(fds))
+
+	i := 0
+	for _, fd := range fds {
+		keys[i] = int(fd.GetNumber())
+		i++
+	}
+
+	for _, fd := range m.extraFields {
+		if !fd.IsExtension() {
+			keys = append(keys, int(fd.GetNumber()))
+		}
+	}
+
 	sort.Ints(keys)
 	return keys
 }

--- a/dynamic/json.go
+++ b/dynamic/json.go
@@ -22,6 +22,11 @@ import (
 	"github.com/jhump/protoreflect/desc"
 )
 
+type MarshalJSONOpts struct {
+	Indent       bool
+	EmitDefaults bool
+}
+
 func (m *Message) MarshalJSON() ([]byte, error) {
 	var b indentBuffer
 	b.indent = -1 // no indentation


### PR DESCRIPTION
Fixes #5.

The implementation strategy largely follows the approach suggested in #8. The only exception is that I added a new method `allKnownFieldTags` instead of passing a flag to `knownFieldTags`. This is mainly because I think bool flags hurt readability at the callsite (e.g. `foo(true, false)`), but I'm happy to change it if you'd like.

How would you like this to be tested? It's obviously a bit thin at the moment.

This requires #17 to be merged first, otherwise the diff is largely unreadable.