### PR TITLE
indent problem when dynamic message with non-dynamic field marshalled to json

### DIFF
--- a/dynamic/json.go
+++ b/dynamic/json.go
@@ -315,19 +315,22 @@ func marshalKnownFieldValueJSON(b *indentBuffer, fd *desc.FieldDescriptor, v int
 					start := pos
 					nextPos := strings.Index(str[pos:], "\n")
 					if nextPos == -1 {
-						pos = len(str)
+						nextPos = len(str)
 					} else {
-						pos = pos + nextPos + 1 // include newline
+						nextPos = pos + nextPos + 1 // include newline
 					}
-					line := str[start:pos]
-					_, err = b.WriteString(indent)
-					if err != nil {
-						return err
+					line := str[start:nextPos]
+					if pos > 0 {
+						_, err = b.WriteString(indent)
+						if err != nil {
+							return err
+						}
 					}
 					_, err = b.WriteString(line)
 					if err != nil {
 						return err
 					}
+					pos = nextPos
 				}
 			}
 			return err

--- a/dynamic/json_test.go
+++ b/dynamic/json_test.go
@@ -108,8 +108,7 @@ func TestMarshalJSONIndent(t *testing.T) {
 	testutil.Eq(t, `{"foo":["VALUE1"],"bar":"bedazzle"}`, string(js))
 	jsIndent, err := dm.MarshalJSONIndent()
 	testutil.Ok(t, err)
-	testutil.Eq(t,
-`{
+	testutil.Eq(t, `{
   "foo": [
     "VALUE1"
   ],
@@ -117,8 +116,7 @@ func TestMarshalJSONIndent(t *testing.T) {
 }`, string(jsIndent))
 	jsIndent, err = dm.MarshalJSONPB(&jsonpb.Marshaler{Indent: "\t"})
 	testutil.Ok(t, err)
-	testutil.Eq(t,
-`{
+	testutil.Eq(t, `{
 	"foo": [
 		"VALUE1"
 	],
@@ -151,8 +149,7 @@ func TestMarshalJSONIndentEmbedWellKnownTypes(t *testing.T) {
 	testutil.Eq(t, `{"startTime":"2010-03-04T05:06:07.000809Z","extras":[{"@type":"type.googleapis.com/testprotos.TestRequest","bar":"foo"},{"@type":"type.googleapis.com/testprotos.TestRequest","bar":"bar"},{"@type":"type.googleapis.com/testprotos.TestRequest","bar":"baz"}]}`, string(js))
 	jsIndent, err := dm.MarshalJSONIndent()
 	testutil.Ok(t, err)
-	testutil.Eq(t,
-`{
+	testutil.Eq(t, `{
   "startTime": "2010-03-04T05:06:07.000809Z",
   "extras": [
     {
@@ -171,8 +168,7 @@ func TestMarshalJSONIndentEmbedWellKnownTypes(t *testing.T) {
 }`, string(jsIndent))
 	jsIndent, err = dm.MarshalJSONPB(&jsonpb.Marshaler{Indent: "\t"})
 	testutil.Ok(t, err)
-	testutil.Eq(t,
-`{
+	testutil.Eq(t, `{
 	"startTime": "2010-03-04T05:06:07.000809Z",
 	"extras": [
 		{

--- a/dynamic/json_test.go
+++ b/dynamic/json_test.go
@@ -3,6 +3,7 @@ package dynamic
 import (
 	"bytes"
 	"testing"
+	"time"
 
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
@@ -107,10 +108,87 @@ func TestMarshalJSONIndent(t *testing.T) {
 	testutil.Eq(t, `{"foo":["VALUE1"],"bar":"bedazzle"}`, string(js))
 	jsIndent, err := dm.MarshalJSONIndent()
 	testutil.Ok(t, err)
-	testutil.Eq(t, "{\n  \"foo\": [\n    \"VALUE1\"\n  ],\n  \"bar\": \"bedazzle\"\n}", string(jsIndent))
+	testutil.Eq(t,
+`{
+  "foo": [
+    "VALUE1"
+  ],
+  "bar": "bedazzle"
+}`, string(jsIndent))
 	jsIndent, err = dm.MarshalJSONPB(&jsonpb.Marshaler{Indent: "\t"})
 	testutil.Ok(t, err)
-	testutil.Eq(t, "{\n\t\"foo\": [\n\t\t\"VALUE1\"\n\t],\n\t\"bar\": \"bedazzle\"\n}", string(jsIndent))
+	testutil.Eq(t,
+`{
+	"foo": [
+		"VALUE1"
+	],
+	"bar": "bedazzle"
+}`, string(jsIndent))
+}
+
+func TestMarshalJSONIndentEmbedWellKnownTypes(t *testing.T) {
+	// testing the formatting of dynamic message that embeds non-dynamic message,
+	// both those w/ special/simple JSON encoding (like timestamp) and those with
+	// more structure (Any).
+	md, err := desc.LoadMessageDescriptorForMessage((*testprotos.TestWellKnownTypes)(nil))
+	testutil.Ok(t, err)
+	dm := NewMessage(md)
+
+	ts, err := ptypes.TimestampProto(time.Date(2010, 3, 4, 5, 6, 7, 809000, time.UTC))
+	testutil.Ok(t, err)
+	dm.SetFieldByNumber(1, ts)
+
+	anys := make([]*any.Any, 3)
+	anys[0], err = ptypes.MarshalAny(&testprotos.TestRequest{Bar: "foo"})
+	testutil.Ok(t, err)
+	anys[1], err = ptypes.MarshalAny(&testprotos.TestRequest{Bar: "bar"})
+	testutil.Ok(t, err)
+	anys[2], err = ptypes.MarshalAny(&testprotos.TestRequest{Bar: "baz"})
+	dm.SetFieldByNumber(13, anys)
+
+	js, err := dm.MarshalJSON()
+	testutil.Ok(t, err)
+	testutil.Eq(t, `{"startTime":"2010-03-04T05:06:07.000809Z","extras":[{"@type":"type.googleapis.com/testprotos.TestRequest","bar":"foo"},{"@type":"type.googleapis.com/testprotos.TestRequest","bar":"bar"},{"@type":"type.googleapis.com/testprotos.TestRequest","bar":"baz"}]}`, string(js))
+	jsIndent, err := dm.MarshalJSONIndent()
+	testutil.Ok(t, err)
+	testutil.Eq(t,
+`{
+  "startTime": "2010-03-04T05:06:07.000809Z",
+  "extras": [
+    {
+      "@type": "type.googleapis.com/testprotos.TestRequest",
+      "bar": "foo"
+    },
+    {
+      "@type": "type.googleapis.com/testprotos.TestRequest",
+      "bar": "bar"
+    },
+    {
+      "@type": "type.googleapis.com/testprotos.TestRequest",
+      "bar": "baz"
+    }
+  ]
+}`, string(jsIndent))
+	jsIndent, err = dm.MarshalJSONPB(&jsonpb.Marshaler{Indent: "\t"})
+	testutil.Ok(t, err)
+	testutil.Eq(t,
+`{
+	"startTime": "2010-03-04T05:06:07.000809Z",
+	"extras": [
+		{
+			"@type": "type.googleapis.com/testprotos.TestRequest",
+			"bar": "foo"
+		},
+		{
+			"@type": "type.googleapis.com/testprotos.TestRequest",
+			"bar": "bar"
+		},
+		{
+			"@type": "type.googleapis.com/testprotos.TestRequest",
+			"bar": "baz"
+		}
+	]
+}`, string(jsIndent))
 }
 
 func TestUnmarshalJSONAllowUnknownFields(t *testing.T) {


### PR DESCRIPTION
By default, well-known types are represented as normal, generated messages -- not dynamic messages. So de-serializing a dynamic message that contains a field of well-known type produces a "mixed content" message -- dynamic message with some non-dynamic (e.g. generated) message components. When marshaling to JSON, the code incorrectly applied the configured indent level even to the first line of the non-dynamic message's JSON output, which looked wonky.