### PR TITLE
dynamic message implements JSONPBMarshaler/JSONPBUnmarshaler

### DIFF
--- a/dynamic/indent.go
+++ b/dynamic/indent.go
@@ -4,20 +4,21 @@ import "bytes"
 
 type indentBuffer struct {
 	bytes.Buffer
-	indent int
-	comma  bool
+	indent      string
+	indentCount int
+	comma       bool
 }
 
 func (b *indentBuffer) start() error {
-	if b.indent >= 0 {
-		b.indent++
+	if b.indentCount >= 0 {
+		b.indentCount++
 		return b.newLine(false)
 	}
 	return nil
 }
 
 func (b *indentBuffer) sep() error {
-	if b.indent >= 0 {
+	if b.indentCount >= 0 {
 		_, err := b.WriteString(": ")
 		return err
 	} else {
@@ -26,8 +27,8 @@ func (b *indentBuffer) sep() error {
 }
 
 func (b *indentBuffer) end() error {
-	if b.indent >= 0 {
-		b.indent--
+	if b.indentCount >= 0 {
+		b.indentCount--
 		return b.newLine(false)
 	}
 	return nil
@@ -43,7 +44,7 @@ func (b *indentBuffer) maybeNext(first *bool) error {
 }
 
 func (b *indentBuffer) next() error {
-	if b.indent >= 0 {
+	if b.indentCount >= 0 {
 		return b.newLine(b.comma)
 	} else if b.comma {
 		return b.WriteByte(',')
@@ -65,8 +66,8 @@ func (b *indentBuffer) newLine(comma bool) error {
 		return err
 	}
 
-	for i := 0; i < b.indent; i++ {
-		_, err := b.WriteString("  ")
+	for i := 0; i < b.indentCount; i++ {
+		_, err := b.WriteString(b.indent)
 		if err != nil {
 			return err
 		}

--- a/dynamic/json_test.go
+++ b/dynamic/json_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
+	"bytes"
 )
 
 func TestUnaryFieldsJSON(t *testing.T) {
@@ -39,31 +40,40 @@ func TestExtensionFieldsJSON(t *testing.T) {
 	// TODO
 }
 
+func TestMarshalJSONEmitDefaults(t *testing.T) {
+	// TODO
+}
+
+func TestMarshalJSONEnumsAsInts(t *testing.T) {
+	// TODO
+}
+
+func TestMarshalJSONOrigName(t *testing.T) {
+	// TODO
+}
+
+func TestMarshalJSONIndent(t *testing.T) {
+	// TODO
+}
+
+func TestUnmarshalJSONAllowUnknownFields(t *testing.T) {
+	// TODO
+}
+
 func jsonTranslationParty(t *testing.T, msg proto.Message) {
 	doTranslationParty(t, msg,
 		func(pm proto.Message) ([]byte, error) {
-			// TODO: jsonpb should handle case where given message implements json.Marshaler
-			// https://github.com/golang/protobuf/pull/325
-			// Remove the following three lines if/when that change is merged
-			if dm, ok := pm.(*Message); ok {
-				return dm.MarshalJSON()
-			}
 			m := jsonpb.Marshaler{}
-			s, err := m.MarshalToString(pm)
+			var b bytes.Buffer
+			err := m.Marshal(&b, pm)
 			if err != nil {
 				return nil, err
 			} else {
-				return []byte(s), nil
+				return b.Bytes(), nil
 			}
 		},
 		func(b []byte, pm proto.Message) error {
-			// TODO: jsonpb should handle case where given message implements json.Marshaler
-			// https://github.com/golang/protobuf/pull/325
-			// Remove the following three lines if/when that change is merged
-			if dm, ok := pm.(*Message); ok {
-				return dm.UnmarshalJSON(b)
-			}
-			return jsonpb.UnmarshalString(string(b), pm)
+			return jsonpb.Unmarshal(bytes.NewReader(b), pm)
 		},
 		(*Message).MarshalJSON, (*Message).UnmarshalJSON)
 }

--- a/dynamic/text.go
+++ b/dynamic/text.go
@@ -22,7 +22,7 @@ import (
 
 func (m *Message) MarshalText() ([]byte, error) {
 	var b indentBuffer
-	b.indent = -1 // no indentation
+	b.indentCount = -1 // no indentation
 	if err := m.marshalText(&b); err != nil {
 		return nil, err
 	}
@@ -31,6 +31,7 @@ func (m *Message) MarshalText() ([]byte, error) {
 
 func (m *Message) MarshalTextIndent() ([]byte, error) {
 	var b indentBuffer
+	b.indent = "  " // TODO: option for indent?
 	if err := m.marshalText(&b); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
@pboyer, I managed to get a change landed in golang/protobuf (https://github.com/golang/protobuf/pull/325) that gave me reason to re-work the JSON marshaling a little. While at it, I implemented the other options provided by `jsonpb.Marshaler` and added a few new tests.

So heads up that this is changing in an incompatible way (though should be trivial to update).