### PR TITLE
desc.LoadEnumDescriptor*

### DIFF
--- a/desc/descriptor_test.go
+++ b/desc/descriptor_test.go
@@ -879,6 +879,38 @@ func TestLoadMessageDescriptor(t *testing.T) {
 	testutil.Eq(t, md, md3)
 }
 
+func TestLoadEnumDescriptor(t *testing.T) {
+	ed, err := LoadEnumDescriptorForEnum(testprotos.TestMessage_NestedMessage_AnotherNestedMessage_YetAnotherNestedMessage_DeeplyNestedEnum(0))
+	testutil.Ok(t, err)
+	testutil.Eq(t, "DeeplyNestedEnum", ed.GetName())
+	testutil.Eq(t, "testprotos.TestMessage.NestedMessage.AnotherNestedMessage.YetAnotherNestedMessage.DeeplyNestedEnum", ed.GetFullyQualifiedName())
+	fd := ed.GetFile()
+	testutil.Eq(t, "desc_test1.proto", fd.GetName())
+	ofd, err := LoadFileDescriptor("desc_test1.proto")
+	testutil.Ok(t, err)
+	testutil.Eq(t, ofd, fd)
+
+	ed2, err := LoadEnumDescriptorForEnum((*testprotos.TestEnum)(nil)) // pointer type for interface
+	testutil.Ok(t, err)
+	testutil.Eq(t, "TestEnum", ed2.GetName())
+	testutil.Eq(t, "testprotos.TestEnum", ed2.GetFullyQualifiedName())
+	fd = ed2.GetFile()
+	testutil.Eq(t, "desc_test_field_types.proto", fd.GetName())
+	ofd, err = LoadFileDescriptor("desc_test_field_types.proto")
+	testutil.Ok(t, err)
+	testutil.Eq(t, ofd, fd)
+	testutil.Eq(t, fd, ed2.GetParent())
+
+	// now use the APIs that take reflect.Type
+	ed3, err := LoadEnumDescriptorForType(reflect.TypeOf((*testprotos.TestMessage_NestedMessage_AnotherNestedMessage_YetAnotherNestedMessage_DeeplyNestedEnum)(nil)))
+	testutil.Ok(t, err)
+	testutil.Eq(t, ed, ed3)
+
+	ed4, err := LoadEnumDescriptorForType(reflect.TypeOf(testprotos.TestEnum_FIRST))
+	testutil.Ok(t, err)
+	testutil.Eq(t, ed2, ed4)
+}
+
 func TestLoadFileDescriptorWithDeps(t *testing.T) {
 	// Try one with some imports
 	fd, err := LoadFileDescriptor("desc_test2.proto")

--- a/internal/standard_files.go
+++ b/internal/standard_files.go
@@ -94,14 +94,14 @@ func LoadFileDescriptor(file string) (*dpb.FileDescriptorProto, error) {
 // Registered file descriptors are first "proto encoded" (e.g. binary format
 // for the descriptor protos) and then gzipped. So this function gunzips and
 // then unmarshals into a descriptor proto.
-func DecodeFileDescriptor(file string, fdb []byte) (*dpb.FileDescriptorProto, error) {
+func DecodeFileDescriptor(element string, fdb []byte) (*dpb.FileDescriptorProto, error) {
 	raw, err := decompress(fdb)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decompress %q descriptor: %v", file, err)
+		return nil, fmt.Errorf("failed to decompress %q descriptor: %v", element, err)
 	}
 	fd := dpb.FileDescriptorProto{}
 	if err := proto.Unmarshal(raw, &fd); err != nil {
-		return nil, fmt.Errorf("bad descriptor for %q: %v", file, err)
+		return nil, fmt.Errorf("bad descriptor for %q: %v", element, err)
 	}
 	return &fd, nil
 }


### PR DESCRIPTION
New APIs for loading enum descriptors for generated types using those generated types.

Registration of enum types does not register their name. And protoc-gen-go's code-gen doesn't generate the enums' fully-qualified names into anything accessible by reflection code. So enum descriptors can only be loaded using instances of generated enum types or corresponding `reflect.Type` instances.