### PR TITLE
Handle CR or LF to signify line ending on the proto file

### DIFF
--- a/desc/protoparse/lexer.go
+++ b/desc/protoparse/lexer.go
@@ -131,7 +131,7 @@ func (l *protoLex) Lex(lval *protoSymType) (code int) {
 			return _ERROR
 		}
 
-		if c == '\n' {
+		if c == '\n' || c == '\r' {
 			l.colNo = 0
 			l.lineNo++
 			continue


### PR DESCRIPTION
The lexer was only checking for \n line endings, which mean't that files with \r\n or \r (rarer) cause the lexer to throw  syntax error: unexpected $unk