### PR TITLE
lots of API changes for MessageFactory and MessageRegistry

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-go get -d github.com/golang/protobuf/{proto,ptypes,protoc-gen-go} google.golang.org/grpc golang.org/x/net/context
-
 fmtdiff="$(gofmt -s -l ./)"
 if [[ -n "$fmtdiff" ]]; then
   gofmt -s -l ./ >&2

--- a/desc/descriptor.go
+++ b/desc/descriptor.go
@@ -1619,7 +1619,8 @@ type protoMessage interface {
 }
 
 // LoadMessageDescriptor loads descriptor using the encoded descriptor proto returned by
-// Message.Descriptor() for the given message type.
+// Message.Descriptor() for the given message type. If the given type is not recognized,
+// then a nil descriptor is returned.
 func LoadMessageDescriptor(message string) (*MessageDescriptor, error) {
 	m := getMessageFromCache(message)
 	if m != nil {
@@ -1628,7 +1629,7 @@ func LoadMessageDescriptor(message string) (*MessageDescriptor, error) {
 
 	pt := proto.MessageType(message)
 	if pt == nil {
-		return nil, fmt.Errorf("unknown type: %q", message)
+		return nil, nil
 	}
 	msg, err := messageFromType(pt)
 	if err != nil {
@@ -1641,7 +1642,8 @@ func LoadMessageDescriptor(message string) (*MessageDescriptor, error) {
 }
 
 // LoadMessageDescriptorForType loads descriptor using the encoded descriptor proto returned
-// by Message.Descriptor() for the given message type.
+// by Message.Descriptor() for the given message type. If the given type is not recognized,
+// then a nil descriptor is returned.
 func LoadMessageDescriptorForType(messageType reflect.Type) (*MessageDescriptor, error) {
 	m, err := messageFromType(messageType)
 	if err != nil {
@@ -1651,9 +1653,13 @@ func LoadMessageDescriptorForType(messageType reflect.Type) (*MessageDescriptor,
 }
 
 // LoadMessageDescriptorForMessage loads descriptor using the encoded descriptor proto
-// returned by message.Descriptor().
+// returned by message.Descriptor(). If the given type is not recognized, then a nil
+// descriptor is returned.
 func LoadMessageDescriptorForMessage(message proto.Message) (*MessageDescriptor, error) {
 	name := proto.MessageName(message)
+	if name == "" {
+		return nil, nil
+	}
 	m := getMessageFromCache(name)
 	if m != nil {
 		return m, nil

--- a/dynamic/doc.go
+++ b/dynamic/doc.go
@@ -6,11 +6,12 @@
 // contexts, including the use of proto.Marshal and proto.Unmarshal to
 // serialize and de-serialize messages.
 //
-// This package also contains a type named ExtensionRegistry. This allows the
-// parsing of dynamic messages to recognize and parse extension fields. It is
-// the dynamic analog of the various extension-related methods in the proto
-// package (that allow code to query for known extensions and to get extension
-// field values from message objects).
+// This package also contains a several registries, for managing known types and
+// descriptors. The MessageRegistry is used for interacting with Any messages
+// where the actual embedded value may be a dynamic message. The KnownTypeRegistry
+// allows de-serialization to use generated message types, instead of dynamic
+// messages, for some kinds of nested message fields. And the ExtensionRegistry
+// is for recognizing and parsing extensions fields (for proto2 messages).
 //
 // The dynamic Message supports binary and text marshaling, using protobuf's
 // well-defined binary format and the same text format that protoc-generated

--- a/dynamic/equal.go
+++ b/dynamic/equal.go
@@ -162,7 +162,7 @@ func MessagesEqual(a, b proto.Message) bool {
 		if err != nil {
 			return false
 		}
-		db = NewMessageWithExtensionRegistry(md, da.er)
+		db = newMessageWithMessageFactory(md, da.mf)
 		if db.ConvertFrom(b) != nil {
 			return false
 		}
@@ -172,10 +172,17 @@ func MessagesEqual(a, b proto.Message) bool {
 		if err != nil {
 			return false
 		}
-		da = NewMessageWithExtensionRegistry(md, db.er)
+		da = newMessageWithMessageFactory(md, db.mf)
 		if da.ConvertFrom(a) != nil {
 			return false
 		}
 		return Equal(da, db)
 	}
+}
+
+func MessageName(msg proto.Message) string {
+	if dm, ok := msg.(*Message); ok {
+		return dm.md.GetFullyQualifiedName()
+	}
+	return proto.MessageName(msg)
 }

--- a/dynamic/extension_registry.go
+++ b/dynamic/extension_registry.go
@@ -10,13 +10,15 @@ import (
 	"github.com/jhump/protoreflect/desc"
 )
 
+// ExtensionRegistry is a registry of known extension fields. This is used to parse
+// extension fields encountered when de-serializing a dynamic message.
 type ExtensionRegistry struct {
 	includeDefault bool
 	mu             sync.RWMutex
 	exts           map[string]map[int32]*desc.FieldDescriptor
 }
 
-func NewRegistryWithDefaults() *ExtensionRegistry {
+func NewExtensionRegistryWithDefaults() *ExtensionRegistry {
 	return &ExtensionRegistry{includeDefault: true}
 }
 

--- a/dynamic/extension_registry_test.go
+++ b/dynamic/extension_registry_test.go
@@ -75,7 +75,7 @@ func TestExtensionRegistry_Empty(t *testing.T) {
 }
 
 func TestExtensionRegistry_Defaults(t *testing.T) {
-	er := NewRegistryWithDefaults()
+	er := NewExtensionRegistryWithDefaults()
 
 	fds := er.AllExtensionsForType("testprotos.AnotherTestMessage")
 	sort.Sort(fields(fds))

--- a/dynamic/grpcdynamic/stub_test.go
+++ b/dynamic/grpcdynamic/stub_test.go
@@ -74,8 +74,9 @@ var payload = &grpc_testing.Payload{
 func TestUnaryRpc(t *testing.T) {
 	resp, err := stub.InvokeRpc(context.Background(), unaryMd, &grpc_testing.SimpleRequest{Payload: payload})
 	testutil.Ok(t, err, "Failed to invoke unary RPC")
-	fd := resp.GetMessageDescriptor().FindFieldByName("payload")
-	p := resp.GetField(fd)
+	dm := resp.(*dynamic.Message)
+	fd := dm.GetMessageDescriptor().FindFieldByName("payload")
+	p := dm.GetField(fd)
 	testutil.Require(t, dynamic.MessagesEqual(p.(proto.Message), payload), "Incorrect payload returned from RPC: %v != %v", p, payload)
 }
 
@@ -89,8 +90,9 @@ func TestClientStreamingRpc(t *testing.T) {
 	}
 	resp, err := cs.CloseAndReceive()
 	testutil.Ok(t, err, "Failed to receive response")
-	fd := resp.GetMessageDescriptor().FindFieldByName("aggregated_payload_size")
-	sz := resp.GetField(fd)
+	dm := resp.(*dynamic.Message)
+	fd := dm.GetMessageDescriptor().FindFieldByName("aggregated_payload_size")
+	sz := dm.GetField(fd)
 	expectedSz := 3 * len(payload.Body)
 	testutil.Eq(t, expectedSz, int(sz.(int32)), "Incorrect response returned from RPC")
 }
@@ -106,8 +108,9 @@ func TestServerStreamingRpc(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		resp, err := ss.RecvMsg()
 		testutil.Ok(t, err, "Failed to receive response message")
-		fd := resp.GetMessageDescriptor().FindFieldByName("payload")
-		p := resp.GetField(fd)
+		dm := resp.(*dynamic.Message)
+		fd := dm.GetMessageDescriptor().FindFieldByName("payload")
+		p := dm.GetField(fd)
 		testutil.Require(t, dynamic.MessagesEqual(p.(proto.Message), payload), "Incorrect payload returned from RPC: %v != %v", p, payload)
 	}
 	_, err = ss.RecvMsg()
@@ -122,8 +125,9 @@ func TestBidiStreamingRpc(t *testing.T) {
 		testutil.Ok(t, err, "Failed to send request message")
 		resp, err := bds.RecvMsg()
 		testutil.Ok(t, err, "Failed to receive response message")
-		fd := resp.GetMessageDescriptor().FindFieldByName("payload")
-		p := resp.GetField(fd)
+		dm := resp.(*dynamic.Message)
+		fd := dm.GetMessageDescriptor().FindFieldByName("payload")
+		p := dm.GetField(fd)
 		testutil.Require(t, dynamic.MessagesEqual(p.(proto.Message), payload), "Incorrect payload returned from RPC: %v != %v", p, payload)
 	}
 	err = bds.CloseSend()

--- a/dynamic/message_factory.go
+++ b/dynamic/message_factory.go
@@ -1,0 +1,60 @@
+package dynamic
+
+import (
+	"github.com/golang/protobuf/proto"
+
+	"github.com/jhump/protoreflect/desc"
+)
+
+// MessageFactory can be used to create new empty message objects.
+type MessageFactory struct {
+	er  *ExtensionRegistry
+	ktr *KnownTypeRegistry
+}
+
+// NewMessageFactoryWithExtensionRegistry creates a new message factory where any
+// dynamic messages produced will use the given extension registry to recognize and
+// parse extension fields.
+func NewMessageFactoryWithExtensionRegistry(er *ExtensionRegistry) *MessageFactory {
+	return NewMessageFactoryWithRegistries(er, nil)
+}
+
+// NewMessageFactoryWithKnownTypeRegistry creates a new message factory where the
+// known types, per the given registry, will be returned as normal protobuf messages
+// (e.g. generated structs, instead of dynamic messages).
+func NewMessageFactoryWithKnownTypeRegistry(ktr *KnownTypeRegistry) *MessageFactory {
+	return NewMessageFactoryWithRegistries(nil, ktr)
+}
+
+// NewMessageFactoryWithDefaults creates a new message factory where all "default" types
+// (those for which protoc-generated code is statically linked into the Go program) are
+// known types. Is any dynamic messages are produced, they will recognize and parse all
+// "default" extension fields. This is the equivalent of:
+//   NewMessageFactoryWithRegistries(
+//       NewExtensionRegistryWithDefaults(),
+//       NewKnownTypeRegistryWithDefaults())
+func NewMessageFactoryWithDefaults() *MessageFactory {
+	return NewMessageFactoryWithRegistries(NewExtensionRegistryWithDefaults(), NewKnownTypeRegistryWithDefaults())
+}
+
+// NewMessageFactoryWithRegistries creates a new message factory with the given extension
+// and known type registries.
+func NewMessageFactoryWithRegistries(er *ExtensionRegistry, ktr *KnownTypeRegistry) *MessageFactory {
+	return &MessageFactory{
+		er:  er,
+		ktr: ktr,
+	}
+}
+
+// NewMessage creates a new empty message that corresponds to the given descriptor.
+// If the given descriptor describes a "known type" then that type is instantiated.
+// Otherwise, an empty dynamic message is returned.
+func (f *MessageFactory) NewMessage(md *desc.MessageDescriptor) proto.Message {
+	if f == nil {
+		return NewMessage(md)
+	}
+	if m := f.ktr.CreateIfKnown(md.GetFullyQualifiedName()); m != nil {
+		return m
+	}
+	return newMessageWithMessageFactory(md, f)
+}

--- a/dynamic/message_registry.go
+++ b/dynamic/message_registry.go
@@ -1,0 +1,333 @@
+package dynamic
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/any"
+
+	"github.com/jhump/protoreflect/desc"
+)
+
+const googleApisDomain = "type.googleapis.com"
+
+// MessageRegistry is a registry that maps URLs to message types. It allows for marsalling
+// and unmarshalling Any types to and from dynamic messages.
+type MessageRegistry struct {
+	includeDefault bool
+	resolver       typeResolver
+	mf             *MessageFactory
+	er             *ExtensionRegistry
+	mu             sync.RWMutex
+	messages       map[string]desc.Descriptor
+	domains        map[string]string
+	defaultDomain  string
+}
+
+func NewMessageRegistryWithDefaults() *MessageRegistry {
+	mf := NewMessageFactoryWithDefaults()
+	return &MessageRegistry{
+		includeDefault: true,
+		mf:             mf,
+		er:             mf.er,
+	}
+}
+
+// WithFetcher sets the TypeFetcher that this registry uses to resolve unknown
+// URLs. This method is not thread-safe and is intended to be used for one-time
+// initialization of the registry, before it published for use by other threads.
+func (r *MessageRegistry) WithFetcher(fetcher TypeFetcher) *MessageRegistry {
+	r.resolver = typeResolver{fetcher: fetcher, mr: r}
+	return r
+}
+
+// WithMessageFactory sets the MessageFactory used to instantiate any messages.
+// This method is not thread-safe and is intended to be used for one-time
+// initialization of the registry, before it published for use by other threads.
+func (r *MessageRegistry) WithMessageFactory(mf *MessageFactory) *MessageRegistry {
+	r.mf = mf
+	if mf == nil {
+		r.er = nil
+	} else {
+		r.er = mf.er
+	}
+	return r
+}
+
+// WithDefaultDomain sets the default domain used when constructing type URLs for
+// marshalling messages as Any types. If unspecified, the default domain is
+// "type.googleapis.com". This method is not thread-safe and is intended to be used
+// for one-time initialization of the registry, before it published for use by other
+// threads.
+func (r *MessageRegistry) WithDefaultDomain(domain string) *MessageRegistry {
+	domain = canonicalizeDomain(domain)
+	r.defaultDomain = domain
+	return r
+}
+
+func canonicalizeDomain(domain string) string {
+	domain = ensureScheme(domain)
+	if domain[len(domain)-1] == '/' {
+		return domain[:len(domain)-1]
+	}
+	return domain
+}
+
+func (r *MessageRegistry) AddMessage(url string, md *desc.MessageDescriptor) error {
+	if !strings.HasSuffix(url, "/"+md.GetFullyQualifiedName()) {
+		return fmt.Errorf("URL %s is invalid: it should end with path element %s", url, md.GetFullyQualifiedName())
+	}
+	url = ensureScheme(url)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.messages[url] = md
+	return nil
+}
+
+func (r *MessageRegistry) AddEnum(url string, ed *desc.EnumDescriptor) error {
+	if !strings.HasSuffix(url, "/"+ed.GetFullyQualifiedName()) {
+		return fmt.Errorf("URL %s is invalid: it should end with path element %s", url, ed.GetFullyQualifiedName())
+	}
+	url = ensureScheme(url)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.messages[url] = ed
+	return nil
+}
+
+func (r *MessageRegistry) AddFile(domain string, fd *desc.FileDescriptor) {
+	domain = canonicalizeDomain(domain)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.addEnumTypesLocked(domain, fd.GetEnumTypes())
+	r.addMessageTypesLocked(domain, fd.GetMessageTypes())
+}
+
+func (r *MessageRegistry) addEnumTypesLocked(domain string, enums []*desc.EnumDescriptor) {
+	for _, ed := range enums {
+		r.messages[fmt.Sprintf("%s/%s", domain, ed.GetFullyQualifiedName())] = ed
+	}
+}
+
+func (r *MessageRegistry) addMessageTypesLocked(domain string, msgs []*desc.MessageDescriptor) {
+	for _, md := range msgs {
+		r.messages[fmt.Sprintf("%s/%s", domain, md.GetFullyQualifiedName())] = md
+		r.addEnumTypesLocked(domain, md.GetNestedEnumTypes())
+		r.addMessageTypesLocked(domain, md.GetNestedMessageTypes())
+	}
+}
+
+func (r *MessageRegistry) AddDomainForElement(domain, packageOrTypeName string) {
+	if domain[len(domain)-1] == '/' {
+		domain = domain[:len(domain)-1]
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.domains[packageOrTypeName] = domain
+}
+
+func (r *MessageRegistry) FindMessageTypeByUrl(url string) (*desc.MessageDescriptor, error) {
+	if r == nil {
+		return nil, nil
+	}
+	url = ensureScheme(url)
+	r.mu.RLock()
+	m := r.messages[url]
+	r.mu.RUnlock()
+	if md, ok := m.(*desc.MessageDescriptor); ok {
+		return md, nil
+	}
+	if r.includeDefault {
+		pos := strings.LastIndex(url, "/")
+		var msgName string
+		if pos >= 0 {
+			msgName = url[pos+1:]
+		} else {
+			msgName = url
+		}
+		if md, err := desc.LoadMessageDescriptor(msgName); err != nil {
+			return nil, err
+		} else if md != nil {
+			return md, nil
+		}
+	}
+	if r.resolver.fetcher == nil {
+		return nil, nil
+	}
+	if md, err := r.resolver.resolveUrlToMessageDescriptor(url); err != nil {
+		return nil, err
+	} else {
+		return md, nil
+	}
+}
+
+func (r *MessageRegistry) FindEnumTypeByUrl(url string) (*desc.EnumDescriptor, error) {
+	if r == nil {
+		return nil, nil
+	}
+	url = ensureScheme(url)
+	r.mu.RLock()
+	m := r.messages[url]
+	r.mu.RUnlock()
+	if ed, ok := m.(*desc.EnumDescriptor); ok {
+		return ed, nil
+	}
+	if r.resolver.fetcher == nil {
+		return nil, nil
+	}
+	if ed, err := r.resolver.resolveUrlToEnumDescriptor(url); err != nil {
+		return nil, err
+	} else {
+		return ed, nil
+	}
+}
+
+func (r *MessageRegistry) UnmarshalAny(any *any.Any) (proto.Message, error) {
+	return r.unmarshalAny(any, r.FindMessageTypeByUrl)
+}
+
+func (r *MessageRegistry) unmarshalAny(any *any.Any, fetch func(string) (*desc.MessageDescriptor, error)) (proto.Message, error) {
+	name, err := ptypes.AnyMessageName(any)
+	if err != nil {
+		return nil, err
+	}
+
+	var msg proto.Message
+	if r == nil {
+		// a nil registry only knows about well-known types
+		if msg = (*KnownTypeRegistry)(nil).CreateIfKnown(name); msg == nil {
+			return nil, fmt.Errorf("Unknown message type: %s", any.TypeUrl)
+		}
+	} else {
+		var ktr *KnownTypeRegistry
+		if r.mf != nil {
+			ktr = r.mf.ktr
+		}
+		if msg = ktr.CreateIfKnown(name); msg == nil {
+			if md, err := fetch(any.TypeUrl); err != nil {
+				return nil, err
+			} else if md == nil {
+				return nil, fmt.Errorf("Unknown message type: %s", any.TypeUrl)
+			} else {
+				msg = newMessageWithMessageFactory(md, r.mf)
+			}
+		}
+	}
+
+	err = proto.Unmarshal(any.Value, msg)
+	if err != nil {
+		return nil, err
+	} else {
+		return msg, nil
+	}
+}
+
+func (r *MessageRegistry) MarshalAny(m proto.Message) (*any.Any, error) {
+	name := MessageName(m)
+	if name == "" {
+		return nil, fmt.Errorf("could not determine message name for %v", reflect.TypeOf(m))
+	}
+	r.mu.RLock()
+	domain := r.domains[name]
+	if domain == "" {
+		// lookup domain for the package
+		domain = r.domains[name[strings.LastIndex(name, ".")+1:]]
+	}
+	r.mu.RUnlock()
+
+	if domain == "" {
+		domain = r.defaultDomain
+		if domain == "" {
+			domain = googleApisDomain
+		}
+	}
+
+	if b, err := proto.Marshal(m); err != nil {
+		return nil, err
+	} else {
+		return &any.Any{TypeUrl: fmt.Sprintf("%s/%s", domain, name), Value: b}, nil
+	}
+}
+
+type wkt interface {
+	XXX_WellKnownType() string
+}
+
+// KnownTypeRegistry is a registry of known message types, as identified by their
+// fully-qualified name. A known message type is one for which a protoc-generated
+// struct exists, so a dynamic message is not necessary to represent it. A
+// MessageFactory uses a KnownTypeRegistry to decide whether to create a generated
+// struct or a dynamic message. The zero-value registry (including the behavior of
+// a nil pointer) only knows about the "well-known types" in protobuf. These
+// include only the wrapper types and a handful of other special types like Any,
+// Duration, and Timestamp.
+type KnownTypeRegistry struct {
+	excludeWkt     bool
+	includeDefault bool
+	mu             sync.RWMutex
+	types          map[string]reflect.Type
+}
+
+// NewKnownTypeRegistryWithDefaults creates a new registry that knows about all
+// "default" types (those for which protoc-generated code is statically linked
+// into the Go program).
+func NewKnownTypeRegistryWithDefaults() *KnownTypeRegistry {
+	return &KnownTypeRegistry{includeDefault: true}
+}
+
+// NewKnownTypeRegistryWithoutWellKnownTypes creates a new registry that does *not*
+// include the "well-known types" in protobuf. So even well-known types would be
+// represented by a dynamic message.
+func NewKnownTypeRegistryWithoutWellKnownTypes() *KnownTypeRegistry {
+	return &KnownTypeRegistry{excludeWkt: true}
+}
+
+func (r *KnownTypeRegistry) AddKnownType(kts ...proto.Message) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.types == nil {
+		r.types = map[string]reflect.Type{}
+	}
+	for _, kt := range kts {
+		r.types[proto.MessageName(kt)] = reflect.TypeOf(kt)
+	}
+}
+
+func (r *KnownTypeRegistry) CreateIfKnown(messageName string) proto.Message {
+	var msgType reflect.Type
+	if r == nil {
+		// a nil registry behaves the same as zero value instance: only know of well-known types
+		t := proto.MessageType(messageName)
+		if _, ok := t.(wkt); ok {
+			msgType = t
+		}
+	} else {
+		if r.includeDefault {
+			msgType = proto.MessageType(messageName)
+		} else if !r.excludeWkt {
+			t := proto.MessageType(messageName)
+			if _, ok := t.(wkt); ok {
+				msgType = t
+			}
+		}
+		if msgType == nil {
+			r.mu.RLock()
+			msgType = r.types[messageName]
+			r.mu.RUnlock()
+		}
+	}
+
+	if msgType == nil {
+		return nil
+	}
+
+	if msgType.Kind() == reflect.Ptr {
+		return reflect.New(msgType.Elem()).Interface().(proto.Message)
+	} else {
+		return reflect.New(msgType).Elem().Interface().(proto.Message)
+	}
+}

--- a/dynamic/ptype_resolver.go
+++ b/dynamic/ptype_resolver.go
@@ -1,0 +1,841 @@
+package dynamic
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/golang/protobuf/ptypes/wrappers"
+	"golang.org/x/net/context"
+	"google.golang.org/genproto/protobuf/ptype"
+
+	"github.com/jhump/protoreflect/desc"
+)
+
+var enumOptionsDesc, enumValueOptionsDesc, msgOptionsDesc, fieldOptionsDesc *desc.MessageDescriptor
+
+func init() {
+	var err error
+	enumOptionsDesc, err = desc.LoadMessageDescriptorForMessage((*descriptor.EnumOptions)(nil))
+	if err != nil {
+		panic("Failed to load descriptor for EnumOptions")
+	}
+	enumValueOptionsDesc, err = desc.LoadMessageDescriptorForMessage((*descriptor.EnumValueOptions)(nil))
+	if err != nil {
+		panic("Failed to load descriptor for EnumValueOptions")
+	}
+	msgOptionsDesc, err = desc.LoadMessageDescriptorForMessage((*descriptor.MessageOptions)(nil))
+	if err != nil {
+		panic("Failed to load descriptor for MessageOptions")
+	}
+	fieldOptionsDesc, err = desc.LoadMessageDescriptorForMessage((*descriptor.FieldOptions)(nil))
+	if err != nil {
+		panic("Failed to load descriptor for FieldOptions")
+	}
+}
+
+// TypeFetcher is a simple operation that retrieves a type definition for a given type URL.
+// The returned proto message will be either a *ptype.Enum or a *ptype.Type, depending on
+// whether the enum flag is true or not.
+type TypeFetcher func(url string, enum bool) (proto.Message, error)
+
+// CachingTypeFetcher adds a caching layer to the given type fetcher. Queries for
+// types that have already been fetched will not result in another call to the
+// underlying fetcher and instead are retrieved from the cache.
+func CachingTypeFetcher(fetcher TypeFetcher) TypeFetcher {
+	c := protoCache{entries: map[string]*protoCacheEntry{}}
+	return func(typeUrl string, enum bool) (proto.Message, error) {
+		m, err := c.getOrLoad(typeUrl, func() (proto.Message, error) {
+			return fetcher(typeUrl, enum)
+		})
+		if err != nil {
+			return nil, err
+		}
+		if _, isEnum := m.(*ptype.Enum); enum != isEnum {
+			var want, got string
+			if enum {
+				want = "enum"
+				got = "message"
+			} else {
+				want = "message"
+				got = "enum"
+			}
+			return nil, fmt.Errorf("Type for url %v is the wrong type: wanted %s, got %s", typeUrl, want, got)
+		}
+		return m.(proto.Message), nil
+	}
+}
+
+type protoCache struct {
+	mu      sync.RWMutex
+	entries map[string]*protoCacheEntry
+}
+
+type protoCacheEntry struct {
+	msg proto.Message
+	err error
+	wg  sync.WaitGroup
+}
+
+func (c *protoCache) getOrLoad(key string, loader func() (proto.Message, error)) (m proto.Message, err error) {
+	// see if it's cached
+	c.mu.RLock()
+	cached, ok := c.entries[key]
+	c.mu.RUnlock()
+	if ok {
+		cached.wg.Wait()
+		return cached.msg, cached.err
+	}
+
+	// must delegate and cache the result
+	c.mu.Lock()
+	// double-check, in case it was added concurrently while we were upgrading lock
+	cached, ok = c.entries[key]
+	if ok {
+		c.mu.Unlock()
+		cached.wg.Wait()
+		return cached.msg, cached.err
+	}
+	e := &protoCacheEntry{}
+	e.wg.Add(1)
+	c.entries[key] = e
+	c.mu.Unlock()
+	defer func() {
+		if err != nil {
+			// don't leave broken entry in the cache
+			c.mu.Lock()
+			delete(c.entries, key)
+			c.mu.Unlock()
+		}
+		e.msg, e.err = m, err
+		e.wg.Done()
+	}()
+
+	return loader()
+}
+
+func (c *protoCache) put(key string, m proto.Message) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[key] = &protoCacheEntry{msg: m}
+}
+
+// HttpTypeFetcher returns a TypeFetcher that uses the given HTTP transport to query and
+// download type definitions. The given szLimit is the maximum response size accepted. If
+// used from multiple goroutines (like when a type's dependency graph is resolved in
+// parallel), this resolver limits the number of parallel queries/downloads to the given
+// parLimit.
+func HttpTypeFetcher(transport http.RoundTripper, szLimit, parLimit int) TypeFetcher {
+	sem := semaphore{count: parLimit, permits: parLimit}
+	return CachingTypeFetcher(func(typeUrl string, enum bool) (proto.Message, error) {
+		sem.Acquire()
+		defer sem.Release()
+
+		// build URL
+		u, err := url.Parse(ensureScheme(typeUrl))
+		if err != nil {
+			return nil, err
+		}
+
+		resp, err := transport.RoundTrip(&http.Request{URL: u})
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+
+		if resp.ContentLength > int64(szLimit) {
+			return nil, fmt.Errorf("Type definition size %d is larger than limit of %d", resp.ContentLength, szLimit)
+		}
+
+		// download the response, up to the given size limit, into a buffer
+		buf := bufferPool.Get().([]byte)
+		defer bufferPool.Put(buf)
+		var b bytes.Buffer
+		for {
+			n, err := resp.Body.Read(buf)
+			if err != nil && err != io.EOF {
+				return nil, err
+			}
+			if n > 0 {
+				if b.Len()+n > szLimit {
+					return nil, fmt.Errorf("Type definition size %d is larger than limit of %d", resp.ContentLength, szLimit)
+				}
+				b.Write(buf[:n])
+			}
+			if err == io.EOF {
+				break
+			}
+		}
+
+		// now we can de-serialize the type definition
+		if enum {
+			var ret ptype.Enum
+			if err = proto.Unmarshal(b.Bytes(), &ret); err != nil {
+				return nil, err
+			}
+			return &ret, nil
+		} else {
+			var ret ptype.Type
+			if err = proto.Unmarshal(b.Bytes(), &ret); err != nil {
+				return nil, err
+			}
+			return &ret, nil
+		}
+	})
+}
+
+func ensureScheme(url string) string {
+	pos := strings.Index(url, "://")
+	if pos < 0 {
+		return "https://" + url
+	}
+	return url
+}
+
+var bufferPool = sync.Pool{New: func() interface{} {
+	return make([]byte, 8192)
+}}
+
+type semaphore struct {
+	lock    sync.Mutex
+	count   int
+	permits int
+	cond    sync.Cond
+}
+
+func (s *semaphore) Acquire() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if s.cond.L == nil {
+		s.cond.L = &s.lock
+	}
+
+	for s.count == 0 {
+		s.cond.Wait()
+	}
+	s.count--
+}
+
+func (s *semaphore) Release() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if s.cond.L == nil {
+		s.cond.L = &s.lock
+	}
+
+	if s.count == s.permits {
+		panic("call to Release() without corresponding call to Acquire()")
+	}
+	s.count++
+	s.cond.Signal()
+}
+
+type typeResolver struct {
+	fetcher TypeFetcher
+	mr      *MessageRegistry
+	mu      sync.RWMutex
+	cache   map[string]desc.Descriptor
+}
+
+func (r *typeResolver) resolveUrlToMessageDescriptor(url string) (md *desc.MessageDescriptor, err error) {
+	r.mu.RLock()
+	cached := r.cache[url]
+	r.mu.RUnlock()
+	if cached != nil {
+		var ok bool
+		if md, ok = cached.(*desc.MessageDescriptor); ok {
+			return
+		} else {
+			err = fmt.Errorf("Type for url %v is the wrong type: wanted message, got enum", url)
+			return
+		}
+	}
+
+	rc := newResolutionContext()
+	if err = rc.addType(url, r.fetcher, false); err != nil {
+		return
+	}
+
+	var files map[string]*desc.FileDescriptor
+	files, err = rc.toFileDescriptors(r.mr)
+	if err != nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for typeUrl, fileName := range rc.typeLocations {
+		fd := files[fileName]
+		sym := fd.FindSymbol(typeName(typeUrl))
+		r.cache[typeUrl] = sym
+		if url == typeUrl {
+			md = sym.(*desc.MessageDescriptor)
+		}
+	}
+	return
+}
+
+func (r *typeResolver) resolveUrlToEnumDescriptor(url string) (ed *desc.EnumDescriptor, err error) {
+	r.mu.RLock()
+	cached := r.cache[url]
+	r.mu.RUnlock()
+	if cached != nil {
+		var ok bool
+		if ed, ok = cached.(*desc.EnumDescriptor); ok {
+			return
+		} else {
+			err = fmt.Errorf("Type for url %v is the wrong type: wanted enum, got message", url)
+			return
+		}
+	}
+
+	rc := newResolutionContext()
+	if err = rc.addType(url, r.fetcher, true); err != nil {
+		return
+	}
+
+	var files map[string]*desc.FileDescriptor
+	files, err = rc.toFileDescriptors(r.mr)
+	if err != nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for typeUrl, fileName := range rc.typeLocations {
+		fd := files[fileName]
+		sym := fd.FindSymbol(typeName(typeUrl))
+		r.cache[typeUrl] = sym
+		if url == typeUrl {
+			ed = sym.(*desc.EnumDescriptor)
+		}
+	}
+	return
+}
+
+type resolutionContext struct {
+	ctx           context.Context
+	cancel        func()
+	mu            sync.Mutex
+	files         map[string]*fileEntry
+	typeLocations map[string]string
+	unknownCount  int
+}
+
+func newResolutionContext() *resolutionContext {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &resolutionContext{
+		ctx:           ctx,
+		cancel:        cancel,
+		typeLocations: map[string]string{},
+		files:         map[string]*fileEntry{},
+	}
+}
+
+func (rc *resolutionContext) addType(url string, fetcher TypeFetcher, enum bool) error {
+	if err := rc.ctx.Err(); err != nil {
+		return err
+	}
+	m, err := fetcher(url, enum)
+	if err != nil {
+		return err
+	}
+
+	if enum {
+		e := m.(*ptype.Enum)
+
+		rc.mu.Lock()
+		defer rc.mu.Unlock()
+
+		var fileName string
+		if e.SourceContext != nil && e.SourceContext.FileName != "" {
+			fileName = e.SourceContext.FileName
+		} else {
+			fileName = fmt.Sprintf("--unknown--%d.proto", rc.unknownCount)
+			rc.unknownCount++
+		}
+		rc.typeLocations[url] = fileName
+
+		fe := rc.files[fileName]
+		if fe == nil {
+			fe = &fileEntry{}
+			rc.files[fileName] = fe
+		}
+		fe.types.addType(e.Name, e)
+		if e.Syntax == ptype.Syntax_SYNTAX_PROTO3 {
+			fe.proto3 = true
+		}
+		return nil
+	}
+
+	// for messages, resolve dependencies in parallel
+	t := m.(*ptype.Type)
+	var wg sync.WaitGroup
+	var failed int32
+	for _, f := range t.Fields {
+		if f.Kind == ptype.Field_TYPE_GROUP || f.Kind == ptype.Field_TYPE_MESSAGE || f.Kind == ptype.Field_TYPE_ENUM {
+			typeUrl := ensureScheme(f.TypeUrl)
+			kind := f.Kind
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				innerErr := rc.addType(typeUrl, fetcher, kind == ptype.Field_TYPE_ENUM)
+				// We want the "real" error to ultimately propagate to root, not
+				// one of the resulting cancellations (from any concurrent goroutines
+				// working in the same resolution context).
+				if innerErr != nil && (rc.ctx.Err() == nil || innerErr != context.Canceled) {
+					if atomic.CompareAndSwapInt32(&failed, 0, 1) {
+						err = innerErr
+					}
+					rc.cancel()
+				}
+			}()
+		}
+	}
+	wg.Wait()
+	if err != nil {
+		return err
+	}
+	// double-check if context has been cancelled
+	if err = rc.ctx.Err(); err != nil {
+		return err
+	}
+
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+
+	var fileName string
+	if t.SourceContext != nil && t.SourceContext.FileName != "" {
+		fileName = t.SourceContext.FileName
+	} else {
+		fileName = fmt.Sprintf("--unknown--%d.proto", rc.unknownCount)
+		rc.unknownCount++
+	}
+	rc.typeLocations[url] = fileName
+
+	fe := rc.files[fileName]
+	if fe == nil {
+		fe = &fileEntry{}
+		rc.files[fileName] = fe
+	}
+	fe.types.addType(t.Name, t)
+	if t.Syntax == ptype.Syntax_SYNTAX_PROTO3 {
+		fe.proto3 = true
+	}
+
+	for _, f := range t.Fields {
+		if f.Kind == ptype.Field_TYPE_GROUP || f.Kind == ptype.Field_TYPE_MESSAGE || f.Kind == ptype.Field_TYPE_ENUM {
+			typeUrl := ensureScheme(f.TypeUrl)
+			if fe.deps == nil {
+				fe.deps = map[string]struct{}{}
+			}
+			dep := rc.typeLocations[typeUrl]
+			if dep != fileName {
+				fe.deps[dep] = struct{}{}
+			}
+		}
+	}
+	return nil
+}
+
+func (rc *resolutionContext) toFileDescriptors(mr *MessageRegistry) (map[string]*desc.FileDescriptor, error) {
+	fdps := map[string]*descriptor.FileDescriptorProto{}
+	for name, file := range rc.files {
+		fdps[name] = file.toFileDescriptor(name, mr)
+	}
+	fds := map[string]*desc.FileDescriptor{}
+	for name, fdp := range fdps {
+		if _, ok := fds[name]; ok {
+			continue
+		}
+		var err error
+		if fds[name], err = makeFileDesc(fdp, fds, fdps); err != nil {
+			return nil, err
+		}
+	}
+	return fds, nil
+}
+
+func makeFileDesc(fdp *descriptor.FileDescriptorProto, fds map[string]*desc.FileDescriptor, fdps map[string]*descriptor.FileDescriptorProto) (*desc.FileDescriptor, error) {
+	deps := make([]*desc.FileDescriptor, len(fdp.Dependency))
+	for i, dep := range fdp.Dependency {
+		d := fds[dep]
+		if d == nil {
+			var err error
+			d, err = makeFileDesc(fdps[dep], fds, fdps)
+			if err != nil {
+				return nil, err
+			}
+		}
+		deps[i] = d
+	}
+	if fd, err := desc.CreateFileDescriptor(fdp, deps...); err != nil {
+		return nil, err
+	} else {
+		fds[fdp.GetName()] = fd
+		return fd, nil
+	}
+}
+
+type fileEntry struct {
+	types  typeTrie
+	deps   map[string]struct{}
+	proto3 bool
+}
+
+func (fe fileEntry) toFileDescriptor(name string, mr *MessageRegistry) *descriptor.FileDescriptorProto {
+	var pkg bytes.Buffer
+	tt := &fe.types
+	first := true
+	last := ""
+	for tt.typ == nil {
+		if last != "" {
+			if first {
+				first = false
+			} else {
+				pkg.WriteByte('.')
+			}
+			pkg.WriteString(last)
+		}
+		if len(tt.children) != 1 {
+			break
+		}
+		for last, tt = range tt.children {
+		}
+	}
+	fd := createFileDescriptor(name, pkg.String(), fe.proto3, fe.deps)
+	if tt.typ != nil {
+		msg, enum := tt.toDescriptor(last, mr)
+		if msg != nil {
+			fd.MessageType = append(fd.MessageType, msg)
+		}
+		if enum != nil {
+			fd.EnumType = append(fd.EnumType, enum)
+		}
+	} else {
+		for name, nested := range tt.children {
+			msg, enum := nested.toDescriptor(name, mr)
+			if msg != nil {
+				fd.MessageType = append(fd.MessageType, msg)
+			}
+			if enum != nil {
+				fd.EnumType = append(fd.EnumType, enum)
+			}
+		}
+	}
+	return fd
+}
+
+type typeTrie struct {
+	children map[string]*typeTrie
+	typ      proto.Message
+}
+
+func (t *typeTrie) addType(key string, typ proto.Message) {
+	if key == "" {
+		t.typ = typ
+		return
+	}
+	if t.children == nil {
+		t.children = map[string]*typeTrie{}
+	}
+	curr, rest := split(key)
+	child := t.children[curr]
+	if child == nil {
+		child = &typeTrie{}
+		t.children[curr] = child
+	}
+	child.addType(rest, typ)
+}
+
+func (t *typeTrie) toDescriptor(name string, mr *MessageRegistry) (*descriptor.DescriptorProto, *descriptor.EnumDescriptorProto) {
+	if en, ok := t.typ.(*ptype.Enum); ok {
+		return nil, createEnumDescriptor(en, mr)
+	} else {
+		var msg *descriptor.DescriptorProto
+		if t.typ == nil {
+			msg = createIntermediateMessageDescriptor(name)
+		} else {
+			msg = createMessageDescriptor(t.typ.(*ptype.Type), mr)
+		}
+		for name, nested := range t.children {
+			msg, enum := nested.toDescriptor(name, mr)
+			if msg != nil {
+				msg.NestedType = append(msg.NestedType, msg)
+			}
+			if enum != nil {
+				msg.EnumType = append(msg.EnumType, enum)
+			}
+		}
+		return msg, nil
+	}
+}
+
+func split(s string) (string, string) {
+	pos := strings.Index(s, ".")
+	if pos >= 0 {
+		return s[:pos], s[pos+1:]
+	} else {
+		return s, ""
+	}
+}
+
+func createEnumDescriptor(e *ptype.Enum, mr *MessageRegistry) *descriptor.EnumDescriptorProto {
+	var opts *descriptor.EnumOptions
+	if len(e.Options) > 0 {
+		dopts := createOptions(e.Options, enumOptionsDesc, mr)
+		dopts.ConvertTo(opts)
+	}
+
+	var vals []*descriptor.EnumValueDescriptorProto
+	for _, v := range e.Enumvalue {
+		evd := createEnumValueDescriptor(v, mr)
+		vals = append(vals, evd)
+	}
+
+	return &descriptor.EnumDescriptorProto{
+		Name:    proto.String(base(e.Name)),
+		Options: opts,
+		Value:   vals,
+	}
+}
+
+func createEnumValueDescriptor(v *ptype.EnumValue, mr *MessageRegistry) *descriptor.EnumValueDescriptorProto {
+	var opts *descriptor.EnumValueOptions
+	if len(v.Options) > 0 {
+		dopts := createOptions(v.Options, enumValueOptionsDesc, mr)
+		dopts.ConvertTo(opts)
+	}
+
+	return &descriptor.EnumValueDescriptorProto{
+		Name:    proto.String(v.Name),
+		Number:  proto.Int32(v.Number),
+		Options: opts,
+	}
+}
+
+func createMessageDescriptor(m *ptype.Type, mr *MessageRegistry) *descriptor.DescriptorProto {
+	var opts *descriptor.MessageOptions
+	if len(m.Options) > 0 {
+		dopts := createOptions(m.Options, msgOptionsDesc, mr)
+		dopts.ConvertTo(opts) // ignore any error
+	}
+
+	var fields []*descriptor.FieldDescriptorProto
+	for _, f := range m.Fields {
+		fields = append(fields, createFieldDescriptor(f, mr))
+	}
+
+	var oneOfs []*descriptor.OneofDescriptorProto
+	for _, o := range m.Oneofs {
+		oneOfs = append(oneOfs, &descriptor.OneofDescriptorProto{
+			Name: proto.String(o),
+		})
+	}
+
+	return &descriptor.DescriptorProto{
+		Name:      proto.String(base(m.Name)),
+		Options:   opts,
+		Field:     fields,
+		OneofDecl: oneOfs,
+	}
+}
+
+func createFieldDescriptor(f *ptype.Field, mr *MessageRegistry) *descriptor.FieldDescriptorProto {
+	var opts *descriptor.FieldOptions
+	if len(f.Options) > 0 {
+		dopts := createOptions(f.Options, fieldOptionsDesc, mr)
+		dopts.ConvertTo(opts) // ignore any error
+	}
+	if f.Packed {
+		if opts == nil {
+			opts = &descriptor.FieldOptions{Packed: proto.Bool(true)}
+		} else {
+			opts.Packed = proto.Bool(true)
+		}
+	}
+
+	var typeName string
+	if f.Kind == ptype.Field_TYPE_GROUP || f.Kind == ptype.Field_TYPE_MESSAGE || f.Kind == ptype.Field_TYPE_ENUM {
+		pos := strings.LastIndex(f.TypeUrl, "/")
+		typeName = "." + f.TypeUrl[pos+1:]
+	}
+
+	var label descriptor.FieldDescriptorProto_Label
+	switch f.Cardinality {
+	case ptype.Field_CARDINALITY_OPTIONAL:
+		label = descriptor.FieldDescriptorProto_LABEL_OPTIONAL
+	case ptype.Field_CARDINALITY_REPEATED:
+		label = descriptor.FieldDescriptorProto_LABEL_REPEATED
+	case ptype.Field_CARDINALITY_REQUIRED:
+		label = descriptor.FieldDescriptorProto_LABEL_REQUIRED
+	}
+
+	var typ descriptor.FieldDescriptorProto_Type
+	switch f.Kind {
+	case ptype.Field_TYPE_ENUM:
+		typ = descriptor.FieldDescriptorProto_TYPE_ENUM
+	case ptype.Field_TYPE_GROUP:
+		typ = descriptor.FieldDescriptorProto_TYPE_GROUP
+	case ptype.Field_TYPE_MESSAGE:
+		typ = descriptor.FieldDescriptorProto_TYPE_MESSAGE
+	case ptype.Field_TYPE_BYTES:
+		typ = descriptor.FieldDescriptorProto_TYPE_BYTES
+	case ptype.Field_TYPE_STRING:
+		typ = descriptor.FieldDescriptorProto_TYPE_STRING
+	case ptype.Field_TYPE_BOOL:
+		typ = descriptor.FieldDescriptorProto_TYPE_BOOL
+	case ptype.Field_TYPE_DOUBLE:
+		typ = descriptor.FieldDescriptorProto_TYPE_DOUBLE
+	case ptype.Field_TYPE_FLOAT:
+		typ = descriptor.FieldDescriptorProto_TYPE_FLOAT
+	case ptype.Field_TYPE_FIXED32:
+		typ = descriptor.FieldDescriptorProto_TYPE_FIXED32
+	case ptype.Field_TYPE_FIXED64:
+		typ = descriptor.FieldDescriptorProto_TYPE_FIXED64
+	case ptype.Field_TYPE_INT32:
+		typ = descriptor.FieldDescriptorProto_TYPE_INT32
+	case ptype.Field_TYPE_INT64:
+		typ = descriptor.FieldDescriptorProto_TYPE_INT64
+	case ptype.Field_TYPE_SFIXED32:
+		typ = descriptor.FieldDescriptorProto_TYPE_SFIXED32
+	case ptype.Field_TYPE_SFIXED64:
+		typ = descriptor.FieldDescriptorProto_TYPE_SFIXED64
+	case ptype.Field_TYPE_SINT32:
+		typ = descriptor.FieldDescriptorProto_TYPE_SINT32
+	case ptype.Field_TYPE_SINT64:
+		typ = descriptor.FieldDescriptorProto_TYPE_SINT64
+	case ptype.Field_TYPE_UINT32:
+		typ = descriptor.FieldDescriptorProto_TYPE_UINT32
+	case ptype.Field_TYPE_UINT64:
+		typ = descriptor.FieldDescriptorProto_TYPE_UINT64
+	}
+
+	return &descriptor.FieldDescriptorProto{
+		Name:         proto.String(f.Name),
+		Number:       proto.Int32(f.Number),
+		DefaultValue: proto.String(f.DefaultValue),
+		JsonName:     proto.String(f.JsonName),
+		OneofIndex:   proto.Int32(f.OneofIndex),
+		TypeName:     proto.String(typeName),
+		Label:        label.Enum(),
+		Type:         typ.Enum(),
+	}
+}
+
+func createIntermediateMessageDescriptor(name string) *descriptor.DescriptorProto {
+	return &descriptor.DescriptorProto{
+		Name: proto.String(name),
+	}
+}
+
+func createFileDescriptor(name, pkg string, proto3 bool, deps map[string]struct{}) *descriptor.FileDescriptorProto {
+	imports := make([]string, 0, len(deps))
+	for k := range deps {
+		imports = append(imports, k)
+	}
+	sort.Strings(imports)
+	var syntax string
+	if proto3 {
+		syntax = "proto3"
+	} else {
+		syntax = "proto2"
+	}
+	return &descriptor.FileDescriptorProto{
+		Name:       proto.String(name),
+		Package:    proto.String(pkg),
+		Syntax:     proto.String(syntax),
+		Dependency: imports,
+	}
+}
+
+func createOptions(options []*ptype.Option, optionsDesc *desc.MessageDescriptor, mr *MessageRegistry) *Message {
+	// these are created "best effort" so entries which are unresolvable
+	// (or seemingly invalid) are simply ignored...
+	dopts := newMessageWithMessageFactory(optionsDesc, mr.mf)
+	for _, o := range options {
+		field := optionsDesc.FindFieldByName(o.Name)
+		if field == nil {
+			field = mr.er.FindExtensionByName(optionsDesc.GetFullyQualifiedName(), o.Name)
+			if field == nil && o.Name[0] != '[' {
+				field = mr.er.FindExtensionByName(optionsDesc.GetFullyQualifiedName(), fmt.Sprintf("[%s]", o.Name))
+			}
+			if field == nil {
+				// can't resolve option name? skip it
+				continue
+			}
+		}
+		v, err := mr.unmarshalAny(o.Value, func(url string) (*desc.MessageDescriptor, error) {
+			// we don't want to try to recursively fetch this value's type, so if it doesn't
+			// match the type of the extension field, we'll skip it
+			if (field.GetType() == descriptor.FieldDescriptorProto_TYPE_GROUP ||
+				field.GetType() == descriptor.FieldDescriptorProto_TYPE_MESSAGE) &&
+				typeName(url) == field.GetMessageType().GetFullyQualifiedName() {
+
+				return field.GetMessageType(), nil
+			}
+			return nil, nil
+		})
+		if err != nil {
+			// can't interpret value? skip it
+			continue
+		}
+		var fv interface{}
+		if field.GetType() != descriptor.FieldDescriptorProto_TYPE_MESSAGE && field.GetType() != descriptor.FieldDescriptorProto_TYPE_GROUP {
+			fv = unwrap(v)
+			if v == nil {
+				// non-wrapper type for scalar field? skip it
+				continue
+			}
+		} else {
+			fv = v
+		}
+		dopts.setField(field, fv) // ignore any error
+	}
+	return dopts
+}
+
+func base(name string) string {
+	pos := strings.LastIndex(name, ".")
+	if pos >= 0 {
+		return name[pos+1:]
+	}
+	return name
+}
+
+func unwrap(msg proto.Message) interface{} {
+	switch m := msg.(type) {
+	case (*wrappers.BoolValue):
+		return m.Value
+	case (*wrappers.FloatValue):
+		return m.Value
+	case (*wrappers.DoubleValue):
+		return m.Value
+	case (*wrappers.Int32Value):
+		return m.Value
+	case (*wrappers.Int64Value):
+		return m.Value
+	case (*wrappers.UInt32Value):
+		return m.Value
+	case (*wrappers.UInt64Value):
+		return m.Value
+	case (*wrappers.BytesValue):
+		return m.Value
+	case (*wrappers.StringValue):
+		return m.Value
+	default:
+		return nil
+	}
+}
+
+func typeName(url string) string {
+	return url[strings.LastIndex(url, "/")+1:]
+}

--- a/dynamic/text.go
+++ b/dynamic/text.go
@@ -517,7 +517,8 @@ func (m *Message) unmarshalText(tr *txtReader, end tokenType) error {
 			if tok.tokTyp != tokenOpenBrace {
 				return textError(tok, "Expecting a brace '{'; instead got %q", tok.txt)
 			}
-			g := NewMessageWithExtensionRegistry(fd.GetMessageType(), m.er)
+			// TODO: use mf.NewMessage and, if not a dynamic message, use proto.UnmarshalText to unmarshal it
+			g := newMessageWithMessageFactory(fd.GetMessageType(), m.mf)
 			if err := g.unmarshalText(tr, tokenCloseBrace); err != nil {
 				return err
 			}
@@ -697,7 +698,8 @@ func (m *Message) unmarshalFieldElementText(fd *desc.FieldDescriptor, tr *txtRea
 		expected = fmt.Sprintf("enum %s value", fd.GetEnumType().GetFullyQualifiedName())
 	case descriptor.FieldDescriptorProto_TYPE_MESSAGE:
 		if tok.tokTyp == tokenOpenAngle {
-			dm := NewMessageWithExtensionRegistry(fd.GetMessageType(), m.er)
+			// TODO: use mf.NewMessage and, if not a dynamic message, use proto.UnmarshalText to unmarshal it
+			dm := newMessageWithMessageFactory(fd.GetMessageType(), m.mf)
 			if err := dm.unmarshalText(tr, tokenCloseAngle); err != nil {
 				return err
 			}


### PR DESCRIPTION
Existing tests pass, but still need tests for the (admittedly voluminous) new stuff.

This adds a `MessageFactory` which includes a `KnownTypeRegistry`, for returning instances of generated protos instead of always creating dynamic messages when de-serializing a message.

Also includes a `MessageRegistry`, which provides support for marshaling and unmarshaling `Any` messages using dynamic messages as the payloads. Also provides a mechanism for dynamically resolving type URLs including an implementation that uses an HTTP client in the manner described by the protobuf documentation for downloading and using type descriptions. This includes (non-trivial) conversions from the `google.protobuf.Type` and `google.protobuf.Enum` messages into descriptors, for use with dynamic messages.