### PR TITLE
support descriptors that refer to known-bad import paths in grpcreflect

### DIFF
--- a/desc/descriptor.go
+++ b/desc/descriptor.go
@@ -53,6 +53,8 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
+
+	"github.com/jhump/protoreflect/internal"
 )
 
 const (
@@ -1570,50 +1572,6 @@ func LoadFileDescriptor(file string) (*FileDescriptor, error) {
 	return loadFileDescriptorLocked(file)
 }
 
-// These are standard protos included with protoc, but older versions of their
-// respective packages registered them using incorrect paths.
-var stdFileAliases = map[string]string{
-	// Files for the github.com/golang/protobuf/ptypes package at one point were
-	// registered using the path where the proto files are mirrored in GOPATH,
-	// inside the golang/protobuf repo.
-	// (Fixed as of https://github.com/golang/protobuf/pull/412)
-	"google/protobuf/any.proto":       "github.com/golang/protobuf/ptypes/any/any.proto",
-	"google/protobuf/duration.proto":  "github.com/golang/protobuf/ptypes/duration/duration.proto",
-	"google/protobuf/empty.proto":     "github.com/golang/protobuf/ptypes/empty/empty.proto",
-	"google/protobuf/struct.proto":    "github.com/golang/protobuf/ptypes/struct/struct.proto",
-	"google/protobuf/timestamp.proto": "github.com/golang/protobuf/ptypes/timestamp/timestamp.proto",
-	"google/protobuf/wrappers.proto":  "github.com/golang/protobuf/ptypes/wrappers/wrappers.proto",
-	// Files for the google.golang.org/genproto/protobuf package at one point
-	// were registered with an anomalous "src/" prefix.
-	// (Fixed as of https://github.com/google/go-genproto/pull/31)
-	"google/protobuf/api.proto":            "src/google/protobuf/api.proto",
-	"google/protobuf/field_mask.proto":     "src/google/protobuf/field_mask.proto",
-	"google/protobuf/source_context.proto": "src/google/protobuf/source_context.proto",
-	"google/protobuf/type.proto":           "src/google/protobuf/type.proto",
-
-	// Other standard files (descriptor.proto and compiler/plugin.proto) are
-	// registered correctly, so we don't need rules for them here.
-}
-
-func init() {
-	// We provide aliasing in both directions, to support files with the
-	// proper import path linked against older versions of the generated
-	// files AND files that used the aliased import path but linked against
-	// newer versions of the generated files (which register with the
-	// correct path).
-
-	// Get all files defined above
-	keys := make([]string, 0, len(stdFileAliases))
-	for k := range stdFileAliases {
-		keys = append(keys, k)
-	}
-	// And add inverse mappings
-	for _, k := range keys {
-		alias := stdFileAliases[k]
-		stdFileAliases[alias] = k
-	}
-}
-
 func loadFileDescriptorLocked(file string) (*FileDescriptor, error) {
 	f := filesCache[file]
 	if f != nil {
@@ -1624,7 +1582,7 @@ func loadFileDescriptorLocked(file string) (*FileDescriptor, error) {
 	aliased := false
 	if fdb == nil {
 		var ok bool
-		alias, ok := stdFileAliases[file]
+		alias, ok := internal.StdFileAliases[file]
 		if ok {
 			aliased = true
 			if fdb = proto.FileDescriptor(alias); fdb == nil {

--- a/desc/descriptor_test.go
+++ b/desc/descriptor_test.go
@@ -15,6 +15,7 @@ import (
 	_ "google.golang.org/genproto/protobuf/ptype"
 	_ "google.golang.org/genproto/protobuf/source_context"
 
+	"github.com/jhump/protoreflect/internal"
 	"github.com/jhump/protoreflect/internal/testprotos"
 	"github.com/jhump/protoreflect/internal/testutil"
 )
@@ -923,8 +924,21 @@ func TestLoadFileDescriptorForWellKnownProtos(t *testing.T) {
 	}
 
 	for file, types := range wellKnownProtos {
-		// Try one with some imports
 		fd, err := LoadFileDescriptor(file)
+		testutil.Ok(t, err)
+		testutil.Eq(t, file, fd.GetName())
+		for _, typ := range types {
+			d := fd.FindSymbol(typ)
+			testutil.Require(t, d != nil)
+		}
+
+		// also try loading via alternate name
+		file = internal.StdFileAliases[file]
+		if file == "" {
+			// not a file that has a known alternate, so nothing else to check...
+			continue
+		}
+		fd, err = LoadFileDescriptor(file)
 		testutil.Ok(t, err)
 		testutil.Eq(t, file, fd.GetName())
 		for _, typ := range types {

--- a/grpcreflect/client_test.go
+++ b/grpcreflect/client_test.go
@@ -8,11 +8,18 @@ import (
 	"sync/atomic"
 	"testing"
 
+	_ "github.com/golang/protobuf/protoc-gen-go/plugin"
+	_ "github.com/golang/protobuf/ptypes/empty"
 	"golang.org/x/net/context"
+	_ "google.golang.org/genproto/protobuf/api"
+	_ "google.golang.org/genproto/protobuf/field_mask"
+	_ "google.golang.org/genproto/protobuf/ptype"
+	_ "google.golang.org/genproto/protobuf/source_context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 	rpb "google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
 
+	"github.com/jhump/protoreflect/internal"
 	"github.com/jhump/protoreflect/internal/testprotos"
 	"github.com/jhump/protoreflect/internal/testutil"
 )
@@ -72,6 +79,47 @@ func TestFileByFileName(t *testing.T) {
 
 	_, err = client.FileByFilename("does not exist")
 	testutil.Eq(t, ErrFileOrSymbolNotFound, err)
+}
+
+func TestFileByFileNameForWellKnownProtos(t *testing.T) {
+	wellKnownProtos := map[string][]string{
+		"google/protobuf/any.proto":             {"google.protobuf.Any"},
+		"google/protobuf/api.proto":             {"google.protobuf.Api", "google.protobuf.Method", "google.protobuf.Mixin"},
+		"google/protobuf/descriptor.proto":      {"google.protobuf.FileDescriptorSet", "google.protobuf.DescriptorProto"},
+		"google/protobuf/duration.proto":        {"google.protobuf.Duration"},
+		"google/protobuf/empty.proto":           {"google.protobuf.Empty"},
+		"google/protobuf/field_mask.proto":      {"google.protobuf.FieldMask"},
+		"google/protobuf/source_context.proto":  {"google.protobuf.SourceContext"},
+		"google/protobuf/struct.proto":          {"google.protobuf.Struct", "google.protobuf.Value", "google.protobuf.NullValue"},
+		"google/protobuf/timestamp.proto":       {"google.protobuf.Timestamp"},
+		"google/protobuf/type.proto":            {"google.protobuf.Type", "google.protobuf.Field", "google.protobuf.Syntax"},
+		"google/protobuf/wrappers.proto":        {"google.protobuf.DoubleValue", "google.protobuf.Int32Value", "google.protobuf.StringValue"},
+		"google/protobuf/compiler/plugin.proto": {"google.protobuf.compiler.CodeGeneratorRequest"},
+	}
+
+	for file, types := range wellKnownProtos {
+		fd, err := client.FileByFilename(file)
+		testutil.Ok(t, err)
+		testutil.Eq(t, file, fd.GetName())
+		for _, typ := range types {
+			d := fd.FindSymbol(typ)
+			testutil.Require(t, d != nil)
+		}
+
+		// also try loading via alternate name
+		file = internal.StdFileAliases[file]
+		if file == "" {
+			// not a file that has a known alternate, so nothing else to check...
+			continue
+		}
+		fd, err = client.FileByFilename(file)
+		testutil.Ok(t, err)
+		testutil.Eq(t, file, fd.GetName())
+		for _, typ := range types {
+			d := fd.FindSymbol(typ)
+			testutil.Require(t, d != nil)
+		}
+	}
 }
 
 func TestFileContainingSymbol(t *testing.T) {

--- a/internal/standard_file_aliases.go
+++ b/internal/standard_file_aliases.go
@@ -1,0 +1,47 @@
+// Package internal contains some code that should not be exported but needs to
+// be shared across more than one of the protoreflect sub-packages.
+package internal
+
+// These are standard protos included with protoc, but older versions of their
+// respective packages registered them using incorrect paths.
+var StdFileAliases = map[string]string{
+	// Files for the github.com/golang/protobuf/ptypes package at one point were
+	// registered using the path where the proto files are mirrored in GOPATH,
+	// inside the golang/protobuf repo.
+	// (Fixed as of https://github.com/golang/protobuf/pull/412)
+	"google/protobuf/any.proto":       "github.com/golang/protobuf/ptypes/any/any.proto",
+	"google/protobuf/duration.proto":  "github.com/golang/protobuf/ptypes/duration/duration.proto",
+	"google/protobuf/empty.proto":     "github.com/golang/protobuf/ptypes/empty/empty.proto",
+	"google/protobuf/struct.proto":    "github.com/golang/protobuf/ptypes/struct/struct.proto",
+	"google/protobuf/timestamp.proto": "github.com/golang/protobuf/ptypes/timestamp/timestamp.proto",
+	"google/protobuf/wrappers.proto":  "github.com/golang/protobuf/ptypes/wrappers/wrappers.proto",
+	// Files for the google.golang.org/genproto/protobuf package at one point
+	// were registered with an anomalous "src/" prefix.
+	// (Fixed as of https://github.com/google/go-genproto/pull/31)
+	"google/protobuf/api.proto":            "src/google/protobuf/api.proto",
+	"google/protobuf/field_mask.proto":     "src/google/protobuf/field_mask.proto",
+	"google/protobuf/source_context.proto": "src/google/protobuf/source_context.proto",
+	"google/protobuf/type.proto":           "src/google/protobuf/type.proto",
+
+	// Other standard files (descriptor.proto and compiler/plugin.proto) are
+	// registered correctly, so we don't need rules for them here.
+}
+
+func init() {
+	// We provide aliasing in both directions, to support files with the
+	// proper import path linked against older versions of the generated
+	// files AND files that used the aliased import path but linked against
+	// newer versions of the generated files (which register with the
+	// correct path).
+
+	// Get all files defined above
+	keys := make([]string, 0, len(StdFileAliases))
+	for k := range StdFileAliases {
+		keys = append(keys, k)
+	}
+	// And add inverse mappings
+	for _, k := range keys {
+		alias := StdFileAliases[k]
+		StdFileAliases[alias] = k
+	}
+}


### PR DESCRIPTION
This allows server reflection to work for protos that, for example, imported `github.com/golang/protobuf/ptypes/empty/empty.proto` instead of `google/protobuf/empty.proto`.