### PR TITLE
several fixes

### DIFF
--- a/desc/descriptor.go
+++ b/desc/descriptor.go
@@ -908,6 +908,24 @@ func (fd *FieldDescriptor) IsMap() bool {
 	return fd.isMap
 }
 
+// GetMapKeyType returns the type of the key field if this is a map field. If it is
+// not a map field, nil is returned.
+func (fd *FieldDescriptor) GetMapKeyType() *FieldDescriptor {
+	if fd.isMap {
+		return fd.msgType.FindFieldByNumber(int32(1))
+	}
+	return nil
+}
+
+// GetMapValueType returns the type of the value field if this is a map field. If it
+// is not a map field, nil is returned.
+func (fd *FieldDescriptor) GetMapValueType() *FieldDescriptor {
+	if fd.isMap {
+		return fd.msgType.FindFieldByNumber(int32(2))
+	}
+	return nil
+}
+
 // GetMessageType returns the type of this field if it is a message type. If
 // this field is not a message type, it returns nil.
 func (fd *FieldDescriptor) GetMessageType() *MessageDescriptor {

--- a/dynamic/json.go
+++ b/dynamic/json.go
@@ -295,11 +295,11 @@ func marshalKnownFieldValueJSON(b *indentBuffer, fd *desc.FieldDescriptor, v int
 				// add indention prefix to each line
 				for pos < len(str) {
 					start := pos
-					pos = strings.Index(str[pos:], "\n")
-					if pos == -1 {
+					nextPos := strings.Index(str[pos:], "\n")
+					if nextPos == -1 {
 						pos = len(str)
 					} else {
-						pos++ // include newline
+						pos = pos + nextPos + 1 // include newline
 					}
 					line := str[start:pos]
 					_, err = b.WriteString(indent)


### PR DESCRIPTION
* fix issue with converting unrecognized extensions into dynamic message (unrecognized extensions do not get put into `XXX_unrecognized` field)
* fix how nil `*MessageFactory responds` to `NewMessage(...)` (make it consistent with how pointer to zero value `MessageFactory` would respond)
* fix in JSON marshalling when indenting a non-dynamic message into the JSON of a dynamic message (addresses an index-out-of-range panic)