### PR TITLE
more ptypes conversions, backfill some tests

### DIFF
--- a/dynamic/equal.go
+++ b/dynamic/equal.go
@@ -179,10 +179,3 @@ func MessagesEqual(a, b proto.Message) bool {
 		return Equal(da, db)
 	}
 }
-
-func MessageName(msg proto.Message) string {
-	if dm, ok := msg.(*Message); ok {
-		return dm.md.GetFullyQualifiedName()
-	}
-	return proto.MessageName(msg)
-}

--- a/dynamic/equal_test.go
+++ b/dynamic/equal_test.go
@@ -1,0 +1,17 @@
+package dynamic
+
+import (
+	"github.com/golang/protobuf/proto"
+)
+
+func eqm(a, b interface{}) bool {
+	return MessagesEqual(a.(proto.Message), b.(proto.Message))
+}
+
+func eqdm(a, b interface{}) bool {
+	return Equal(a.(*Message), b.(*Message))
+}
+
+func eqpm(a, b interface{}) bool {
+	return proto.Equal(a.(proto.Message), b.(proto.Message))
+}

--- a/dynamic/extension_registry.go
+++ b/dynamic/extension_registry.go
@@ -18,10 +18,16 @@ type ExtensionRegistry struct {
 	exts           map[string]map[int32]*desc.FieldDescriptor
 }
 
+// NewExtensionRegistryWithDefaults is a registry that includes all "default" extensions,
+// which are those that are statically linked into the current program (e.g. registered by
+// protoc-generated code via proto.RegisterExtension). Extensions explicitly added to the
+// registry will override any default extensions that are for the same extendee and have the
+// same tag number and/or name.
 func NewExtensionRegistryWithDefaults() *ExtensionRegistry {
 	return &ExtensionRegistry{includeDefault: true}
 }
 
