### PR TITLE
check isMap before determineDefault to set default correctly

### DIFF
--- a/desc/descriptor.go
+++ b/desc/descriptor.go
@@ -685,10 +685,10 @@ func (fd *FieldDescriptor) resolve(path []int32, sourceCodeInfo map[string]*dpb.
 		}
 	}
 	fd.file.registerField(fd)
-	fd.def = fd.determineDefault()
 	fd.isMap = fd.proto.GetLabel() == dpb.FieldDescriptorProto_LABEL_REPEATED &&
 		fd.proto.GetType() == dpb.FieldDescriptorProto_TYPE_MESSAGE &&
 		fd.GetMessageType().IsMapEntry()
+	fd.def = fd.determineDefault()
 	return nil
 }
 

--- a/dynamic/json_test.go
+++ b/dynamic/json_test.go
@@ -55,6 +55,25 @@ func TestMarshalJSONEmitDefaults(t *testing.T) {
 	testutil.Eq(t, `{"id":0,"name":""}`, string(jsDefaults))
 }
 
+func TestMarshalJSONEmitDefaultsMapKeyFields(t *testing.T) {
+	sort_map_keys = true
+	defer func() {
+		sort_map_keys = false
+	}()
+
+	md, err := desc.LoadMessageDescriptorForMessage((*testprotos.MapKeyFields)(nil))
+	testutil.Ok(t, err)
+	dm := NewMessage(md)
+	m := &jsonpb.Marshaler{EmitDefaults: true}
+	jsDefaults, err := dm.MarshalJSONPB(m)
+	testutil.Ok(t, err)
+	testutil.Eq(t, `{"i":{},"j":{},"k":{},"l":{},"m":{},"n":{},"o":{},"p":{},"q":{},"r":{},"s":{},"t":{}}`, string(jsDefaults))
+
+	jsDefaults2, err := m.MarshalToString(&testprotos.MapKeyFields{})
+	testutil.Ok(t, err)
+	testutil.Eq(t, string(jsDefaults), string(jsDefaults2))
+}
+
 func TestMarshalJSONEnumsAsInts(t *testing.T) {
 	md, err := desc.LoadMessageDescriptorForMessage((*testprotos.TestRequest)(nil))
 	testutil.Ok(t, err)


### PR DESCRIPTION
 `determineDefault`  checks message type and set default value for the message but `isMap` is populated after the method called, so `Map` type is handled  as `repeated`. Then, marshaler with EmitDefaults option causes panic because type asserting fails.