+// AddExtensionDesc adds the given extensions to the registry.
 func (r *ExtensionRegistry) AddExtensionDesc(exts ...*proto.ExtensionDesc) error {
 	flds := make([]*desc.FieldDescriptor, len(exts))
 	for i, ext := range exts {
@@ -56,6 +62,7 @@ func asFieldDescriptor(ext *proto.ExtensionDesc) (*desc.FieldDescriptor, error) 
 	return field, nil
 }
 
+// AddExtension adds the given extensions to the registry.
 func (r *ExtensionRegistry) AddExtension(exts ...*desc.FieldDescriptor) error {
 	for _, ext := range exts {
 		if !ext.IsExtension() {
@@ -73,6 +80,7 @@ func (r *ExtensionRegistry) AddExtension(exts ...*desc.FieldDescriptor) error {
 	return nil
 }
 
+// AddExtensionsFromFile adds to the registry all extension fields defined in the given file descriptor.
 func (r *ExtensionRegistry) AddExtensionsFromFile(fd *desc.FileDescriptor) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -106,6 +114,8 @@ func (r *ExtensionRegistry) putExtensionLocked(fd *desc.FieldDescriptor) {
 	m[fd.GetNumber()] = fd
 }
 
+// FindExtension queries for the extension field with the given extendee name (must be a fully-qualified
+// message name) and tag number. If no extension is known, nil is returned.
 func (r *ExtensionRegistry) FindExtension(messageName string, tagNumber int32) *desc.FieldDescriptor {
 	if r == nil {
 		return nil
@@ -122,6 +132,9 @@ func (r *ExtensionRegistry) FindExtension(messageName string, tagNumber int32) *
 	return fd
 }
 
+// FindExtensionByName queries for the extension field with the given extendee name (must be a fully-qualified
+// message name) and field name (must also be a fully-qualified extension name). If no extension is known, nil
+// is returned.
 func (r *ExtensionRegistry) FindExtensionByName(messageName string, fieldName string) *desc.FieldDescriptor {
 	if r == nil {
 		return nil
@@ -153,6 +166,8 @@ func getDefaultExtensions(messageName string) map[int32]*proto.ExtensionDesc {
 	return nil
 }
 
+// AllExtensionsForType returns all known extension fields for the given extendee name (must be a
+// fully-qualified message name).
 func (r *ExtensionRegistry) AllExtensionsForType(messageName string) []*desc.FieldDescriptor {
 	if r == nil {
 		return []*desc.FieldDescriptor(nil)

--- a/dynamic/marshal_test.go
+++ b/dynamic/marshal_test.go
@@ -174,11 +174,3 @@ func doTranslationParty(t *testing.T, msg proto.Message,
 	testutil.Ceq(t, dm, dm3, eqdm)
 	testutil.Ceq(t, dm, dm4, eqdm)
 }
-
-func eqdm(a, b interface{}) bool {
-	return Equal(a.(*Message), b.(*Message))
-}
-
-func eqpm(a, b interface{}) bool {
-	return proto.Equal(a.(proto.Message), b.(proto.Message))
-}

--- a/dynamic/message_factory_test.go
+++ b/dynamic/message_factory_test.go
@@ -1,0 +1,122 @@
+package dynamic
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/golang/protobuf/ptypes/any"
+	"github.com/golang/protobuf/ptypes/duration"
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/golang/protobuf/ptypes/struct"
+	"github.com/golang/protobuf/ptypes/timestamp"
+	"github.com/golang/protobuf/ptypes/wrappers"
+
+	"github.com/jhump/protoreflect/desc"
+	"github.com/jhump/protoreflect/internal/testprotos"
+	"github.com/jhump/protoreflect/internal/testutil"
+)
+
+var wellKnownTypes = []proto.Message{
+	(*wrappers.BoolValue)(nil),
+	(*wrappers.BytesValue)(nil),
+	(*wrappers.StringValue)(nil),
+	(*wrappers.FloatValue)(nil),
+	(*wrappers.DoubleValue)(nil),
+	(*wrappers.Int32Value)(nil),
+	(*wrappers.Int64Value)(nil),
+	(*wrappers.UInt32Value)(nil),
+	(*wrappers.UInt64Value)(nil),
+	(*timestamp.Timestamp)(nil),
+	(*duration.Duration)(nil),
+	(*any.Any)(nil),
+	(*empty.Empty)(nil),
+	(*structpb.Struct)(nil),
+	(*structpb.Value)(nil),
+	(*structpb.ListValue)(nil),
+}
+
+func TestKnownTypeRegistry_AddKnownType(t *testing.T) {
+	ktr := &KnownTypeRegistry{}
+	dp := (*descriptor.DescriptorProto)(nil)
+	ktr.AddKnownType(dp)
+
+	checkKnownTypes(t, ktr, wellKnownTypes...)
+	checkKnownTypes(t, ktr, dp)
+	checkUnknownTypes(t, ktr, (*descriptor.FileDescriptorProto)(nil), (*testprotos.TestMessage)(nil))
+}
+
+func TestKnownTypeRegistry_WithoutWellKnownTypes(t *testing.T) {
+	ktr := NewKnownTypeRegistryWithoutWellKnownTypes()
+	dp := (*descriptor.DescriptorProto)(nil)
+	ktr.AddKnownType(dp)
+
+	checkKnownTypes(t, ktr, dp)
+	checkUnknownTypes(t, ktr, wellKnownTypes...)
+	checkUnknownTypes(t, ktr, (*descriptor.FileDescriptorProto)(nil), (*testprotos.TestMessage)(nil))
+}
+
+func TestKnownTypeRegistry_WithDefaults(t *testing.T) {
+	ktr := NewKnownTypeRegistryWithDefaults()
+	dp := (*descriptor.DescriptorProto)(nil)
+
+	// they're all known
+	checkKnownTypes(t, ktr, dp)
+	checkKnownTypes(t, ktr, (*descriptor.DescriptorProto)(nil), (*descriptor.FileDescriptorProto)(nil), (*testprotos.TestMessage)(nil))
+}
+
+func checkKnownTypes(t *testing.T, ktr *KnownTypeRegistry, knownTypes ...proto.Message) {
+	for _, kt := range knownTypes {
+		md, err := desc.LoadMessageDescriptorForMessage(kt)
+		testutil.Ok(t, err)
+		m := ktr.CreateIfKnown(md.GetFullyQualifiedName())
+		testutil.Require(t, m != nil, "%v should be a known type", reflect.TypeOf(kt))
+		testutil.Eq(t, reflect.TypeOf(kt), reflect.TypeOf(m))
+	}
+}
+
+func checkUnknownTypes(t *testing.T, ktr *KnownTypeRegistry, unknownTypes ...proto.Message) {
+	for _, kt := range unknownTypes {
+		md, err := desc.LoadMessageDescriptorForMessage(kt)
+		testutil.Ok(t, err)
+		m := ktr.CreateIfKnown(md.GetFullyQualifiedName())
+		testutil.Require(t, m == nil, "%v should not be a known type", reflect.TypeOf(kt))
+	}
+}
+
+func TestMessageFactory(t *testing.T) {
+	mf := &MessageFactory{}
+
+	checkTypes(t, mf, false, wellKnownTypes...)
+	checkTypes(t, mf, true, (*descriptor.DescriptorProto)(nil), (*descriptor.FileDescriptorProto)(nil), (*testprotos.TestMessage)(nil))
+}
+
+func TestMessageFactory_WithDefaults(t *testing.T) {
+	mf := NewMessageFactoryWithDefaults()
+
+	checkTypes(t, mf, false, wellKnownTypes...)
+	checkTypes(t, mf, false, (*descriptor.DescriptorProto)(nil), (*descriptor.FileDescriptorProto)(nil), (*testprotos.TestMessage)(nil))
+}
+
+func TestMessageFactory_WithKnownTypeRegistry(t *testing.T) {
+	ktr := NewKnownTypeRegistryWithoutWellKnownTypes()
+	mf := NewMessageFactoryWithKnownTypeRegistry(ktr)
+
+	checkTypes(t, mf, true, wellKnownTypes...)
+	checkTypes(t, mf, true, (*descriptor.DescriptorProto)(nil), (*descriptor.FileDescriptorProto)(nil), (*testprotos.TestMessage)(nil))
+}
+
+func checkTypes(t *testing.T, mf *MessageFactory, dynamic bool, types ...proto.Message) {
+	for _, typ := range types {
+		md, err := desc.LoadMessageDescriptorForMessage(typ)
+		testutil.Ok(t, err)
+		m := mf.NewMessage(md)
+		if dynamic {
+			testutil.Eq(t, typeOfDynamicMessage, reflect.TypeOf(m))
+		} else {
+			testutil.Eq(t, reflect.TypeOf(typ), reflect.TypeOf(m))
+		}
+	}
+
+}

--- a/dynamic/message_registry.go
+++ b/dynamic/message_registry.go
@@ -7,8 +7,13 @@ import (
 	"sync"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
+	"github.com/golang/protobuf/ptypes/wrappers"
+	"google.golang.org/genproto/protobuf/api"
+	"google.golang.org/genproto/protobuf/ptype"
+	"google.golang.org/genproto/protobuf/source_context"
 
 	"github.com/jhump/protoreflect/desc"
 )
@@ -121,15 +126,6 @@ func (r *MessageRegistry) addMessageTypesLocked(domain string, msgs []*desc.Mess
 	}
 }
 
-func (r *MessageRegistry) AddDomainForElement(domain, packageOrTypeName string) {
-	if domain[len(domain)-1] == '/' {
-		domain = domain[:len(domain)-1]
-	}
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.domains[packageOrTypeName] = domain
-}
-
 func (r *MessageRegistry) FindMessageTypeByUrl(url string) (*desc.MessageDescriptor, error) {
 	if r == nil {
 		return nil, nil
@@ -186,6 +182,13 @@ func (r *MessageRegistry) FindEnumTypeByUrl(url string) (*desc.EnumDescriptor, e
 	}
 }
 
+func (r *MessageRegistry) ResolveApiIntoServiceDescriptor(a *api.Api) (*desc.ServiceDescriptor, error) {
+	if r.resolver.fetcher == nil {
+		return nil, nil
+	}
+	return r.resolver.resolveApiToServiceDescriptor(a)
+}
+
 func (r *MessageRegistry) UnmarshalAny(any *any.Any) (proto.Message, error) {
 	return r.unmarshalAny(any, r.FindMessageTypeByUrl)
 }
@@ -226,11 +229,256 @@ func (r *MessageRegistry) unmarshalAny(any *any.Any, fetch func(string) (*desc.M
 	}
 }
 
+func (r *MessageRegistry) AddDomainForElement(domain, packageOrTypeName string) {
+	if domain[len(domain)-1] == '/' {
+		domain = domain[:len(domain)-1]
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.domains[packageOrTypeName] = domain
+}
+
 func (r *MessageRegistry) MarshalAny(m proto.Message) (*any.Any, error) {
 	name := MessageName(m)
 	if name == "" {
 		return nil, fmt.Errorf("could not determine message name for %v", reflect.TypeOf(m))
 	}
+
+	if b, err := proto.Marshal(m); err != nil {
+		return nil, err
+	} else {
+		return &any.Any{TypeUrl: r.asUrl(name), Value: b}, nil
+	}
+}
+
+func (r *MessageRegistry) MessageAsPType(md *desc.MessageDescriptor) *ptype.Type {
+	fs := md.GetFields()
+	fields := make([]*ptype.Field, len(fs))
+	for i, f := range fs {
+		fields[i] = r.fieldAsPType(f)
+	}
+	oos := md.GetOneOfs()
+	oneOfs := make([]string, len(oos))
+	for i, oo := range oos {
+		oneOfs[i] = oo.GetName()
+	}
+	return &ptype.Type{
+		Name:          md.GetFullyQualifiedName(),
+		Fields:        fields,
+		Oneofs:        oneOfs,
+		Options:       r.options(md.GetOptions()),
+		Syntax:        syntax(md.GetFile()),
+		SourceContext: &source_context.SourceContext{FileName: md.GetFile().GetName()},
+	}
+}
+
+func (r *MessageRegistry) fieldAsPType(fd *desc.FieldDescriptor) *ptype.Field {
+	opts := r.options(fd.GetOptions())
+	// remove the "packed" option as that is represented via separate field in ptype.Field
+	for i, o := range opts {
+		if o.Name == "packed" {
+			opts = append(opts[:i], opts[i+1:]...)
+			break
+		}
+	}
+
+	var card ptype.Field_Cardinality
+	switch fd.GetLabel() {
+	case descriptor.FieldDescriptorProto_LABEL_OPTIONAL:
+		card = ptype.Field_CARDINALITY_OPTIONAL
+	case descriptor.FieldDescriptorProto_LABEL_REPEATED:
+		card = ptype.Field_CARDINALITY_REPEATED
+	case descriptor.FieldDescriptorProto_LABEL_REQUIRED:
+		card = ptype.Field_CARDINALITY_REQUIRED
+	}
+
+	var kind ptype.Field_Kind
+	switch fd.GetType() {
+	case descriptor.FieldDescriptorProto_TYPE_ENUM:
+		kind = ptype.Field_TYPE_ENUM
+	case descriptor.FieldDescriptorProto_TYPE_GROUP:
+		kind = ptype.Field_TYPE_GROUP
+	case descriptor.FieldDescriptorProto_TYPE_MESSAGE:
+		kind = ptype.Field_TYPE_MESSAGE
+	case descriptor.FieldDescriptorProto_TYPE_BYTES:
+		kind = ptype.Field_TYPE_BYTES
+	case descriptor.FieldDescriptorProto_TYPE_STRING:
+		kind = ptype.Field_TYPE_STRING
+	case descriptor.FieldDescriptorProto_TYPE_BOOL:
+		kind = ptype.Field_TYPE_BOOL
+	case descriptor.FieldDescriptorProto_TYPE_DOUBLE:
+		kind = ptype.Field_TYPE_DOUBLE
+	case descriptor.FieldDescriptorProto_TYPE_FLOAT:
+		kind = ptype.Field_TYPE_FLOAT
+	case descriptor.FieldDescriptorProto_TYPE_FIXED32:
+		kind = ptype.Field_TYPE_FIXED32
+	case descriptor.FieldDescriptorProto_TYPE_FIXED64:
+		kind = ptype.Field_TYPE_FIXED64
+	case descriptor.FieldDescriptorProto_TYPE_INT32:
+		kind = ptype.Field_TYPE_INT32
+	case descriptor.FieldDescriptorProto_TYPE_INT64:
+		kind = ptype.Field_TYPE_INT64
+	case descriptor.FieldDescriptorProto_TYPE_SFIXED32:
+		kind = ptype.Field_TYPE_SFIXED32
+	case descriptor.FieldDescriptorProto_TYPE_SFIXED64:
+		kind = ptype.Field_TYPE_SFIXED64
+	case descriptor.FieldDescriptorProto_TYPE_SINT32:
+		kind = ptype.Field_TYPE_SINT32
+	case descriptor.FieldDescriptorProto_TYPE_SINT64:
+		kind = ptype.Field_TYPE_SINT64
+	case descriptor.FieldDescriptorProto_TYPE_UINT32:
+		kind = ptype.Field_TYPE_UINT32
+	case descriptor.FieldDescriptorProto_TYPE_UINT64:
+		kind = ptype.Field_TYPE_UINT64
+	}
+
+	return &ptype.Field{
+		Name:         fd.GetName(),
+		Number:       fd.GetNumber(),
+		JsonName:     fd.AsFieldDescriptorProto().GetJsonName(),
+		OneofIndex:   fd.AsFieldDescriptorProto().GetOneofIndex(),
+		DefaultValue: fd.AsFieldDescriptorProto().GetDefaultValue(),
+		Options:      opts,
+		Packed:       fd.GetFieldOptions().GetPacked(),
+		TypeUrl:      r.asUrl(fd.GetMessageType().GetFullyQualifiedName()),
+		Cardinality:  card,
+		Kind:         kind,
+	}
+}
+
+func (r *MessageRegistry) EnumAsPType(ed *desc.EnumDescriptor) *ptype.Enum {
+	vs := ed.GetValues()
+	vals := make([]*ptype.EnumValue, len(vs))
+	for i, v := range vs {
+		vals[i] = r.enumValueAsPType(v)
+	}
+	return &ptype.Enum{
+		Name:          ed.GetFullyQualifiedName(),
+		Enumvalue:     vals,
+		Options:       r.options(ed.GetOptions()),
+		Syntax:        syntax(ed.GetFile()),
+		SourceContext: &source_context.SourceContext{FileName: ed.GetFile().GetName()},
+	}
+}
+
+func (r *MessageRegistry) enumValueAsPType(vd *desc.EnumValueDescriptor) *ptype.EnumValue {
+	return &ptype.EnumValue{
+		Name:    vd.GetName(),
+		Number:  vd.GetNumber(),
+		Options: r.options(vd.GetOptions()),
+	}
+}
+
+func (r *MessageRegistry) ServiceAsApi(sd *desc.ServiceDescriptor) *api.Api {
+	ms := sd.GetMethods()
+	methods := make([]*api.Method, len(ms))
+	for i, m := range ms {
+		methods[i] = r.methodAsApi(m)
+	}
+	return &api.Api{
+		Name:          sd.GetFullyQualifiedName(),
+		Methods:       methods,
+		Options:       r.options(sd.GetOptions()),
+		Syntax:        syntax(sd.GetFile()),
+		SourceContext: &source_context.SourceContext{FileName: sd.GetFile().GetName()},
+	}
+}
+
+func (r *MessageRegistry) methodAsApi(md *desc.MethodDescriptor) *api.Method {
+	return &api.Method{
+		Name:              md.GetName(),
+		RequestStreaming:  md.IsClientStreaming(),
+		ResponseStreaming: md.IsServerStreaming(),
+		RequestTypeUrl:    r.asUrl(md.GetInputType().GetFullyQualifiedName()),
+		ResponseTypeUrl:   r.asUrl(md.GetOutputType().GetFullyQualifiedName()),
+		Options:           r.options(md.GetOptions()),
+		Syntax:            syntax(md.GetFile()),
+	}
+}
+
+func (r *MessageRegistry) options(options proto.Message) []*ptype.Option {
+	rv := reflect.ValueOf(options)
+	if rv.Kind() == reflect.Ptr {
+		rv = rv.Elem()
+	}
+	var opts []*ptype.Option
+	for _, p := range proto.GetProperties(rv.Type()).Prop {
+		o := r.option(p.OrigName, rv.FieldByName(p.Name))
+		if o != nil {
+			opts = append(opts, o)
+		}
+	}
+	for _, ext := range proto.RegisteredExtensions(options) {
+		if proto.HasExtension(options, ext) {
+			v, err := proto.GetExtension(options, ext)
+			if err == nil && v != nil {
+				o := r.option(ext.Name, reflect.ValueOf(v))
+				if o != nil {
+					opts = append(opts, o)
+				}
+			}
+		}
+	}
+	return opts
+}
+
+func (r *MessageRegistry) option(name string, value reflect.Value) *ptype.Option {
+	// ignoring unsupported types or values that cannot be marshalled
+	// TODO(jh): error or panic?
+	pm := wrap(value)
+	if pm == nil {
+		return nil
+	}
+	a, err := r.MarshalAny(pm)
+	if err != nil {
+		return nil
+	}
+	return &ptype.Option{
+		Name:  name,
+		Value: a,
+	}
+}
+
+func wrap(v reflect.Value) proto.Message {
+	if pm, ok := v.Interface().(proto.Message); ok {
+		return pm
+	}
+	switch v.Kind() {
+	case reflect.Bool:
+		return &wrappers.BoolValue{Value: v.Bool()}
+	case reflect.Slice:
+		if v.Type() != typeOfBytes {
+			return nil
+		}
+		return &wrappers.BytesValue{Value: v.Bytes()}
+	case reflect.String:
+		return &wrappers.StringValue{Value: v.String()}
+	case reflect.Float32:
+		return &wrappers.FloatValue{Value: float32(v.Float())}
+	case reflect.Float64:
+		return &wrappers.DoubleValue{Value: v.Float()}
+	case reflect.Int32:
+		return &wrappers.Int32Value{Value: int32(v.Int())}
+	case reflect.Int64:
+		return &wrappers.Int64Value{Value: v.Int()}
+	case reflect.Uint32:
+		return &wrappers.UInt32Value{Value: uint32(v.Uint())}
+	case reflect.Uint64:
+		return &wrappers.UInt64Value{Value: v.Uint()}
+	default:
+		return nil
+	}
+}
+
+func syntax(fd *desc.FileDescriptor) ptype.Syntax {
+	if fd.IsProto3() {
+		return ptype.Syntax_SYNTAX_PROTO3
+	} else {
+		return ptype.Syntax_SYNTAX_PROTO2
+	}
+}
+
+func (r *MessageRegistry) asUrl(name string) string {
 	r.mu.RLock()
 	domain := r.domains[name]
 	if domain == "" {
@@ -246,9 +494,5 @@ func (r *MessageRegistry) MarshalAny(m proto.Message) (*any.Any, error) {
 		}
 	}
 
-	if b, err := proto.Marshal(m); err != nil {
-		return nil, err
-	} else {
-		return &any.Any{TypeUrl: fmt.Sprintf("%s/%s", domain, name), Value: b}, nil
-	}
+	return fmt.Sprintf("%s/%s", domain, name)
 }

--- a/dynamic/message_registry_test.go
+++ b/dynamic/message_registry_test.go
@@ -1,0 +1,158 @@
+package dynamic
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/any"
+	"github.com/golang/protobuf/ptypes/duration"
+
+	"github.com/jhump/protoreflect/desc"
+	"github.com/jhump/protoreflect/internal/testutil"
+)
+
+func TestMessageRegistry_LookupTypes(t *testing.T) {
+	mr := &MessageRegistry{}
+
+	// register some types
+	md, err := desc.LoadMessageDescriptor("google.protobuf.DescriptorProto")
+	testutil.Ok(t, err)
+	err = mr.AddMessage("foo.bar/google.protobuf.DescriptorProto", md)
+	testutil.Ok(t, err)
+	ed := md.GetFile().FindEnum("google.protobuf.FieldDescriptorProto.Type")
+	testutil.Require(t, ed != nil)
+	err = mr.AddEnum("foo.bar/google.protobuf.FieldDescriptorProto.Type", ed)
+	testutil.Ok(t, err)
+
+	// lookups succeed
+	msg, err := mr.FindMessageTypeByUrl("foo.bar/google.protobuf.DescriptorProto")
+	testutil.Ok(t, err)
+	testutil.Eq(t, md, msg)
+	en, err := mr.FindEnumTypeByUrl("foo.bar/google.protobuf.FieldDescriptorProto.Type")
+	testutil.Ok(t, err)
+	testutil.Eq(t, ed, en)
+
+	// right name but wrong domain? not found
+	msg, err = mr.FindMessageTypeByUrl("type.googleapis.com/google.protobuf.DescriptorProto")
+	testutil.Ok(t, err)
+	testutil.Require(t, msg == nil)
+	en, err = mr.FindEnumTypeByUrl("type.googleapis.com/google.protobuf.FieldDescriptorProto.Type")
+	testutil.Ok(t, err)
+	testutil.Require(t, en == nil)
+
+	// wrong type
+	_, err = mr.FindMessageTypeByUrl("foo.bar/google.protobuf.FieldDescriptorProto.Type")
+	testutil.Require(t, err != nil && strings.Contains(err.Error(), "wanted message, got enum"))
+	_, err = mr.FindEnumTypeByUrl("foo.bar/google.protobuf.DescriptorProto")
+	testutil.Require(t, err != nil && strings.Contains(err.Error(), "wanted enum, got message"))
+
+	// unmarshal any successfully finds the registered type
+	b, err := proto.Marshal(md.AsProto())
+	testutil.Ok(t, err)
+	a := &any.Any{TypeUrl: "foo.bar/google.protobuf.DescriptorProto", Value: b}
+	pm, err := mr.UnmarshalAny(a)
+	testutil.Ok(t, err)
+	testutil.Ceq(t, md.AsProto(), pm, eqm)
+	// we didn't configure the registry with a message factory, so it would have
+	// produced a dynamic message instead of a generated message
+	testutil.Eq(t, typeOfDynamicMessage, reflect.TypeOf(pm))
+
+	// by default, message registry knows about well-known types
+	dur := &duration.Duration{Nanos: 100, Seconds: 1000}
+	b, err = proto.Marshal(dur)
+	testutil.Ok(t, err)
+	a = &any.Any{TypeUrl: "foo.bar/google.protobuf.Duration", Value: b}
+	pm, err = mr.UnmarshalAny(a)
+	testutil.Ok(t, err)
+	testutil.Ceq(t, dur, pm, eqm)
+	testutil.Eq(t, reflect.TypeOf((*duration.Duration)(nil)), reflect.TypeOf(pm))
+}
+
+func TestMessageRegistry_LookupTypes_WithDefaults(t *testing.T) {
+	mr := NewMessageRegistryWithDefaults()
+
+	md, err := desc.LoadMessageDescriptor("google.protobuf.DescriptorProto")
+	testutil.Ok(t, err)
+	ed := md.GetFile().FindEnum("google.protobuf.FieldDescriptorProto.Type")
+	testutil.Require(t, ed != nil)
+
+	// lookups succeed
+	msg, err := mr.FindMessageTypeByUrl("type.googleapis.com/google.protobuf.DescriptorProto")
+	testutil.Ok(t, err)
+	testutil.Eq(t, md, msg)
+	// default types don't know their base URL, so will resolve even w/ wrong name
+	// (just have to get fully-qualified message name right)
+	msg, err = mr.FindMessageTypeByUrl("foo.bar/google.protobuf.DescriptorProto")
+	testutil.Ok(t, err)
+	testutil.Eq(t, md, msg)
+
+	// sad trombone: no way to lookup "default" enum types, so enums don't resolve
+	// without being explicitly registered :(
+	en, err := mr.FindEnumTypeByUrl("type.googleapis.com/google.protobuf.FieldDescriptorProto.Type")
+	testutil.Ok(t, err)
+	testutil.Require(t, en == nil)
+	en, err = mr.FindEnumTypeByUrl("foo.bar/google.protobuf.FieldDescriptorProto.Type")
+	testutil.Ok(t, err)
+	testutil.Require(t, en == nil)
+
+	// unmarshal any successfully finds the registered type
+	b, err := proto.Marshal(md.AsProto())
+	testutil.Ok(t, err)
+	a := &any.Any{TypeUrl: "foo.bar/google.protobuf.DescriptorProto", Value: b}
+	pm, err := mr.UnmarshalAny(a)
+	testutil.Ok(t, err)
+	testutil.Ceq(t, md.AsProto(), pm, eqm)
+	// message registry with defaults implies known-type registry with defaults, so
+	// it should have marshalled the message into a generated message
+	testutil.Eq(t, reflect.TypeOf((*descriptor.DescriptorProto)(nil)), reflect.TypeOf(pm))
+}
+
+func TestMessageRegistry_LookupTypes_WithFetcher(t *testing.T) {
+	// TODO
+}
+
+func TestMessageRegistry_ResolveApiIntoServiceDescriptor(t *testing.T) {
+	// TODO
+}
+
+func TestMessageRegistry_MarshalAny(t *testing.T) {
+	mr := &MessageRegistry{}
+
+	md, err := desc.LoadMessageDescriptor("google.protobuf.DescriptorProto")
+	testutil.Ok(t, err)
+
+	// default base URL
+	a, err := mr.MarshalAny(md.AsProto())
+	testutil.Ok(t, err)
+	testutil.Eq(t, "type.googleapis.com/google.protobuf.DescriptorProto", a.TypeUrl)
+	var umd descriptor.DescriptorProto
+	err = ptypes.UnmarshalAny(a, &umd)
+	testutil.Ok(t, err)
+	testutil.Ceq(t, md.AsProto(), &umd, eqm)
+
+	// different default
+	mr.WithDefaultBaseUrl("foo.com/some/path/")
+	a, err = mr.MarshalAny(md.AsProto())
+	testutil.Ok(t, err)
+	testutil.Eq(t, "foo.com/some/path/google.protobuf.DescriptorProto", a.TypeUrl)
+
+	// custom base URL for package
+	mr.AddBaseUrlForElement("bar.com/other/", "google.protobuf")
+	a, err = mr.MarshalAny(md.AsProto())
+	testutil.Ok(t, err)
+	testutil.Eq(t, "bar.com/other/google.protobuf.DescriptorProto", a.TypeUrl)
+
+	// custom base URL for type
+	mr.AddBaseUrlForElement("http://baz.com/another/", "google.protobuf.DescriptorProto")
+	a, err = mr.MarshalAny(md.AsProto())
+	testutil.Ok(t, err)
+	testutil.Eq(t, "http://baz.com/another/google.protobuf.DescriptorProto", a.TypeUrl)
+}
+
+func TestMessageRegistry_DescriptorsToPTypes(t *testing.T) {
+	// TODO
+}

--- a/dynamic/ptype_resolver_test.go
+++ b/dynamic/ptype_resolver_test.go
@@ -1,0 +1,289 @@
+package dynamic
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/golang/protobuf/proto"
+	"golang.org/x/net/context"
+	"google.golang.org/genproto/protobuf/ptype"
+	"google.golang.org/genproto/protobuf/source_context"
+
+	"github.com/jhump/protoreflect/internal/testutil"
+)
+
+func TestCachingTypeFetcher(t *testing.T) {
+	counts := map[string]int{}
+	uncached := func(url string, enum bool) (proto.Message, error) {
+		counts[url] = counts[url] + 1
+		return testFetcher(url, enum)
+	}
+
+	// observe the underlying type fetcher get invoked 10x
+	for i := 0; i < 10; i++ {
+		pm, err := uncached("blah.blah.blah/fee.fi.fo.Fum", false)
+		testutil.Ok(t, err)
+		typ := pm.(*ptype.Type)
+		testutil.Eq(t, "fee.fi.fo.Fum", typ.Name)
+	}
+	for i := 0; i < 10; i++ {
+		pm, err := uncached("blah.blah.blah/fee.fi.fo.Foo", true)
+		testutil.Ok(t, err)
+		en := pm.(*ptype.Enum)
+		testutil.Eq(t, "fee.fi.fo.Foo", en.Name)
+	}
+
+	testutil.Eq(t, 10, counts["blah.blah.blah/fee.fi.fo.Fum"])
+	testutil.Eq(t, 10, counts["blah.blah.blah/fee.fi.fo.Foo"])
+
+	// now we'll see the underlying fetcher invoked just one more time,
+	// after which the result is cached
+	cached := CachingTypeFetcher(uncached)
+
+	for i := 0; i < 10; i++ {
+		pm, err := cached("blah.blah.blah/fee.fi.fo.Fum", false)
+		testutil.Ok(t, err)
+		typ := pm.(*ptype.Type)
+		testutil.Eq(t, "fee.fi.fo.Fum", typ.Name)
+	}
+
+	for i := 0; i < 10; i++ {
+		pm, err := cached("blah.blah.blah/fee.fi.fo.Foo", true)
+		testutil.Ok(t, err)
+		en := pm.(*ptype.Enum)
+		testutil.Eq(t, "fee.fi.fo.Foo", en.Name)
+	}
+
+	testutil.Eq(t, 11, counts["blah.blah.blah/fee.fi.fo.Fum"])
+	testutil.Eq(t, 11, counts["blah.blah.blah/fee.fi.fo.Foo"])
+}
+
+func TestCachingTypeFetcher_MismatchType(t *testing.T) {
+	fetcher := CachingTypeFetcher(testFetcher)
+	// get a message type
+	pm, err := fetcher("blah.blah.blah/fee.fi.fo.Fum", false)
+	testutil.Ok(t, err)
+	typ := pm.(*ptype.Type)
+	testutil.Eq(t, "fee.fi.fo.Fum", typ.Name)
+	// and an enum type
+	pm, err = fetcher("blah.blah.blah/fee.fi.fo.Foo", true)
+	testutil.Ok(t, err)
+	en := pm.(*ptype.Enum)
+	testutil.Eq(t, "fee.fi.fo.Foo", en.Name)
+
+	// now ask for same URL, but swapped types
+	pm, err = fetcher("blah.blah.blah/fee.fi.fo.Fum", true)
+	testutil.Require(t, err != nil && strings.Contains(err.Error(), "wanted enum, got message"))
+	pm, err = fetcher("blah.blah.blah/fee.fi.fo.Foo", false)
+	testutil.Require(t, err != nil && strings.Contains(err.Error(), "wanted message, got enum"))
+}
+
+func TestCachingTypeFetcher_Concurrency(t *testing.T) {
+	// make sure we are thread safe
+	var mu sync.Mutex
+	counts := map[string]int{}
+	tf := CachingTypeFetcher(func(url string, enum bool) (proto.Message, error) {
+		mu.Lock()
+		counts[url] = counts[url] + 1
+		mu.Unlock()
+		return testFetcher(url, enum)
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	names := []string{"Fee", "Fi", "Fo", "Fum", "I", "Smell", "Blood", "Of", "Englishman"}
+	var queryCount int32
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; ctx.Err() == nil; i = (i + 1) % len(names) {
+				n := "fee.fi.fo." + names[i]
+				// message
+				pm, err := tf("blah.blah.blah/"+n, false)
+				testutil.Ok(t, err)
+				typ := pm.(*ptype.Type)
+				testutil.Eq(t, n, typ.Name)
+				atomic.AddInt32(&queryCount, 1)
+				// enum
+				pm, err = tf("blah.blah.blah.en/"+n, true)
+				testutil.Ok(t, err)
+				en := pm.(*ptype.Enum)
+				testutil.Eq(t, n, en.Name)
+				atomic.AddInt32(&queryCount, 1)
+			}
+		}()
+	}
+
+	time.Sleep(2 * time.Second)
+	cancel()
+	wg.Wait()
+
+	// underlying fetcher invoked just once per URL
+	for _, v := range counts {
+		testutil.Eq(t, 1, v)
+	}
+
+	testutil.Require(t, atomic.LoadInt32(&queryCount) > int32(len(counts)))
+}
+
+func TestHttpTypeFetcher(t *testing.T) {
+	trt := &testRoundTripper{counts: map[string]int{}}
+	fetcher := HttpTypeFetcher(trt, 65536, 10)
+
+	for i := 0; i < 10; i++ {
+		pm, err := fetcher("blah.blah.blah/fee.fi.fo.Message", false)
+		testutil.Ok(t, err)
+		typ := pm.(*ptype.Type)
+		testutil.Eq(t, "fee.fi.fo.Message", typ.Name)
+	}
+
+	for i := 0; i < 10; i++ {
+		// name must have Enum for test fetcher to return an enum type
+		pm, err := fetcher("blah.blah.blah/fee.fi.fo.Enum", true)
+		testutil.Ok(t, err)
+		en := pm.(*ptype.Enum)
+		testutil.Eq(t, "fee.fi.fo.Enum", en.Name)
+	}
+
+	// HttpTypeFetcher caches results
+	testutil.Eq(t, 1, trt.counts["https://blah.blah.blah/fee.fi.fo.Message"])
+	testutil.Eq(t, 1, trt.counts["https://blah.blah.blah/fee.fi.fo.Enum"])
+}
+
+func TestHttpTypeFetcher_ParallelDownloads(t *testing.T) {
+	trt := &testRoundTripper{counts: map[string]int{}, delay: 100 * time.Millisecond}
+	fetcher := HttpTypeFetcher(trt, 65536, 10)
+	// We spin up 100 fetches in parallel, but only 10 can go at a time and each
+	// one takes 100millis. So it should take about 1 second.
+	start := time.Now()
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		index := i // don't capture loop variable
+		go func() {
+			defer wg.Done()
+			name := fmt.Sprintf("fee.fi.fo.Fum%d", index)
+			pm, err := fetcher("blah.blah.blah/"+name, false)
+			testutil.Ok(t, err)
+			typ := pm.(*ptype.Type)
+			testutil.Eq(t, name, typ.Name)
+		}()
+	}
+	wg.Wait()
+	elapsed := time.Now().Sub(start)
+
+	// we should have observed exactly the maximum number of parallel downloads
+	testutil.Eq(t, 10, trt.max)
+	// should have taken about a second
+	testutil.Require(t, elapsed >= time.Second)
+}
+
+func TestHttpTypeFetcher_SizeLimits(t *testing.T) {
+	trt := &testRoundTripper{counts: map[string]int{}}
+	// small size that will always get tripped
+	fetcher := HttpTypeFetcher(trt, 32, 10)
+
+	// name with "Size" causes content-length to be reported in header
+	_, err := fetcher("blah.blah.blah/fee.fi.fo.FumSize", false)
+	testutil.Require(t, err != nil && strings.Contains(err.Error(), "is larger than limit of 32"))
+
+	// without size in the name, no content-length (e.g. streaming response)
+	_, err = fetcher("blah.blah.blah/fee.fi.fo.Fum", false)
+	testutil.Require(t, err != nil && strings.Contains(err.Error(), "is larger than limit of 32"))
+}
+
+type testRoundTripper struct {
+	// artificial delay that each fake HTTP request will take
+	delay time.Duration
+	mu    sync.Mutex
+	// counts by requested URL
+	counts map[string]int
+	// total active downloads
+	active int
+	// max observed active downloads
+	max int
+}
+
+func (t *testRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	url := req.URL.String()
+
+	t.mu.Lock()
+	t.counts[url] = t.counts[url] + 1
+	t.active++
+	if t.active > t.max {
+		t.max = t.active
+	}
+	t.mu.Unlock()
+
+	defer func() {
+		t.mu.Lock()
+		t.active--
+		t.mu.Unlock()
+	}()
+
+	time.Sleep(t.delay)
+
+	name := url[strings.LastIndex(req.URL.Path, "/")+1:]
+	includeContentLength := strings.Contains(name, "Size")
+	pm, err := testFetcher(url, strings.Contains(name, "Enum"))
+	if err != nil {
+		return nil, err
+	}
+	b, err := proto.Marshal(pm)
+	if err != nil {
+		return nil, err
+	}
+	contentLength := int64(-1)
+	if includeContentLength {
+		contentLength = int64(len(b))
+	}
+	return &http.Response{
+		StatusCode:    200,
+		Status:        "200 OK",
+		ContentLength: contentLength,
+		Body:          ioutil.NopCloser(bytes.NewReader(b)),
+	}, nil
+}
+
+func testFetcher(url string, enum bool) (proto.Message, error) {
+	name := url[strings.LastIndex(url, "/")+1:]
+	if strings.Contains(name, "Error") {
+		return nil, errors.New(name)
+	} else if enum {
+		return &ptype.Enum{
+			Name:          name,
+			SourceContext: &source_context.SourceContext{FileName: "test.proto"},
+			Syntax:        ptype.Syntax_SYNTAX_PROTO3,
+			Enumvalue: []*ptype.EnumValue{
+				{Name: "A", Number: 0},
+				{Name: "B", Number: 1},
+				{Name: "C", Number: 2},
+			},
+		}, nil
+	} else {
+		return &ptype.Type{
+			Name:          name,
+			SourceContext: &source_context.SourceContext{FileName: "test.proto"},
+			Syntax:        ptype.Syntax_SYNTAX_PROTO3,
+			Fields: []*ptype.Field{
+				{Name: "a", Number: 1, Cardinality: ptype.Field_CARDINALITY_OPTIONAL, Kind: ptype.Field_TYPE_INT64},
+				{Name: "b", Number: 2, Cardinality: ptype.Field_CARDINALITY_OPTIONAL, Kind: ptype.Field_TYPE_STRING},
+				{Name: "c1", Number: 3, OneofIndex: 1, Cardinality: ptype.Field_CARDINALITY_OPTIONAL, Kind: ptype.Field_TYPE_STRING},
+				{Name: "c2", Number: 4, OneofIndex: 1, Cardinality: ptype.Field_CARDINALITY_OPTIONAL, Kind: ptype.Field_TYPE_BOOL},
+				{Name: "c3", Number: 5, OneofIndex: 1, Cardinality: ptype.Field_CARDINALITY_OPTIONAL, Kind: ptype.Field_TYPE_DOUBLE},
+				{Name: "d", Number: 6, Cardinality: ptype.Field_CARDINALITY_REPEATED, Kind: ptype.Field_TYPE_MESSAGE, TypeUrl: "type.googleapis.com/foo.bar.Baz"},
+				{Name: "e", Number: 7, Cardinality: ptype.Field_CARDINALITY_OPTIONAL, Kind: ptype.Field_TYPE_ENUM, TypeUrl: "type.googleapis.com/foo.bar.Blah"},
+			},
+			Oneofs: []string{"union"},
+		}, nil
+	}
+}

--- a/dynamic/text.go
+++ b/dynamic/text.go
@@ -297,7 +297,7 @@ func marshalKnownFieldText(b *indentBuffer, fd *desc.FieldDescriptor, v interfac
 				return err
 			}
 		} else {
-			err = proto.MarshalText(b, v.(proto.Message))
+			err = proto.CompactText(b, v.(proto.Message))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Conversions from descriptors to the well-known types (`Type`, `Enum`, `Api`, etc) and vice versa. Also added lots of doc comments to the new-ish files and added lots of tests. *But* still no tests for the hardest parts (and thus most likely to be broken in its current form): the code that does the descriptor generation/translation. Also, there's a big TODO regarding converting an `Api` into a service descriptor that will really need to be addressed...