### PR TITLE
desc/builder package

### DIFF
--- a/desc/builder/builders.go
+++ b/desc/builder/builders.go
@@ -1,0 +1,2654 @@
+package builder
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"sync/atomic"
+	"unicode"
+
+	"github.com/golang/protobuf/proto"
+	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
+
+	"github.com/jhump/protoreflect/desc"
+)
+
+// TODO: finish writing Go doc for all types and methods
+
+// Builder is the core interface implemented by all descriptor builders. It
+// exposes some basic information about the descriptor hierarchy's structure.
+//
+// All Builders also have a Build() method, but that is not part of this
+// interface because its return type varies with the type of descriptor that
+// is built.
+type Builder interface {
+	// GetName returns this element's name. The name returned is a simple name,
+	// not a qualified name.
+	GetName() string
+
+	// TrySetName attempts to set this element's name. If the rename cannot
+	// proceed (e.g. this element's parent already has an element with that
+	// name) then an error is returned.
+	//
+	// All builders also have a method named SetName that panics on error and
+	// returns the builder itself (for method chaining). But that isn't defined
+	// on this interface because its return type varies with the type of the
+	// descriptor builder.
+	TrySetName(newName string) error
+
+	// GetParent returns this element's parent element. It returns nil if there
+	// is no parent element. File builders never have parent elements.
+	GetParent() Builder
+
+	// GetFile returns this element's file. This returns nil if the element has
+	// not yet been assigned to a file.
+	GetFile() *FileBuilder
+
+	// GetChildren returns all of this element's child elements. A file will
+	// return all of its top-level messages, enums, extensions, and services. A
+	// message will return all of its fields as well as nested messages, enums,
+	// and extensions, etc. Children will generally be grouped by type and,
+	// within a group, in the same order as the children were adde to their
+	// parent.
+	GetChildren() []Builder
+
+	// findChild returns the child builder with the given name or nil if this
+	// builder has no such child.
+	findChild(string) Builder
+
+	// removeChild removes the given child builder from this element. If the
+	// given element is not a child, it should do nothing.
+	//
+	// NOTE: It is this method's responsibility to call child.setParent(nil)
+	// after removing references to the child from this element.
+	removeChild(Builder)
+
+	// renamedChild updates references by-name references to the given child and
+	// validates its name. The given string is the child's old name. If the
+	// rename can proceed, no error should be returned and any by-name
+	// references to the old name should be removed.
+	renamedChild(Builder, string) error
+
+	// setParent simply updates the up-link (from child to parent) so that the
+	// this element's parent is up-to-date. It does NOT try to remove references
+	// from the parent to this child. (See doc for removeChild(Builder)).
+	setParent(Builder)
+}
+
+/* NB: There are a few flows that need to maintain strong referential integrity
+ * and perform symbol and/or number uniqueness checks. The way these flows are
+ * implemented is described below. The actions generally involve two different
+ * components: making local changes to an element and making corresponding
+ * and/or related changes in a parent element. Below describes the separation of
+ * responsibilities between the two.
+ *
+ *
+ * RENAMING AN ELEMENT
+ *
+ * Renaming an element is initiated via Builder.TrySetName. Implementations
+ * should do the following:
+ *  1. Validate the new name using any local constraints and naming rules.
+ *  2. If there are child elements whose names should be kept in sync in some
+ *     way, rename them.
+ *  3. Invoke baseBuilder.setName. This changes this element's name and then
+ *     invokes Builder.renamedChild(child, oldName) to update any by-name
+ *     references from the parent to the child.
+ *  4. If step #3 failed, any other element names that were changed to keep
+ *     them in sync (from step #2) should be reverted.
+ *
+ * A key part of this flow is how parents react to child elements being renamed.
+ * This is done in Builder.renamedChild. Implementations should do the
+ * following:
+ *  1. Validate the name using any local constraints. (Often there are no new
+ *     constraints and any checks already done by Builder.TrySetName should
+ *     suffice.)
+ *  2. If the parent element should be renamed to keep it in sync with the
+ *     child's name, rename it.
+ *  3. Register references to the element using the new name. A possible cause
+ *     of error in this step is a uniqueness constraint, e.g. the element's new
+ *     name collides with a sibling element's name.
+ *  4. If step #3 failed and this element name was changed to keep it in sync
+ *     (from step #2), it should be reverted.
+ *  5. Finally, remove references to the element for the old name. This step
+ *     should always succeed.
+ *
+ * Changing the tag number for a non-extension field has a similar flow since it
+ * is also checked for uniqueness, to make sure the new tag number does not
+ * conflict with another existing field.
+ *
+ * Note that TrySetName and renamedChild methods both can return an error, which
+ * should indicate why the element could not be renamed (e.g. name is invalid,
+ * new name conflicts with existing sibling names, etc).
+ *
+ *
+ * MOVING/REMOVING AN ELEMENT
+ *
+ * When an element is added to a new parent but is already assigned to a parent,
+ * it is "moved" to the new parent. This is done via "Add" methods on the parent
+ * entity (for example, MessageBuilder.AddField). Implementations of such a
+ * method should do the following:
+ *  1. Register references to the element. A possible cause of failure in this
+ *     step is that the new element collides with an existing child.
+ *  2. Use the Unlink function to remove the element from any existing parent.
+ *  3. Use Builder.setParent to link the child to its parent.
+ *
+ * The Unlink function, which removes an element from its parent if it has a
+ * parent, relies on the parent's Builder.removeChild method. Implementations of
+ * that method should do the following:
+ *  1. Check that the element is actually a child. If not, return without doing
+ *     anything.
+ *  2. Remove all references to the child.
+ *  3. Finally, this method must call Builder.setParent(nil) to clear the
+ *     element's up-link so it no longer refers to the old parent.
+ *
+ * The "Add" methods typically have a "Try" form which can return an error. This
+ * could happen if the new child is not legal to add (including, for example,
+ * that its name collides with an existing child element).
+ *
+ * The removeChild and setParent methods, on the other hand, cannot return an
+ * error and thus must always succeed.
+ */
+
+// baseBuilder is a struct that can be embedded into each Builder implementation
+// and provides a kernel of builder-wiring support (to reduce boiler-plate in
+// each implementation).
+type baseBuilder struct {
+	name   string
+	parent Builder
+}
+
+func baseBuilderWithName(name string) baseBuilder {
+	if err := checkName(name); err != nil {
+		panic(err)
+	}
+	return baseBuilder{name: name}
+}
+
+func checkName(name string) error {
+	for i, ch := range name {
+		if i == 0 {
+			if ch != '_' && (ch < 'a' || ch > 'z') && (ch < 'A' || ch > 'Z') {
+				return fmt.Errorf("name %q is invalid; It must start with an underscore or letter", name)
+			}
+		} else {
+			if ch != '_' && (ch < '0' || ch > '9') && (ch < 'a' || ch > 'z') && (ch < 'A' || ch > 'Z') {
+				return fmt.Errorf("name %q contains invalid character %q; only underscores, letters, and numbers are allowed", name, string(ch))
+			}
+		}
+	}
+	return nil
+}
+
+func (b *baseBuilder) GetName() string {
+	return b.name
+}
+
+func (b *baseBuilder) setName(fullBuilder Builder, newName string) error {
+	if newName == b.name {
+		return nil // no change
+	}
+	if err := checkName(newName); err != nil {
+		return err
+	}
+	oldName := b.name
+	b.name = newName
+	if b.parent != nil {
+		if err := b.parent.renamedChild(fullBuilder, oldName); err != nil {
+			// revert the rename on error
+			b.name = oldName
+			return err
+		}
+	}
+	return nil
+}
+
+func (b *baseBuilder) GetParent() Builder {
+	return b.parent
+}
+
+func (b *baseBuilder) setParent(newParent Builder) {
+	b.parent = newParent
+}
+
+func (b *baseBuilder) GetFile() *FileBuilder {
+	var p Builder = b.parent
+	for p != nil {
+		if fb, ok := p.(*FileBuilder); ok {
+			return fb
+		}
+		p = p.GetParent()
+	}
+	return nil
+}
+
+// doBuild is a helper for implementing the Build() method that each builder
+// exposes. It is used for all builders except for the root FileBuilder type.
+func doBuild(b Builder) (desc.Descriptor, error) {
+	fd, err := newResolver().resolveElement(b, nil)
+	if err != nil {
+		return nil, err
+	}
+	return fd.FindSymbol(GetFullyQualifiedName(b)), nil
+}
+
+func getFullyQualifiedName(b Builder, buf *bytes.Buffer) {
+	if fb, ok := b.(*FileBuilder); ok {
+		buf.WriteString(fb.Package)
+	} else if b != nil {
+		p := b.GetParent()
+		if _, ok := p.(*FieldBuilder); ok {
+			// field can be the parent of a message (if it's
+			// the field's map entry or group type), but its
+			// name is not part of message's fqn; so skip
+			p = p.GetParent()
+		}
+		if _, ok := p.(*OneOfBuilder); ok {
+			// one-of can be the parent of a field, but its
+			// name is not part of field's fqn; so skip
+			p = p.GetParent()
+		}
+		getFullyQualifiedName(p, buf)
+		if buf.Len() > 0 {
+			buf.WriteByte('.')
+		}
+		buf.WriteString(b.GetName())
+	}
+}
+
+// GetFullyQualifiedName returns the given builder's fully-qualified name. This
+// name is based on the parent elements the builder may be linked to, which
+// provide context like package and (optional) enclosing message names.
+func GetFullyQualifiedName(b Builder) string {
+	var buf bytes.Buffer
+	getFullyQualifiedName(b, &buf)
+	return buf.String()
+}
+
+// Unlink removes the given builder from its parent. The parent will no longer
+// refer to the builder and vice versa.
+func Unlink(b Builder) {
+	if p := b.GetParent(); p != nil {
+		p.removeChild(b)
+	}
+}
+
+// getRoot navigates up the hierarchy to find the root builder for the given
+// instance.
+func getRoot(b Builder) Builder {
+	for {
+		p := b.GetParent()
+		if p == nil {
+			return b
+		}
+		b = p
+	}
+}
+
+// deleteBuilder will delete a descriptor builder with the given name from the
+// given slice. The slice's elements can be any builder type. The parameter has
+// type interface{} so it can accept []*MessageBuilder or []*FieldBuilder, for
+// example. It returns a value of the same type with the named builder omitted.
+func deleteBuilder(name string, descs interface{}) interface{} {
+	rv := reflect.ValueOf(descs)
+	for i := 0; i < rv.Len(); i++ {
+		c := rv.Index(i).Interface().(Builder)
+		if c.GetName() == name {
+			head := rv.Slice(0, i)
+			tail := rv.Slice(i+1, rv.Len())
+			return reflect.AppendSlice(head, tail)
+		}
+	}
+	return descs
+}
+
+var uniqueFileCounter uint64
+
+func uniqueFileName() string {
+	i := atomic.AddUint64(&uniqueFileCounter, 1)
+	return fmt.Sprintf("{generated-file-%04x}.proto", i)
+}
+
+func makeUnique(name string, existingNames map[string]struct{}) string {
+	i := 1
+	n := name
+	for {
+		if _, ok := existingNames[n]; !ok {
+			return n
+		}
+		n = fmt.Sprintf("%s(%d)", name, i)
+		i++
+	}
+}
+
+// FileBuilder is a builder used to construct a desc.FileDescriptor. This is the
+// root of the hierarchy. All other descriptors belong to a file, and thus all
+// other builders also belong to a file.
+//
+// If a builder is *not* associated with a file, the resulting descriptor will
+// be associated with a synthesized file that contains only the built descriptor
+// and its ancestors. This means that such descriptors will have no associated
+// package name.
+type FileBuilder struct {
+	name string
+
+	IsProto3 bool
+	Package  string
+	Options  *dpb.FileOptions
+
+	messages   []*MessageBuilder
+	extensions []*FieldBuilder
+	enums      []*EnumBuilder
+	services   []*ServiceBuilder
+	symbols    map[string]Builder
+}
+
+// NewFile creates a new FileBuilder for a file with the given name. The
+// name can be blank, which indicates a unique name should be generated for it.
+func NewFile(name string) *FileBuilder {
+	return &FileBuilder{
+		name:    name,
+		symbols: map[string]Builder{},
+	}
+}
+
+// FromFile returns a FileBuilder that is effectively a copy of the given
+// descriptor. (Note that builders do not retain source code info, even if the
+// given descriptor included it.)
+func FromFile(fd *desc.FileDescriptor) (*FileBuilder, error) {
+	fb := NewFile(fd.GetName())
+	fb.IsProto3 = fd.IsProto3()
+	fb.Package = fd.GetPackage()
+	fb.Options = fd.GetFileOptions()
+
+	localMessages := map[*desc.MessageDescriptor]*MessageBuilder{}
+	localEnums := map[*desc.EnumDescriptor]*EnumBuilder{}
+
+	for _, md := range fd.GetMessageTypes() {
+		if mb, err := fromMessage(md, localMessages, localEnums); err != nil {
+			return nil, err
+		} else if err := fb.TryAddMessage(mb); err != nil {
+			return nil, err
+		}
+	}
+	for _, ed := range fd.GetEnumTypes() {
+		if eb, err := fromEnum(ed, localEnums); err != nil {
+			return nil, err
+		} else if err := fb.TryAddEnum(eb); err != nil {
+			return nil, err
+		}
+	}
+	for _, exd := range fd.GetExtensions() {
+		if exb, err := fromField(exd); err != nil {
+			return nil, err
+		} else if err := fb.TryAddExtension(exb); err != nil {
+			return nil, err
+		}
+	}
+	for _, sd := range fd.GetServices() {
+		if sb, err := fromService(sd); err != nil {
+			return nil, err
+		} else if err := fb.TryAddService(sb); err != nil {
+			return nil, err
+		}
+	}
+
+	// we've converted everything, so now we update all foreign type references
+	// to be local type references if possible
+	for _, mb := range fb.messages {
+		updateLocalRefsInMessage(mb, localMessages, localEnums)
+	}
+	for _, exb := range fb.extensions {
+		updateLocalRefsInField(exb, localMessages, localEnums)
+	}
+	for _, sb := range fb.services {
+		for _, mtb := range sb.methods {
+			updateLocalRefsInRpcType(mtb.ReqType, localMessages)
+			updateLocalRefsInRpcType(mtb.RespType, localMessages)
+		}
+	}
+
+	return fb, nil
+}
+
+func updateLocalRefsInMessage(mb *MessageBuilder, localMessages map[*desc.MessageDescriptor]*MessageBuilder, localEnums map[*desc.EnumDescriptor]*EnumBuilder) {
+	for _, b := range mb.fieldsAndOneOfs {
+		if flb, ok := b.(*FieldBuilder); ok {
+			updateLocalRefsInField(flb, localMessages, localEnums)
+		} else {
+			oob := b.(*OneOfBuilder)
+			for _, flb := range oob.choices {
+				updateLocalRefsInField(flb, localMessages, localEnums)
+			}
+		}
+	}
+	for _, nmb := range mb.nestedMessages {
+		updateLocalRefsInMessage(nmb, localMessages, localEnums)
+	}
+	for _, exb := range mb.nestedExtensions {
+		updateLocalRefsInField(exb, localMessages, localEnums)
+	}
+}
+
+func updateLocalRefsInField(flb *FieldBuilder, localMessages map[*desc.MessageDescriptor]*MessageBuilder, localEnums map[*desc.EnumDescriptor]*EnumBuilder) {
+	if flb.fieldType.foreignMsgType != nil {
+		if mb, ok := localMessages[flb.fieldType.foreignMsgType]; ok {
+			flb.fieldType.foreignMsgType = nil
+			flb.fieldType.localMsgType = mb
+		}
+	}
+	if flb.fieldType.foreignEnumType != nil {
+		if eb, ok := localEnums[flb.fieldType.foreignEnumType]; ok {
+			flb.fieldType.foreignEnumType = nil
+			flb.fieldType.localEnumType = eb
+		}
+	}
+	if flb.foreignExtendee != nil {
+		if mb, ok := localMessages[flb.foreignExtendee]; ok {
+			flb.foreignExtendee = nil
+			flb.localExtendee = mb
+		}
+	}
+	if flb.msgType != nil {
+		updateLocalRefsInMessage(flb.msgType, localMessages, localEnums)
+	}
+}
+
+func updateLocalRefsInRpcType(rpcType *RpcType, localMessages map[*desc.MessageDescriptor]*MessageBuilder) {
+	if rpcType.foreignType != nil {
+		if mb, ok := localMessages[rpcType.foreignType]; ok {
+			rpcType.foreignType = nil
+			rpcType.localType = mb
+		}
+	}
+}
+
+func (fb *FileBuilder) GetName() string {
+	return fb.name
+}
+
+func (fb *FileBuilder) SetName(newName string) *FileBuilder {
+	fb.name = newName
+	return fb
+}
+
+func (fb *FileBuilder) TrySetName(newName string) error {
+	fb.name = newName
+	return nil
+}
+
+func (fb *FileBuilder) GetParent() Builder {
+	return nil
+}
+
+func (fb *FileBuilder) setParent(parent Builder) {
+	if parent != nil {
+		panic("files cannot have parent elements")
+	}
+}
+
+func (fb *FileBuilder) GetFile() *FileBuilder {
+	return fb
+}
+
+func (fb *FileBuilder) GetChildren() []Builder {
+	var ch []Builder
+	for _, mb := range fb.messages {
+		ch = append(ch, mb)
+	}
+	for _, exb := range fb.extensions {
+		ch = append(ch, exb)
+	}
+	for _, eb := range fb.enums {
+		ch = append(ch, eb)
+	}
+	for _, sb := range fb.services {
+		ch = append(ch, sb)
+	}
+	return ch
+}
+
+func (fb *FileBuilder) findChild(name string) Builder {
+	return fb.symbols[name]
+}
+
+func (fb *FileBuilder) removeChild(b Builder) {
+	if p, ok := b.GetParent().(*FileBuilder); !ok || p != fb {
+		return
+	}
+
+	switch b.(type) {
+	case *MessageBuilder:
+		fb.messages = deleteBuilder(b.GetName(), fb.messages).([]*MessageBuilder)
+	case *FieldBuilder:
+		fb.extensions = deleteBuilder(b.GetName(), fb.extensions).([]*FieldBuilder)
+	case *EnumBuilder:
+		fb.enums = deleteBuilder(b.GetName(), fb.enums).([]*EnumBuilder)
+	case *ServiceBuilder:
+		fb.services = deleteBuilder(b.GetName(), fb.services).([]*ServiceBuilder)
+	}
+	delete(fb.symbols, b.GetName())
+	b.setParent(nil)
+}
+
+func (fb *FileBuilder) renamedChild(b Builder, oldName string) error {
+	if p, ok := b.GetParent().(*FileBuilder); !ok || p != fb {
+		return nil
+	}
+
+	if err := fb.addSymbol(b); err != nil {
+		return err
+	}
+	delete(fb.symbols, oldName)
+	return nil
+}
+
+func (fb *FileBuilder) addSymbol(b Builder) error {
+	if ex, ok := fb.symbols[b.GetName()]; ok {
+		return fmt.Errorf("file %q already contains element (%T) named %q", fb.GetName(), ex, b.GetName())
+	}
+	fb.symbols[b.GetName()] = b
+	return nil
+}
+
+func (fb *FileBuilder) findFullyQualifiedElement(fqn string) Builder {
+	if fb.Package != "" {
+		if !strings.HasPrefix(fqn, fb.Package+".") {
+			return nil
+		}
+		fqn = fqn[len(fb.Package)+1:]
+	}
+	names := strings.Split(fqn, ".")
+	var b Builder = fb
+	for b != nil && len(names) > 0 {
+		b = b.findChild(names[0])
+		names = names[1:]
+	}
+	return b
+}
+
+// GetMessage returns the top-level message with the given name. If no such
+// message exists in the file, nil is returned.
+func (fb *FileBuilder) GetMessage(name string) *MessageBuilder {
+	b := fb.symbols[name]
+	if mb, ok := b.(*MessageBuilder); ok {
+		return mb
+	} else {
+		return nil
+	}
+}
+
+// RemoveMessage removes the top-level message with the given name. If no such
+// message exists in the file, this is a no-op.
+func (fb *FileBuilder) RemoveMessage(name string) *FileBuilder {
+	fb.TryRemoveMessage(name)
+	return fb
+}
+
+func (fb *FileBuilder) TryRemoveMessage(name string) bool {
+	b := fb.symbols[name]
+	if mb, ok := b.(*MessageBuilder); ok {
+		fb.removeChild(mb)
+		return true
+	}
+	return false
+}
+
+// AddMessage adds the given message to this file.
+func (fb *FileBuilder) AddMessage(mb *MessageBuilder) *FileBuilder {
+	if err := fb.TryAddMessage(mb); err != nil {
+		panic(err)
+	}
+	return fb
+}
+
+func (fb *FileBuilder) TryAddMessage(mb *MessageBuilder) error {
+	if err := fb.addSymbol(mb); err != nil {
+		return err
+	}
+	Unlink(mb)
+	mb.setParent(fb)
+	fb.messages = append(fb.messages, mb)
+	return nil
+}
+
+func (fb *FileBuilder) GetExtension(name string) *FieldBuilder {
+	b := fb.symbols[name]
+	if exb, ok := b.(*FieldBuilder); ok {
+		return exb
+	} else {
+		return nil
+	}
+}
+
+func (fb *FileBuilder) RemoveExtension(name string) *FileBuilder {
+	fb.TryRemoveExtension(name)
+	return fb
+}
+
+func (fb *FileBuilder) TryRemoveExtension(name string) bool {
+	b := fb.symbols[name]
+	if exb, ok := b.(*FieldBuilder); ok {
+		fb.removeChild(exb)
+		return true
+	}
+	return false
+}
+
+func (fb *FileBuilder) AddExtension(exb *FieldBuilder) *FileBuilder {
+	if err := fb.TryAddExtension(exb); err != nil {
+		panic(err)
+	}
+	return fb
+}
+
+func (fb *FileBuilder) TryAddExtension(exb *FieldBuilder) error {
+	if !exb.IsExtension() {
+		return fmt.Errorf("field %s is not an extension", exb.GetName())
+	}
+	if err := fb.addSymbol(exb); err != nil {
+		return err
+	}
+	Unlink(exb)
+	exb.setParent(fb)
+	fb.extensions = append(fb.extensions, exb)
+	return nil
+}
+
+func (fb *FileBuilder) GetEnum(name string) *EnumBuilder {
+	b := fb.symbols[name]
+	if eb, ok := b.(*EnumBuilder); ok {
+		return eb
+	} else {
+		return nil
+	}
+}
+
+func (fb *FileBuilder) RemoveEnum(name string) *FileBuilder {
+	fb.TryRemoveEnum(name)
+	return fb
+}
+
+func (fb *FileBuilder) TryRemoveEnum(name string) bool {
+	b := fb.symbols[name]
+	if eb, ok := b.(*EnumBuilder); ok {
+		fb.removeChild(eb)
+		return true
+	}
+	return false
+}
+
+func (fb *FileBuilder) AddEnum(eb *EnumBuilder) *FileBuilder {
+	if err := fb.TryAddEnum(eb); err != nil {
+		panic(err)
+	}
+	return fb
+}
+
+func (fb *FileBuilder) TryAddEnum(eb *EnumBuilder) error {
+	if err := fb.addSymbol(eb); err != nil {
+		return err
+	}
+	Unlink(eb)
+	eb.setParent(fb)
+	fb.enums = append(fb.enums, eb)
+	return nil
+}
+
+func (fb *FileBuilder) GetService(name string) *ServiceBuilder {
+	b := fb.symbols[name]
+	if sb, ok := b.(*ServiceBuilder); ok {
+		return sb
+	} else {
+		return nil
+	}
+}
+
+func (fb *FileBuilder) RemoveService(name string) *FileBuilder {
+	fb.TryRemoveService(name)
+	return fb
+}
+
+func (fb *FileBuilder) TryRemoveService(name string) bool {
+	b := fb.symbols[name]
+	if sb, ok := b.(*ServiceBuilder); ok {
+		fb.removeChild(sb)
+		return true
+	}
+	return false
+}
+
+func (fb *FileBuilder) AddService(sb *ServiceBuilder) *FileBuilder {
+	if err := fb.TryAddService(sb); err != nil {
+		panic(err)
+	}
+	return fb
+}
+
+func (fb *FileBuilder) TryAddService(sb *ServiceBuilder) error {
+	if err := fb.addSymbol(sb); err != nil {
+		return err
+	}
+	Unlink(sb)
+	sb.setParent(fb)
+	fb.services = append(fb.services, sb)
+	return nil
+}
+
+func (fb *FileBuilder) SetOptions(options *dpb.FileOptions) *FileBuilder {
+	fb.Options = options
+	return fb
+}
+
+func (fb *FileBuilder) SetPackageName(pkg string) *FileBuilder {
+	fb.Package = pkg
+	return fb
+}
+
+func (fb *FileBuilder) SetProto3(isProto3 bool) *FileBuilder {
+	fb.IsProto3 = isProto3
+	return fb
+}
+
+func (fb *FileBuilder) buildProto() (*dpb.FileDescriptorProto, error) {
+	name := fb.name
+	if name == "" {
+		name = uniqueFileName()
+	}
+	var syntax *string
+	if fb.IsProto3 {
+		syntax = proto.String("proto3")
+	}
+	var pkg *string
+	if fb.Package != "" {
+		pkg = proto.String(fb.Package)
+	}
+
+	messages := make([]*dpb.DescriptorProto, 0, len(fb.messages))
+	for _, mb := range fb.messages {
+		if md, err := mb.buildProto(); err != nil {
+			return nil, err
+		} else {
+			messages = append(messages, md)
+		}
+	}
+
+	enums := make([]*dpb.EnumDescriptorProto, 0, len(fb.enums))
+	for _, eb := range fb.enums {
+		if ed, err := eb.buildProto(); err != nil {
+			return nil, err
+		} else {
+			enums = append(enums, ed)
+		}
+	}
+
+	extensions := make([]*dpb.FieldDescriptorProto, 0, len(fb.extensions))
+	for _, exb := range fb.extensions {
+		if exd, err := exb.buildProto(); err != nil {
+			return nil, err
+		} else {
+			extensions = append(extensions, exd)
+		}
+	}
+
+	services := make([]*dpb.ServiceDescriptorProto, 0, len(fb.services))
+	for _, sb := range fb.services {
+		if sd, err := sb.buildProto(); err != nil {
+			return nil, err
+		} else {
+			services = append(services, sd)
+		}
+	}
+
+	return &dpb.FileDescriptorProto{
+		Name:        proto.String(name),
+		Package:     pkg,
+		Options:     fb.Options,
+		Syntax:      syntax,
+		MessageType: messages,
+		EnumType:    enums,
+		Extension:   extensions,
+		Service:     services,
+	}, nil
+}
+
+// Build contructs a file descriptor based on the contents of this file builder.
+func (fb *FileBuilder) Build() (*desc.FileDescriptor, error) {
+	return newResolver().resolveElement(fb, nil)
+}
+
+// MessageBuilder is a builder used to construct a desc.MessageDescriptor. A
+// message builder can define nested messages, enums, and extensions in addition
+// to defining the message's fields.
+//
+// Note that when building a descriptor from a MessageBuilder, not all protobuf
+// validation rules are enforced. See the package documentation for more info.
+type MessageBuilder struct {
+	baseBuilder
+
+	Options         *dpb.MessageOptions
+	ExtensionRanges []*dpb.DescriptorProto_ExtensionRange
+	ReservedRanges  []*dpb.DescriptorProto_ReservedRange
+	ReservedNames   []string
+
+	fieldsAndOneOfs  []Builder
+	fieldTags        map[int32]*FieldBuilder
+	nestedMessages   []*MessageBuilder
+	nestedExtensions []*FieldBuilder
+	nestedEnums      []*EnumBuilder
+	symbols          map[string]Builder
+}
+
+// NewMessage creates a new MessageBuilder for a message with the given
+// name. Since the new message has no parent element, it also has no package
+// name (e.g. it is in the unnamed package, until it is assigned to a file
+// builder that defines a package name).
+func NewMessage(name string) *MessageBuilder {
+	return &MessageBuilder{
+		baseBuilder: baseBuilderWithName(name),
+		fieldTags:   map[int32]*FieldBuilder{},
+		symbols:     map[string]Builder{},
+	}
+}
+
+// FromMessage returns a MessageBuilder that is effectively a copy of the
+// given descriptor.
+//
+// Note that is is not just the given message that is copied but its entire
+// file. So the caller can get the parent element of the returned builder and
+// the result would be a builder that is effectively a copy of the message
+// descriptor's parent.
+//
+// This means that message builders created from descriptors do not need to be
+// explicitly assigned to a file in order to preserve the original message's
+// package name.
+func FromMessage(md *desc.MessageDescriptor) (*MessageBuilder, error) {
+	if fb, err := FromFile(md.GetFile()); err != nil {
+		return nil, err
+	} else if mb, ok := fb.findFullyQualifiedElement(md.GetFullyQualifiedName()).(*MessageBuilder); ok {
+		return mb, nil
+	} else {
+		return nil, fmt.Errorf("could not find message %s after converting file %q to builder", md.GetFullyQualifiedName(), md.GetFile().GetName())
+	}
+}
+
+func fromMessage(md *desc.MessageDescriptor,
+	localMessages map[*desc.MessageDescriptor]*MessageBuilder,
+	localEnums map[*desc.EnumDescriptor]*EnumBuilder) (*MessageBuilder, error) {
+
+	mb := NewMessage(md.GetName())
+	mb.Options = md.GetMessageOptions()
+	mb.ExtensionRanges = md.AsDescriptorProto().GetExtensionRange()
+	mb.ReservedRanges = md.AsDescriptorProto().GetReservedRange()
+	mb.ReservedNames = md.AsDescriptorProto().GetReservedName()
+
+	localMessages[md] = mb
+
+	oneOfs := make([]*OneOfBuilder, len(md.GetOneOfs()))
+	for i, ood := range md.GetOneOfs() {
+		if oob, err := fromOneOf(ood); err != nil {
+			return nil, err
+		} else {
+			oneOfs[i] = oob
+		}
+	}
+
+	for _, fld := range md.GetFields() {
+		if fld.GetOneOf() != nil {
+			// add one-ofs in the order of their first constituent field
+			oob := oneOfs[fld.AsFieldDescriptorProto().GetOneofIndex()]
+			if oob != nil {
+				oneOfs[fld.AsFieldDescriptorProto().GetOneofIndex()] = nil
+				if err := mb.TryAddOneOf(oob); err != nil {
+					return nil, err
+				}
+			}
+			continue
+		}
+		if flb, err := fromField(fld); err != nil {
+			return nil, err
+		} else if err := mb.TryAddField(flb); err != nil {
+			return nil, err
+		}
+	}
+
+	for _, nmd := range md.GetNestedMessageTypes() {
+		if nmb, err := fromMessage(nmd, localMessages, localEnums); err != nil {
+			return nil, err
+		} else if err := mb.TryAddNestedMessage(nmb); err != nil {
+			return nil, err
+		}
+	}
+	for _, ed := range md.GetNestedEnumTypes() {
+		if eb, err := fromEnum(ed, localEnums); err != nil {
+			return nil, err
+		} else if err := mb.TryAddNestedEnum(eb); err != nil {
+			return nil, err
+		}
+	}
+	for _, exd := range md.GetNestedExtensions() {
+		if exb, err := fromField(exd); err != nil {
+			return nil, err
+		} else if err := mb.TryAddNestedExtension(exb); err != nil {
+			return nil, err
+		}
+	}
+
+	return mb, nil
+}
+
+func (mb *MessageBuilder) SetName(newName string) *MessageBuilder {
+	if err := mb.TrySetName(newName); err != nil {
+		panic(err)
+	}
+	return mb
+}
+
+func (mb *MessageBuilder) TrySetName(newName string) error {
+	if p, ok := mb.parent.(*FieldBuilder); ok && p.fieldType.fieldType != dpb.FieldDescriptorProto_TYPE_GROUP {
+		return fmt.Errorf("cannot change name of map entry %s; change name of field instead", GetFullyQualifiedName(mb))
+	}
+	return mb.trySetNameInternal(newName)
+}
+
+func (mb *MessageBuilder) trySetNameInternal(newName string) error {
+	return mb.baseBuilder.setName(mb, newName)
+}
+
+func (mb *MessageBuilder) setNameInternal(newName string) {
+	if err := mb.trySetNameInternal(newName); err != nil {
+		panic(err)
+	}
+}
+
+func (mb *MessageBuilder) GetChildren() []Builder {
+	var ch []Builder
+	for _, b := range mb.fieldsAndOneOfs {
+		ch = append(ch, b)
+	}
+	for _, nmb := range mb.nestedMessages {
+		ch = append(ch, nmb)
+	}
+	for _, exb := range mb.nestedExtensions {
+		ch = append(ch, exb)
+	}
+	for _, eb := range mb.nestedEnums {
+		ch = append(ch, eb)
+	}
+	return ch
+}
+
+func (mb *MessageBuilder) findChild(name string) Builder {
+	return mb.symbols[name]
+}
+
+func (mb *MessageBuilder) removeChild(b Builder) {
+	if p, ok := b.GetParent().(*MessageBuilder); !ok || p != mb {
+		return
+	}
+
+	switch b := b.(type) {
+	case *FieldBuilder:
+		if b.IsExtension() {
+			mb.nestedExtensions = deleteBuilder(b.GetName(), mb.nestedExtensions).([]*FieldBuilder)
+		} else {
+			mb.fieldsAndOneOfs = deleteBuilder(b.GetName(), mb.fieldsAndOneOfs).([]Builder)
+			delete(mb.fieldTags, b.GetNumber())
+			if b.msgType != nil {
+				delete(mb.symbols, b.msgType.GetName())
+			}
+		}
+	case *OneOfBuilder:
+		mb.fieldsAndOneOfs = deleteBuilder(b.GetName(), mb.fieldsAndOneOfs).([]Builder)
+		for _, flb := range b.choices {
+			delete(mb.symbols, flb.GetName())
+			delete(mb.fieldTags, flb.GetNumber())
+		}
+	case *MessageBuilder:
+		mb.nestedMessages = deleteBuilder(b.GetName(), mb.nestedMessages).([]*MessageBuilder)
+	case *EnumBuilder:
+		mb.nestedEnums = deleteBuilder(b.GetName(), mb.nestedEnums).([]*EnumBuilder)
+	}
+	delete(mb.symbols, b.GetName())
+	b.setParent(nil)
+}
+
+func (mb *MessageBuilder) renamedChild(b Builder, oldName string) error {
+	if p, ok := b.GetParent().(*MessageBuilder); !ok || p != mb {
+		return nil
+	}
+
+	if err := mb.addSymbol(b); err != nil {
+		return err
+	}
+	delete(mb.symbols, oldName)
+	return nil
+}
+
+func (mb *MessageBuilder) addSymbol(b Builder) error {
+	if ex, ok := mb.symbols[b.GetName()]; ok {
+		return fmt.Errorf("message %s already contains element (%T) named %q", GetFullyQualifiedName(mb), ex, b.GetName())
+	}
+	mb.symbols[b.GetName()] = b
+	return nil
+}
+
+func (mb *MessageBuilder) addTag(flb *FieldBuilder) error {
+	if flb.number == 0 {
+		return nil
+	}
+	if ex, ok := mb.fieldTags[flb.GetNumber()]; ok {
+		return fmt.Errorf("message %s already contains field with tag %d: %s", GetFullyQualifiedName(mb), flb.GetNumber(), ex.GetName())
+	}
+	mb.fieldTags[flb.GetNumber()] = flb
+	return nil
+}
+
+func (mb *MessageBuilder) registerField(flb *FieldBuilder) error {
+	if err := mb.addSymbol(flb); err != nil {
+		return err
+	}
+	if err := mb.addTag(flb); err != nil {
+		delete(mb.symbols, flb.GetName())
+		return err
+	}
+	if flb.msgType != nil {
+		if err := mb.addSymbol(flb.msgType); err != nil {
+			delete(mb.symbols, flb.GetName())
+			delete(mb.fieldTags, flb.GetNumber())
+			return err
+		}
+	}
+	return nil
+}
+
+func (mb *MessageBuilder) GetField(name string) *FieldBuilder {
+	b := mb.symbols[name]
+	if flb, ok := b.(*FieldBuilder); ok && !flb.IsExtension() {
+		return flb
+	} else {
+		return nil
+	}
+}
+
+func (mb *MessageBuilder) RemoveField(name string) *MessageBuilder {
+	mb.TryRemoveField(name)
+	return mb
+}
+
+func (mb *MessageBuilder) TryRemoveField(name string) bool {
+	b := mb.symbols[name]
+	if flb, ok := b.(*FieldBuilder); ok && !flb.IsExtension() {
+		// parent could be mb, but could also be a one-of
+		flb.GetParent().removeChild(flb)
+		return true
+	}
+	return false
+}
+
+func (mb *MessageBuilder) AddField(flb *FieldBuilder) *MessageBuilder {
+	if err := mb.TryAddField(flb); err != nil {
+		panic(err)
+	}
+	return mb
+}
+
+func (mb *MessageBuilder) TryAddField(flb *FieldBuilder) error {
+	if flb.IsExtension() {
+		return fmt.Errorf("field %s is an extension, not a regular field", flb.GetName())
+	}
+	// If we are moving field from a one-of that belongs to this message
+	// directly to this message, we have to use different order of operations
+	// to prevent failure (otherwise, it looks like it's being added twice).
+	// (We do similar if moving the other direction, from message to a one-of
+	// that is already assigned to same message.)
+	needToUnlinkFirst := mb.isPresentButNotChild(flb)
+	if needToUnlinkFirst {
+		Unlink(flb)
+		mb.registerField(flb)
+	} else {
+		if err := mb.registerField(flb); err != nil {
+			return err
+		}
+		Unlink(flb)
+	}
+	flb.setParent(mb)
+	mb.fieldsAndOneOfs = append(mb.fieldsAndOneOfs, flb)
+	return nil
+}
+
+func (mb *MessageBuilder) GetOneOf(name string) *OneOfBuilder {
+	b := mb.symbols[name]
+	if oob, ok := b.(*OneOfBuilder); ok {
+		return oob
+	} else {
+		return nil
+	}
+}
+
+func (mb *MessageBuilder) RemoveOneOf(name string) *MessageBuilder {
+	mb.TryRemoveOneOf(name)
+	return mb
+}
+
+func (mb *MessageBuilder) TryRemoveOneOf(name string) bool {
+	b := mb.symbols[name]
+	if oob, ok := b.(*OneOfBuilder); ok {
+		mb.removeChild(oob)
+		return true
+	}
+	return false
+}
+
+func (mb *MessageBuilder) AddOneOf(oob *OneOfBuilder) *MessageBuilder {
+	if err := mb.TryAddOneOf(oob); err != nil {
+		panic(err)
+	}
+	return mb
+}
+
+func (mb *MessageBuilder) TryAddOneOf(oob *OneOfBuilder) error {
+	if err := mb.addSymbol(oob); err != nil {
+		return err
+	}
+	// add nested fields to symbol and tag map
+	for i, flb := range oob.choices {
+		if err := mb.registerField(flb); err != nil {
+			// must undo all additions we've made so far
+			delete(mb.symbols, oob.GetName())
+			for i > 1 {
+				i--
+				flb := oob.choices[i]
+				delete(mb.symbols, flb.GetName())
+				delete(mb.fieldTags, flb.GetNumber())
+			}
+			return err
+		}
+	}
+	Unlink(oob)
+	oob.setParent(mb)
+	mb.fieldsAndOneOfs = append(mb.fieldsAndOneOfs, oob)
+	return nil
+}
+
+func (mb *MessageBuilder) GetNestedMessage(name string) *MessageBuilder {
+	b := mb.symbols[name]
+	if nmb, ok := b.(*MessageBuilder); ok {
+		return nmb
+	} else {
+		return nil
+	}
+}
+
+func (mb *MessageBuilder) RemoveNestedMessage(name string) *MessageBuilder {
+	mb.TryRemoveNestedMessage(name)
+	return mb
+}
+
+func (mb *MessageBuilder) TryRemoveNestedMessage(name string) bool {
+	b := mb.symbols[name]
+	if nmb, ok := b.(*MessageBuilder); ok {
+		mb.removeChild(nmb)
+		return true
+	}
+	return false
+}
+
+func (mb *MessageBuilder) AddNestedMessage(nmb *MessageBuilder) *MessageBuilder {
+	if err := mb.TryAddNestedMessage(nmb); err != nil {
+		panic(err)
+	}
+	return mb
+}
+
+func (mb *MessageBuilder) TryAddNestedMessage(nmb *MessageBuilder) error {
+	// If we are moving nested message from field (map entry or group type)
+	// directly to this message, we have to use different order of operations
+	// to prevent failure (otherwise, it looks like it's being added twice).
+	// (We don't need to do similar for the other direction, because that isn't
+	// possible: you can't add messages to a field, they can only be constructed
+	// that way using NewGroupField or NewMapField.)
+	needToUnlinkFirst := mb.isPresentButNotChild(nmb)
+	if needToUnlinkFirst {
+		Unlink(nmb)
+		mb.addSymbol(nmb)
+	} else {
+		if err := mb.addSymbol(nmb); err != nil {
+			return err
+		}
+		Unlink(mb)
+	}
+	nmb.setParent(mb)
+	mb.nestedMessages = append(mb.nestedMessages, nmb)
+	return nil
+}
+
+func (mb *MessageBuilder) isPresentButNotChild(b Builder) bool {
+	if p, ok := b.GetParent().(*MessageBuilder); ok && p == mb {
+		// it's a child
+		return false
+	}
+	return mb.symbols[b.GetName()] == b
+}
+
+func (mb *MessageBuilder) GetNestedExtension(name string) *FieldBuilder {
+	b := mb.symbols[name]
+	if exb, ok := b.(*FieldBuilder); ok && exb.IsExtension() {
+		return exb
+	} else {
+		return nil
+	}
+}
+
+func (mb *MessageBuilder) RemoveNestedExtension(name string) *MessageBuilder {
+	mb.TryRemoveNestedExtension(name)
+	return mb
+}
+
+func (mb *MessageBuilder) TryRemoveNestedExtension(name string) bool {
+	b := mb.symbols[name]
+	if exb, ok := b.(*FieldBuilder); ok && exb.IsExtension() {
+		mb.removeChild(exb)
+		return true
+	}
+	return false
+}
+
+func (mb *MessageBuilder) AddNestedExtension(exb *FieldBuilder) *MessageBuilder {
+	if err := mb.TryAddNestedExtension(exb); err != nil {
+		panic(err)
+	}
+	return mb
+}
+
+func (mb *MessageBuilder) TryAddNestedExtension(exb *FieldBuilder) error {
+	if !exb.IsExtension() {
+		return fmt.Errorf("field %s is not an extension", exb.GetName())
+	}
+	if err := mb.addSymbol(exb); err != nil {
+		return err
+	}
+	Unlink(exb)
+	exb.setParent(mb)
+	mb.nestedExtensions = append(mb.nestedExtensions, exb)
+	return nil
+}
+
+func (mb *MessageBuilder) GetNestedEnum(name string) *EnumBuilder {
+	b := mb.symbols[name]
+	if eb, ok := b.(*EnumBuilder); ok {
+		return eb
+	} else {
+		return nil
+	}
+}
+
+func (mb *MessageBuilder) RemoveNestedEnum(name string) *MessageBuilder {
+	mb.TryRemoveNestedEnum(name)
+	return mb
+}
+
+func (mb *MessageBuilder) TryRemoveNestedEnum(name string) bool {
+	b := mb.symbols[name]
+	if eb, ok := b.(*EnumBuilder); ok {
+		mb.removeChild(eb)
+		return true
+	}
+	return false
+}
+
+func (mb *MessageBuilder) AddNestedEnum(eb *EnumBuilder) *MessageBuilder {
+	if err := mb.TryAddNestedEnum(eb); err != nil {
+		panic(err)
+	}
+	return mb
+}
+
+func (mb *MessageBuilder) TryAddNestedEnum(eb *EnumBuilder) error {
+	if err := mb.addSymbol(eb); err != nil {
+		return err
+	}
+	Unlink(eb)
+	eb.setParent(mb)
+	mb.nestedEnums = append(mb.nestedEnums, eb)
+	return nil
+}
+
+func (mb *MessageBuilder) SetOptions(options *dpb.MessageOptions) *MessageBuilder {
+	mb.Options = options
+	return mb
+}
+
+func (mb *MessageBuilder) AddExtensionRange(start, end int32) *MessageBuilder {
+	return mb.AddExtensionRangeWithOptions(start, end, nil)
+}
+
+func (mb *MessageBuilder) AddExtensionRangeWithOptions(start, end int32, options *dpb.ExtensionRangeOptions) *MessageBuilder {
+	er := &dpb.DescriptorProto_ExtensionRange{
+		Start:   proto.Int32(start),
+		End:     proto.Int32(end + 1),
+		Options: options,
+	}
+	mb.ExtensionRanges = append(mb.ExtensionRanges, er)
+	return mb
+}
+
+func (mb *MessageBuilder) SetExtensionRanges(ranges []*dpb.DescriptorProto_ExtensionRange) *MessageBuilder {
+	mb.ExtensionRanges = ranges
+	return mb
+}
+
+func (mb *MessageBuilder) AddReservedRange(start, end int32) *MessageBuilder {
+	rr := &dpb.DescriptorProto_ReservedRange{
+		Start: proto.Int32(start),
+		End:   proto.Int32(end + 1),
+	}
+	mb.ReservedRanges = append(mb.ReservedRanges, rr)
+	return mb
+}
+
+func (mb *MessageBuilder) SetReservedRanges(ranges []*dpb.DescriptorProto_ReservedRange) *MessageBuilder {
+	mb.ReservedRanges = ranges
+	return mb
+}
+
+func (mb *MessageBuilder) AddReservedName(name string) *MessageBuilder {
+	mb.ReservedNames = append(mb.ReservedNames, name)
+	return mb
+}
+
+func (mb *MessageBuilder) SetReservedNames(names []string) *MessageBuilder {
+	mb.ReservedNames = names
+	return mb
+}
+
+func (mb *MessageBuilder) buildProto() (*dpb.DescriptorProto, error) {
+	var needTagsAssigned []*dpb.FieldDescriptorProto
+	nestedMessages := make([]*dpb.DescriptorProto, 0, len(mb.nestedMessages))
+	oneOfCount := 0
+	for _, b := range mb.fieldsAndOneOfs {
+		if _, ok := b.(*OneOfBuilder); ok {
+			oneOfCount++
+		}
+	}
+	fields := make([]*dpb.FieldDescriptorProto, 0, len(mb.fieldsAndOneOfs)-oneOfCount)
+	oneOfs := make([]*dpb.OneofDescriptorProto, 0, oneOfCount)
+	for _, b := range mb.fieldsAndOneOfs {
+		if flb, ok := b.(*FieldBuilder); ok {
+			fld, err := flb.buildProto()
+			if err != nil {
+				return nil, err
+			}
+			fields = append(fields, fld)
+			if flb.number == 0 {
+				needTagsAssigned = append(needTagsAssigned, fld)
+			}
+			if flb.msgType != nil {
+				if entry, err := flb.msgType.buildProto(); err != nil {
+					return nil, err
+				} else {
+					nestedMessages = append(nestedMessages, entry)
+				}
+			}
+		} else {
+			oob := b.(*OneOfBuilder)
+			oobIndex := len(oneOfs)
+			ood, err := oob.buildProto()
+			if err != nil {
+				return nil, err
+			}
+			oneOfs = append(oneOfs, ood)
+			for _, flb := range oob.choices {
+				fld, err := flb.buildProto()
+				if err != nil {
+					return nil, err
+				}
+				fld.OneofIndex = proto.Int32(int32(oobIndex))
+				fields = append(fields, fld)
+				if flb.number == 0 {
+					needTagsAssigned = append(needTagsAssigned, fld)
+				}
+			}
+		}
+	}
+
+	if len(needTagsAssigned) > 0 {
+		tags := make([]int, len(fields)-len(needTagsAssigned))
+		for i, fld := range fields {
+			tag := fld.GetNumber()
+			if tag != 0 {
+				tags[i] = int(tag)
+			}
+		}
+		sort.Ints(tags)
+		t := 1
+		for len(needTagsAssigned) > 0 {
+			for len(tags) > 0 && t == tags[0] {
+				t++
+				tags = tags[1:]
+			}
+			needTagsAssigned[0].Number = proto.Int32(int32(t))
+			needTagsAssigned = needTagsAssigned[1:]
+			t++
+		}
+	}
+
+	for _, nmb := range mb.nestedMessages {
+		if nmd, err := nmb.buildProto(); err != nil {
+			return nil, err
+		} else {
+			nestedMessages = append(nestedMessages, nmd)
+		}
+	}
+
+	nestedExtensions := make([]*dpb.FieldDescriptorProto, 0, len(mb.nestedExtensions))
+	for _, exb := range mb.nestedExtensions {
+		if exd, err := exb.buildProto(); err != nil {
+			return nil, err
+		} else {
+			nestedExtensions = append(nestedExtensions, exd)
+		}
+	}
+
+	nestedEnums := make([]*dpb.EnumDescriptorProto, 0, len(mb.nestedEnums))
+	for _, eb := range mb.nestedEnums {
+		if ed, err := eb.buildProto(); err != nil {
+			return nil, err
+		} else {
+			nestedEnums = append(nestedEnums, ed)
+		}
+	}
+
+	return &dpb.DescriptorProto{
+		Name:           proto.String(mb.name),
+		Options:        mb.Options,
+		Field:          fields,
+		OneofDecl:      oneOfs,
+		NestedType:     nestedMessages,
+		EnumType:       nestedEnums,
+		Extension:      nestedExtensions,
+		ExtensionRange: mb.ExtensionRanges,
+		ReservedName:   mb.ReservedNames,
+		ReservedRange:  mb.ReservedRanges,
+	}, nil
+}
+
+func (mb *MessageBuilder) Build() (*desc.MessageDescriptor, error) {
+	d, err := doBuild(mb)
+	if err != nil {
+		return nil, err
+	}
+	return d.(*desc.MessageDescriptor), nil
+}
+
+type FieldBuilder struct {
+	baseBuilder
+	number int32
+
+	// msgType is populated for fields that have a "private" message type that
+	// isn't expected to be referenced elsewhere. This happens for map fields,
+	// where the private message type represents the map entry, and for group
+	// fields.
+	msgType   *MessageBuilder
+	fieldType *FieldType
+
+	Options  *dpb.FieldOptions
+	Label    dpb.FieldDescriptorProto_Label
+	Default  string
+	JsonName string
+
+	foreignExtendee *desc.MessageDescriptor
+	localExtendee   *MessageBuilder
+}
+
+func NewField(name string, typ *FieldType) *FieldBuilder {
+	flb := &FieldBuilder{
+		baseBuilder: baseBuilderWithName(name),
+		fieldType:   typ,
+	}
+	return flb
+}
+
+func NewMapField(name string, keyTyp, valTyp *FieldType) *FieldBuilder {
+	switch keyTyp.fieldType {
+	case dpb.FieldDescriptorProto_TYPE_BOOL,
+		dpb.FieldDescriptorProto_TYPE_STRING,
+		dpb.FieldDescriptorProto_TYPE_INT32, dpb.FieldDescriptorProto_TYPE_INT64,
+		dpb.FieldDescriptorProto_TYPE_SINT32, dpb.FieldDescriptorProto_TYPE_SINT64,
+		dpb.FieldDescriptorProto_TYPE_UINT32, dpb.FieldDescriptorProto_TYPE_UINT64,
+		dpb.FieldDescriptorProto_TYPE_FIXED32, dpb.FieldDescriptorProto_TYPE_FIXED64,
+		dpb.FieldDescriptorProto_TYPE_SFIXED32, dpb.FieldDescriptorProto_TYPE_SFIXED64:
+		// allowed
+	default:
+		panic(fmt.Sprintf("Map types cannot have keys of type %v", keyTyp.fieldType))
+	}
+	if valTyp.fieldType == dpb.FieldDescriptorProto_TYPE_GROUP {
+		panic(fmt.Sprintf("Map types cannot have values of type %v", valTyp.fieldType))
+	}
+	entryMsg := NewMessage(entryTypeName(name))
+	keyFlb := NewField("key", keyTyp)
+	keyFlb.number = 1
+	valFlb := NewField("value", valTyp)
+	valFlb.number = 2
+	entryMsg.AddField(keyFlb)
+	entryMsg.AddField(valFlb)
+	entryMsg.Options = &dpb.MessageOptions{MapEntry: proto.Bool(true)}
+
+	flb := NewField(name, FieldTypeMessage(entryMsg)).
+		SetLabel(dpb.FieldDescriptorProto_LABEL_REPEATED)
+	flb.msgType = entryMsg
+	entryMsg.setParent(flb)
+	return flb
+}
+
+func NewGroupField(mb *MessageBuilder) *FieldBuilder {
+	if !unicode.IsUpper(rune(mb.name[0])) {
+		panic(fmt.Sprintf("group name %s must start with a capital letter", mb.name))
+	}
+	Unlink(mb)
+
+	ft := &FieldType{
+		fieldType:    dpb.FieldDescriptorProto_TYPE_GROUP,
+		localMsgType: mb,
+	}
+	fieldName := strings.ToLower(mb.GetName())
+	flb := NewField(fieldName, ft)
+	flb.msgType = mb
+	mb.setParent(flb)
+	return flb
+}
+
+func NewExtension(name string, tag int32, typ *FieldType, extendee *MessageBuilder) *FieldBuilder {
+	if extendee == nil {
+		panic("extendee cannot be nil")
+	}
+	flb := NewField(name, typ).SetNumber(tag)
+	flb.localExtendee = extendee
+	return flb
+}
+
+func NewExtensionImported(name string, tag int32, typ *FieldType, extendee *desc.MessageDescriptor) *FieldBuilder {
+	if extendee == nil {
+		panic("extendee cannot be nil")
+	}
+	flb := NewField(name, typ).SetNumber(tag)
+	flb.foreignExtendee = extendee
+	return flb
+}
+
+func FromField(fld *desc.FieldDescriptor) (*FieldBuilder, error) {
+	if fb, err := FromFile(fld.GetFile()); err != nil {
+		return nil, err
+	} else if flb, ok := fb.findFullyQualifiedElement(fld.GetFullyQualifiedName()).(*FieldBuilder); ok {
+		return flb, nil
+	} else {
+		return nil, fmt.Errorf("could not find field %s after converting file %q to builder", fld.GetFullyQualifiedName(), fld.GetFile().GetName())
+	}
+}
+
+func fromField(fld *desc.FieldDescriptor) (*FieldBuilder, error) {
+	var ft *FieldType
+	switch fld.GetType() {
+	case dpb.FieldDescriptorProto_TYPE_GROUP:
+		ft = &FieldType{fieldType: dpb.FieldDescriptorProto_TYPE_GROUP, foreignMsgType: fld.GetMessageType()}
+	case dpb.FieldDescriptorProto_TYPE_MESSAGE:
+		ft = FieldTypeImportedMessage(fld.GetMessageType())
+	case dpb.FieldDescriptorProto_TYPE_ENUM:
+		ft = FieldTypeImportedEnum(fld.GetEnumType())
+	default:
+		ft = FieldTypeScalar(fld.GetType())
+	}
+	flb := NewField(fld.GetName(), ft)
+	flb.Options = fld.GetFieldOptions()
+	flb.Label = fld.GetLabel()
+	flb.Default = fld.AsFieldDescriptorProto().GetDefaultValue()
+	flb.JsonName = fld.GetJSONName()
+	if fld.IsExtension() {
+		flb.foreignExtendee = fld.GetOwner()
+	}
+	if err := flb.TrySetNumber(fld.GetNumber()); err != nil {
+		return nil, err
+	}
+	return flb, nil
+}
+
+func (flb *FieldBuilder) SetName(newName string) *FieldBuilder {
+	if err := flb.TrySetName(newName); err != nil {
+		panic(err)
+	}
+	return flb
+}
+
+func (flb *FieldBuilder) TrySetName(newName string) error {
+	var oldMsgName string
+	if flb.msgType != nil {
+		if flb.fieldType.fieldType == dpb.FieldDescriptorProto_TYPE_GROUP {
+			return fmt.Errorf("cannot change name of group field %s; change name of group instead", GetFullyQualifiedName(flb))
+		} else {
+			oldMsgName = flb.msgType.name
+			msgName := entryTypeName(newName)
+			if err := flb.msgType.trySetNameInternal(msgName); err != nil {
+				return err
+			}
+		}
+	}
+	if err := flb.baseBuilder.setName(flb, newName); err != nil {
+		// undo change to map entry name
+		if flb.msgType != nil && flb.fieldType.fieldType != dpb.FieldDescriptorProto_TYPE_GROUP {
+			flb.msgType.setNameInternal(oldMsgName)
+		}
+		return err
+	}
+	return nil
+}
+
+func (flb *FieldBuilder) trySetNameInternal(newName string) error {
+	return flb.baseBuilder.setName(flb, newName)
+}
+
+func (flb *FieldBuilder) setNameInternal(newName string) {
+	if err := flb.trySetNameInternal(newName); err != nil {
+		panic(err)
+	}
+}
+
+func (flb *FieldBuilder) setParent(newParent Builder) {
+	flb.baseBuilder.setParent(newParent)
+}
+
+func (flb *FieldBuilder) GetChildren() []Builder {
+	if flb.msgType != nil {
+		return []Builder{flb.msgType}
+	}
+	return nil
+}
+
+func (flb *FieldBuilder) findChild(name string) Builder {
+	if flb.msgType != nil && flb.msgType.name == name {
+		return flb.msgType
+	}
+	return nil
+}
+
+func (flb *FieldBuilder) removeChild(b Builder) {
+	if mb, ok := b.(*MessageBuilder); ok && mb == flb.msgType {
+		flb.msgType = nil
+		if p, ok := flb.parent.(*MessageBuilder); ok {
+			delete(p.symbols, mb.GetName())
+		}
+	}
+}
+
+func (flb *FieldBuilder) renamedChild(b Builder, oldName string) error {
+	if flb.msgType != nil {
+		var oldFieldName string
+		if flb.fieldType.fieldType == dpb.FieldDescriptorProto_TYPE_GROUP {
+			if !unicode.IsUpper(rune(b.GetName()[0])) {
+				return fmt.Errorf("group name %s must start with capital letter", b.GetName())
+			}
+			// change field name to be lower-case form of group name
+			oldFieldName = flb.name
+			fieldName := strings.ToLower(b.GetName())
+			if err := flb.trySetNameInternal(fieldName); err != nil {
+				return err
+			}
+		}
+		if p, ok := flb.parent.(*MessageBuilder); ok {
+			if err := p.addSymbol(b); err != nil {
+				if flb.fieldType.fieldType == dpb.FieldDescriptorProto_TYPE_GROUP {
+					// revert the field rename
+					flb.setNameInternal(oldFieldName)
+				}
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (flb *FieldBuilder) GetNumber() int32 {
+	return flb.number
+}
+
+func (flb *FieldBuilder) SetNumber(tag int32) *FieldBuilder {
+	if err := flb.TrySetNumber(tag); err != nil {
+		panic(err)
+	}
+	return flb
+}
+
+func (flb *FieldBuilder) TrySetNumber(tag int32) error {
+	const (
+		maxTag = 536870911 // 2^29 - 1
+
+		specialReservedStart = 19000
+		specialReservedEnd   = 19999
+	)
+
+	if tag == flb.number {
+		return nil // no change
+	}
+	if tag < 0 {
+		return fmt.Errorf("cannot set tag number for field %s to negative value %d", GetFullyQualifiedName(flb), tag)
+	}
+	if tag == 0 && flb.IsExtension() {
+		return fmt.Errorf("cannot set tag number for extension %s; only regular fields can be auto-assigned", GetFullyQualifiedName(flb))
+	}
+	if tag >= specialReservedStart && tag <= specialReservedEnd {
+		return fmt.Errorf("tag for field %s cannot be in special reserved range %d-%d", GetFullyQualifiedName(flb), specialReservedStart, specialReservedEnd)
+	}
+	if tag > maxTag {
+		return fmt.Errorf("tag for field %s cannot be above max %d", GetFullyQualifiedName(flb), maxTag)
+	}
+	oldTag := flb.number
+	flb.number = tag
+	switch p := flb.parent.(type) {
+	case *OneOfBuilder:
+		m := p.parent()
+		if m != nil {
+			if err := m.addTag(flb); err != nil {
+				flb.number = oldTag
+				return err
+			}
+			delete(m.fieldTags, oldTag)
+		}
+	case *MessageBuilder:
+		if err := p.addTag(flb); err != nil {
+			flb.number = oldTag
+			return err
+		}
+		delete(p.fieldTags, oldTag)
+	}
+	return nil
+}
+
+func (flb *FieldBuilder) SetOptions(options *dpb.FieldOptions) *FieldBuilder {
+	flb.Options = options
+	return flb
+}
+
+func (flb *FieldBuilder) SetLabel(lbl dpb.FieldDescriptorProto_Label) *FieldBuilder {
+	flb.Label = lbl
+	return flb
+}
+
+func (flb *FieldBuilder) SetRepeated() *FieldBuilder {
+	return flb.SetLabel(dpb.FieldDescriptorProto_LABEL_REPEATED)
+}
+
+func (flb *FieldBuilder) SetRequired() *FieldBuilder {
+	return flb.SetLabel(dpb.FieldDescriptorProto_LABEL_REQUIRED)
+}
+
+func (flb *FieldBuilder) SetOptional() *FieldBuilder {
+	return flb.SetLabel(dpb.FieldDescriptorProto_LABEL_OPTIONAL)
+}
+
+func (flb *FieldBuilder) IsRepeated() bool {
+	return flb.Label == dpb.FieldDescriptorProto_LABEL_REPEATED
+}
+
+func (flb *FieldBuilder) IsRequired() bool {
+	return flb.Label == dpb.FieldDescriptorProto_LABEL_REQUIRED
+}
+
+func (flb *FieldBuilder) IsMap() bool {
+	return flb.IsRepeated() &&
+		flb.msgType != nil &&
+		flb.fieldType.fieldType != dpb.FieldDescriptorProto_TYPE_GROUP &&
+		flb.msgType.Options != nil &&
+		flb.msgType.Options.GetMapEntry()
+}
+
+func (flb *FieldBuilder) GetType() *FieldType {
+	return flb.fieldType
+}
+
+func (flb *FieldBuilder) SetType(ft *FieldType) *FieldBuilder {
+	flb.fieldType = ft
+	if flb.msgType != nil && flb.msgType != ft.localMsgType {
+		Unlink(flb.msgType)
+	}
+	return flb
+}
+
+func (flb *FieldBuilder) SetDefaultValue(defValue string) *FieldBuilder {
+	flb.Default = defValue
+	return flb
+}
+
+func (flb *FieldBuilder) SetJsonName(jsonName string) *FieldBuilder {
+	flb.JsonName = jsonName
+	return flb
+}
+
+func (flb *FieldBuilder) IsExtension() bool {
+	return flb.localExtendee != nil || flb.foreignExtendee != nil
+}
+
+func (flb *FieldBuilder) GetExtendeeTypeName() string {
+	if flb.foreignExtendee != nil {
+		return flb.foreignExtendee.GetFullyQualifiedName()
+	} else if flb.localExtendee != nil {
+		return GetFullyQualifiedName(flb.localExtendee)
+	} else {
+		return ""
+	}
+}
+
+func (flb *FieldBuilder) buildProto() (*dpb.FieldDescriptorProto, error) {
+	var lbl *dpb.FieldDescriptorProto_Label
+	if int32(flb.Label) != 0 {
+		lbl = flb.Label.Enum()
+	}
+	var typeName *string
+	tn := flb.fieldType.GetTypeName()
+	if tn != "" {
+		typeName = proto.String("." + tn)
+	}
+	var extendee *string
+	if flb.IsExtension() {
+		extendee = proto.String("." + flb.GetExtendeeTypeName())
+	}
+	jsName := flb.JsonName
+	if jsName == "" {
+		jsName = jsonName(flb.name)
+	}
+	var def *string
+	if flb.Default != "" {
+		def = proto.String(flb.Default)
+	}
+	return &dpb.FieldDescriptorProto{
+		Name:         proto.String(flb.name),
+		Number:       proto.Int32(flb.number),
+		Options:      flb.Options,
+		Label:        lbl,
+		Type:         flb.fieldType.fieldType.Enum(),
+		TypeName:     typeName,
+		JsonName:     proto.String(jsName),
+		DefaultValue: def,
+		Extendee:     extendee,
+	}, nil
+}
+
+func (flb *FieldBuilder) Build() (*desc.FieldDescriptor, error) {
+	d, err := doBuild(flb)
+	if err != nil {
+		return nil, err
+	}
+	return d.(*desc.FieldDescriptor), nil
+}
+
+type OneOfBuilder struct {
+	baseBuilder
+
+	Options *dpb.OneofOptions
+
+	choices []*FieldBuilder
+	symbols map[string]*FieldBuilder
+}
+
+func NewOneOf(name string) *OneOfBuilder {
+	return &OneOfBuilder{
+		baseBuilder: baseBuilderWithName(name),
+		symbols:     map[string]*FieldBuilder{},
+	}
+}
+
+func FromOneOf(ood *desc.OneOfDescriptor) (*OneOfBuilder, error) {
+	if fb, err := FromFile(ood.GetFile()); err != nil {
+		return nil, err
+	} else if oob, ok := fb.findFullyQualifiedElement(ood.GetFullyQualifiedName()).(*OneOfBuilder); ok {
+		return oob, nil
+	} else {
+		return nil, fmt.Errorf("could not find one-of %s after converting file %q to builder", ood.GetFullyQualifiedName(), ood.GetFile().GetName())
+	}
+}
+
+func fromOneOf(ood *desc.OneOfDescriptor) (*OneOfBuilder, error) {
+	oob := NewOneOf(ood.GetName())
+	oob.Options = ood.GetOneOfOptions()
+
+	for _, fld := range ood.GetChoices() {
+		if flb, err := fromField(fld); err != nil {
+			return nil, err
+		} else if err := oob.TryAddChoice(flb); err != nil {
+			return nil, err
+		}
+	}
+
+	return oob, nil
+}
+
+func (oob *OneOfBuilder) SetName(newName string) *OneOfBuilder {
+	if err := oob.TrySetName(newName); err != nil {
+		panic(err)
+	}
+	return oob
+}
+
+func (oob *OneOfBuilder) TrySetName(newName string) error {
+	return oob.baseBuilder.setName(oob, newName)
+}
+
+func (oob *OneOfBuilder) GetChildren() []Builder {
+	var ch []Builder
+	for _, evb := range oob.choices {
+		ch = append(ch, evb)
+	}
+	return ch
+}
+
+func (oob *OneOfBuilder) parent() *MessageBuilder {
+	if oob.baseBuilder.parent == nil {
+		return nil
+	}
+	return oob.baseBuilder.parent.(*MessageBuilder)
+}
+
+func (oob *OneOfBuilder) findChild(name string) Builder {
+	// in terms of finding a child by qualified name, fields in the
+	// one-of are considered children of the message, not the one-of
+	return nil
+}
+
+func (oob *OneOfBuilder) removeChild(b Builder) {
+	if p, ok := b.GetParent().(*OneOfBuilder); !ok || p != oob {
+		return
+	}
+
+	if oob.parent() != nil {
+		// remove from message's name and tag maps
+		flb := b.(*FieldBuilder)
+		delete(oob.parent().fieldTags, flb.GetNumber())
+		delete(oob.parent().symbols, flb.GetName())
+	}
+
+	oob.choices = deleteBuilder(b.GetName(), oob.choices).([]*FieldBuilder)
+	delete(oob.symbols, b.GetName())
+	b.setParent(nil)
+}
+
+func (oob *OneOfBuilder) renamedChild(b Builder, oldName string) error {
+	if p, ok := b.GetParent().(*OneOfBuilder); !ok || p != oob {
+		return nil
+	}
+
+	if err := oob.addSymbol(b.(*FieldBuilder)); err != nil {
+		return err
+	}
+
+	// update message's name map (to make sure new field name doesn't
+	// collide with other kinds of elements in the message)
+	if oob.parent() != nil {
+		if err := oob.parent().addSymbol(b); err != nil {
+			delete(oob.symbols, b.GetName())
+			return err
+		}
+		delete(oob.parent().symbols, oldName)
+	}
+
+	delete(oob.symbols, oldName)
+	return nil
+}
+
+func (oob *OneOfBuilder) addSymbol(b *FieldBuilder) error {
+	if _, ok := oob.symbols[b.GetName()]; ok {
+		return fmt.Errorf("one-of %s already contains field named %q", GetFullyQualifiedName(oob), b.GetName())
+	}
+	oob.symbols[b.GetName()] = b
+	return nil
+}
+
+func (oob *OneOfBuilder) GetChoice(name string) *FieldBuilder {
+	return oob.symbols[name]
+}
+
+func (oob *OneOfBuilder) RemoveChoice(name string) *OneOfBuilder {
+	oob.TryRemoveChoice(name)
+	return oob
+}
+
+func (oob *OneOfBuilder) TryRemoveChoice(name string) bool {
+	if flb, ok := oob.symbols[name]; ok {
+		oob.removeChild(flb)
+		return true
+	}
+	return false
+}
+
+func (oob *OneOfBuilder) AddChoice(flb *FieldBuilder) *OneOfBuilder {
+	if err := oob.TryAddChoice(flb); err != nil {
+		panic(err)
+	}
+	return oob
+}
+
+func (oob *OneOfBuilder) TryAddChoice(flb *FieldBuilder) error {
+	if flb.IsExtension() {
+		return fmt.Errorf("field %s is an extension, not a regular field", flb.GetName())
+	}
+	if flb.msgType != nil {
+		return fmt.Errorf("cannot add a group or map field %q to one-of %s", flb.name, GetFullyQualifiedName(oob))
+	}
+	if flb.IsRepeated() || flb.IsRequired() {
+		return fmt.Errorf("fields in a one-of must be optional, %s is %v", flb.name, flb.Label)
+	}
+	if err := oob.addSymbol(flb); err != nil {
+		return err
+	}
+	mb := oob.parent()
+	if mb != nil {
+		// If we are moving field from a message to a one-of that belongs to the
+		// same message, we have to use different order of operations to prevent
+		// failure (otherwise, it looks like it's being added twice).
+		// (We do similar if moving the other direction, from the one-of into
+		// the message to which one-of belongs.)
+		needToUnlinkFirst := mb.isPresentButNotChild(flb)
+		if needToUnlinkFirst {
+			Unlink(flb)
+			mb.registerField(flb)
+		} else {
+			if err := mb.registerField(flb); err != nil {
+				delete(oob.symbols, flb.GetName())
+				return err
+			}
+			Unlink(flb)
+		}
+	}
+	flb.setParent(oob)
+	oob.choices = append(oob.choices, flb)
+	return nil
+}
+
+func (oob *OneOfBuilder) SetOptions(options *dpb.OneofOptions) *OneOfBuilder {
+	oob.Options = options
+	return oob
+}
+
+func (oob *OneOfBuilder) buildProto() (*dpb.OneofDescriptorProto, error) {
+	for _, flb := range oob.choices {
+		if flb.IsRepeated() || flb.IsRequired() {
+			return nil, fmt.Errorf("fields in a one-of must be optional, %s is %v", GetFullyQualifiedName(flb), flb.Label)
+		}
+	}
+	return &dpb.OneofDescriptorProto{
+		Name:    proto.String(oob.name),
+		Options: oob.Options,
+	}, nil
+}
+
+func (oob *OneOfBuilder) Build() (*desc.OneOfDescriptor, error) {
+	d, err := doBuild(oob)
+	if err != nil {
+		return nil, err
+	}
+	return d.(*desc.OneOfDescriptor), nil
+}
+
+type EnumBuilder struct {
+	baseBuilder
+
+	Options *dpb.EnumOptions
+
+	values  []*EnumValueBuilder
+	symbols map[string]*EnumValueBuilder
+}
+
+func NewEnum(name string) *EnumBuilder {
+	return &EnumBuilder{
+		baseBuilder: baseBuilderWithName(name),
+		symbols:     map[string]*EnumValueBuilder{},
+	}
+}
+
+func FromEnum(ed *desc.EnumDescriptor) (*EnumBuilder, error) {
+	if fb, err := FromFile(ed.GetFile()); err != nil {
+		return nil, err
+	} else if eb, ok := fb.findFullyQualifiedElement(ed.GetFullyQualifiedName()).(*EnumBuilder); ok {
+		return eb, nil
+	} else {
+		return nil, fmt.Errorf("could not find enum %s after converting file %q to builder", ed.GetFullyQualifiedName(), ed.GetFile().GetName())
+	}
+}
+
+func fromEnum(ed *desc.EnumDescriptor, localEnums map[*desc.EnumDescriptor]*EnumBuilder) (*EnumBuilder, error) {
+	eb := NewEnum(ed.GetName())
+	eb.Options = ed.GetEnumOptions()
+
+	localEnums[ed] = eb
+
+	for _, evd := range ed.GetValues() {
+		if evb, err := fromEnumValue(evd); err != nil {
+			return nil, err
+		} else if err := eb.TryAddValue(evb); err != nil {
+			return nil, err
+		}
+	}
+
+	return eb, nil
+}
+
+func (eb *EnumBuilder) SetName(newName string) *EnumBuilder {
+	if err := eb.TrySetName(newName); err != nil {
+		panic(err)
+	}
+	return eb
+}
+
+func (eb *EnumBuilder) TrySetName(newName string) error {
+	return eb.baseBuilder.setName(eb, newName)
+}
+
+func (eb *EnumBuilder) GetChildren() []Builder {
+	var ch []Builder
+	for _, evb := range eb.values {
+		ch = append(ch, evb)
+	}
+	return ch
+}
+
+func (eb *EnumBuilder) findChild(name string) Builder {
+	return eb.symbols[name]
+}
+
+func (eb *EnumBuilder) removeChild(b Builder) {
+	if p, ok := b.GetParent().(*EnumBuilder); !ok || p != eb {
+		return
+	}
+	eb.values = deleteBuilder(b.GetName(), eb.values).([]*EnumValueBuilder)
+	delete(eb.symbols, b.GetName())
+	b.setParent(nil)
+}
+
+func (eb *EnumBuilder) renamedChild(b Builder, oldName string) error {
+	if p, ok := b.GetParent().(*EnumBuilder); !ok || p != eb {
+		return nil
+	}
+
+	if err := eb.addSymbol(b.(*EnumValueBuilder)); err != nil {
+		return err
+	}
+	delete(eb.symbols, oldName)
+	return nil
+}
+
+func (eb *EnumBuilder) addSymbol(b *EnumValueBuilder) error {
+	if _, ok := eb.symbols[b.GetName()]; ok {
+		return fmt.Errorf("enum %s already contains value named %q", GetFullyQualifiedName(eb), b.GetName())
+	}
+	eb.symbols[b.GetName()] = b
+	return nil
+}
+
+func (eb *EnumBuilder) SetOptions(options *dpb.EnumOptions) *EnumBuilder {
+	eb.Options = options
+	return eb
+}
+
+func (eb *EnumBuilder) GetValue(name string) *EnumValueBuilder {
+	return eb.symbols[name]
+}
+
+func (eb *EnumBuilder) RemoveValue(name string) *EnumBuilder {
+	eb.TryRemoveValue(name)
+	return eb
+}
+
+func (eb *EnumBuilder) TryRemoveValue(name string) bool {
+	if evb, ok := eb.symbols[name]; ok {
+		eb.removeChild(evb)
+		return true
+	}
+	return false
+}
+
+func (eb *EnumBuilder) AddValue(evb *EnumValueBuilder) *EnumBuilder {
+	if err := eb.TryAddValue(evb); err != nil {
+		panic(err)
+	}
+	return eb
+}
+
+func (eb *EnumBuilder) TryAddValue(evb *EnumValueBuilder) error {
+	if err := eb.addSymbol(evb); err != nil {
+		return err
+	}
+	Unlink(evb)
+	evb.setParent(eb)
+	eb.values = append(eb.values, evb)
+	return nil
+}
+
+func (eb *EnumBuilder) buildProto() (*dpb.EnumDescriptorProto, error) {
+	var needNumbersAssigned []*dpb.EnumValueDescriptorProto
+	values := make([]*dpb.EnumValueDescriptorProto, 0, len(eb.values))
+	for _, evb := range eb.values {
+		evp, err := evb.buildProto()
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, evp)
+		if !evb.numberSet {
+			needNumbersAssigned = append(needNumbersAssigned, evp)
+		}
+	}
+
+	if len(needNumbersAssigned) > 0 {
+		tags := make([]int, len(values)-len(needNumbersAssigned))
+		for i, ev := range values {
+			tag := ev.GetNumber()
+			if tag != 0 {
+				tags[i] = int(tag)
+			}
+		}
+		sort.Ints(tags)
+		t := 0
+		ti := sort.Search(len(tags), func(i int) bool {
+			return tags[i] >= 0
+		})
+		if ti < len(tags) {
+			tags = tags[ti:]
+		}
+		for len(needNumbersAssigned) > 0 {
+			for len(tags) > 0 && t == tags[0] {
+				t++
+				tags = tags[1:]
+			}
+			needNumbersAssigned[0].Number = proto.Int32(int32(t))
+			needNumbersAssigned = needNumbersAssigned[1:]
+			t++
+		}
+	}
+
+	return &dpb.EnumDescriptorProto{
+		Name:    proto.String(eb.name),
+		Options: eb.Options,
+		Value:   values,
+	}, nil
+}
+
+func (eb *EnumBuilder) Build() (*desc.EnumDescriptor, error) {
+	d, err := doBuild(eb)
+	if err != nil {
+		return nil, err
+	}
+	return d.(*desc.EnumDescriptor), nil
+}
+
+type EnumValueBuilder struct {
+	baseBuilder
+
+	Number    int32
+	numberSet bool
+	Options   *dpb.EnumValueOptions
+}
+
+func NewEnumValue(name string) *EnumValueBuilder {
+	return &EnumValueBuilder{baseBuilder: baseBuilderWithName(name)}
+}
+
+func FromEnumValue(evd *desc.EnumValueDescriptor) (*EnumValueBuilder, error) {
+	if fb, err := FromFile(evd.GetFile()); err != nil {
+		return nil, err
+	} else if evb, ok := fb.findFullyQualifiedElement(evd.GetFullyQualifiedName()).(*EnumValueBuilder); ok {
+		return evb, nil
+	} else {
+		return nil, fmt.Errorf("could not find enum value %s after converting file %q to builder", evd.GetFullyQualifiedName(), evd.GetFile().GetName())
+	}
+}
+
+func fromEnumValue(evd *desc.EnumValueDescriptor) (*EnumValueBuilder, error) {
+	evb := NewEnumValue(evd.GetName())
+	evb.Options = evd.GetEnumValueOptions()
+	evb.Number = evd.GetNumber()
+	evb.numberSet = true
+	return evb, nil
+}
+
+func (evb *EnumValueBuilder) SetName(newName string) *EnumValueBuilder {
+	if err := evb.TrySetName(newName); err != nil {
+		panic(err)
+	}
+	return evb
+}
+
+func (evb *EnumValueBuilder) TrySetName(newName string) error {
+	return evb.baseBuilder.setName(evb, newName)
+}
+
+func (evb *EnumValueBuilder) GetChildren() []Builder {
+	// enum values do not have children
+	return nil
+}
+
+func (evb *EnumValueBuilder) findChild(name string) Builder {
+	// enum values do not have children
+	return nil
+}
+
+func (evb *EnumValueBuilder) removeChild(b Builder) {
+	// enum values do not have children
+}
+
+func (evb *EnumValueBuilder) renamedChild(b Builder, oldName string) error {
+	// enum values do not have children
+	return nil
+}
+
+func (evb *EnumValueBuilder) SetOptions(options *dpb.EnumValueOptions) *EnumValueBuilder {
+	evb.Options = options
+	return evb
+}
+
+func (evb *EnumValueBuilder) SetNumber(number int32) *EnumValueBuilder {
+	evb.Number = number
+	evb.numberSet = true
+	return evb
+}
+
+func (evb *EnumValueBuilder) buildProto() (*dpb.EnumValueDescriptorProto, error) {
+	return &dpb.EnumValueDescriptorProto{
+		Name:    proto.String(evb.name),
+		Number:  proto.Int32(evb.Number),
+		Options: evb.Options,
+	}, nil
+}
+
+func (evb *EnumValueBuilder) Build() (*desc.EnumValueDescriptor, error) {
+	d, err := doBuild(evb)
+	if err != nil {
+		return nil, err
+	}
+	return d.(*desc.EnumValueDescriptor), nil
+}
+
+type ServiceBuilder struct {
+	baseBuilder
+
+	Options *dpb.ServiceOptions
+
+	methods []*MethodBuilder
+	symbols map[string]*MethodBuilder
+}
+
+func NewService(name string) *ServiceBuilder {
+	return &ServiceBuilder{
+		baseBuilder: baseBuilderWithName(name),
+		symbols:     map[string]*MethodBuilder{},
+	}
+}
+
+func FromService(sd *desc.ServiceDescriptor) (*ServiceBuilder, error) {
+	if fb, err := FromFile(sd.GetFile()); err != nil {
+		return nil, err
+	} else if sb, ok := fb.findFullyQualifiedElement(sd.GetFullyQualifiedName()).(*ServiceBuilder); ok {
+		return sb, nil
+	} else {
+		return nil, fmt.Errorf("could not find service %s after converting file %q to builder", sd.GetFullyQualifiedName(), sd.GetFile().GetName())
+	}
+}
+
+func fromService(sd *desc.ServiceDescriptor) (*ServiceBuilder, error) {
+	sb := NewService(sd.GetName())
+	sb.Options = sd.GetServiceOptions()
+
+	for _, mtd := range sd.GetMethods() {
+		if mtb, err := fromMethod(mtd); err != nil {
+			return nil, err
+		} else if err := sb.TryAddMethod(mtb); err != nil {
+			return nil, err
+		}
+	}
+
+	return sb, nil
+}
+
+func (sb *ServiceBuilder) SetName(newName string) *ServiceBuilder {
+	if err := sb.TrySetName(newName); err != nil {
+		panic(err)
+	}
+	return sb
+}
+
+func (sb *ServiceBuilder) TrySetName(newName string) error {
+	return sb.baseBuilder.setName(sb, newName)
+}
+
+func (sb *ServiceBuilder) GetChildren() []Builder {
+	var ch []Builder
+	for _, mtb := range sb.methods {
+		ch = append(ch, mtb)
+	}
+	return ch
+}
+
+func (sb *ServiceBuilder) findChild(name string) Builder {
+	return sb.symbols[name]
+}
+
+func (sb *ServiceBuilder) removeChild(b Builder) {
+	if p, ok := b.GetParent().(*ServiceBuilder); !ok || p != sb {
+		return
+	}
+	sb.methods = deleteBuilder(b.GetName(), sb.methods).([]*MethodBuilder)
+	delete(sb.symbols, b.GetName())
+	b.setParent(nil)
+}
+
+func (sb *ServiceBuilder) renamedChild(b Builder, oldName string) error {
+	if p, ok := b.GetParent().(*ServiceBuilder); !ok || p != sb {
+		return nil
+	}
+
+	if err := sb.addSymbol(b.(*MethodBuilder)); err != nil {
+		return err
+	}
+	delete(sb.symbols, oldName)
+	return nil
+}
+
+func (sb *ServiceBuilder) addSymbol(b *MethodBuilder) error {
+	if _, ok := sb.symbols[b.GetName()]; ok {
+		return fmt.Errorf("service %s already contains method named %q", GetFullyQualifiedName(sb), b.GetName())
+	}
+	sb.symbols[b.GetName()] = b
+	return nil
+}
+
+func (sb *ServiceBuilder) GetMethod(name string) *MethodBuilder {
+	return sb.symbols[name]
+}
+
+func (sb *ServiceBuilder) RemoveMethod(name string) *ServiceBuilder {
+	sb.TryRemoveMethod(name)
+	return sb
+}
+
+func (sb *ServiceBuilder) TryRemoveMethod(name string) bool {
+	if mtb, ok := sb.symbols[name]; ok {
+		sb.removeChild(mtb)
+		return true
+	}
+	return false
+}
+
+func (sb *ServiceBuilder) AddMethod(mtb *MethodBuilder) *ServiceBuilder {
+	if err := sb.TryAddMethod(mtb); err != nil {
+		panic(err)
+	}
+	return sb
+}
+
+func (sb *ServiceBuilder) TryAddMethod(mtb *MethodBuilder) error {
+	if err := sb.addSymbol(mtb); err != nil {
+		return err
+	}
+	Unlink(mtb)
+	mtb.setParent(sb)
+	sb.methods = append(sb.methods, mtb)
+	return nil
+}
+
+func (sb *ServiceBuilder) SetOptions(options *dpb.ServiceOptions) *ServiceBuilder {
+	sb.Options = options
+	return sb
+}
+
+func (sb *ServiceBuilder) buildProto() (*dpb.ServiceDescriptorProto, error) {
+	methods := make([]*dpb.MethodDescriptorProto, 0, len(sb.methods))
+	for _, mtb := range sb.methods {
+		if mtd, err := mtb.buildProto(); err != nil {
+			return nil, err
+		} else {
+			methods = append(methods, mtd)
+		}
+	}
+
+	return &dpb.ServiceDescriptorProto{
+		Name:    proto.String(sb.name),
+		Options: sb.Options,
+		Method:  methods,
+	}, nil
+}
+
+func (sb *ServiceBuilder) Build() (*desc.ServiceDescriptor, error) {
+	d, err := doBuild(sb)
+	if err != nil {
+		return nil, err
+	}
+	return d.(*desc.ServiceDescriptor), nil
+}
+
+type MethodBuilder struct {
+	baseBuilder
+
+	Options  *dpb.MethodOptions
+	ReqType  *RpcType
+	RespType *RpcType
+}
+
+func NewMethod(name string, req, resp *RpcType) *MethodBuilder {
+	return &MethodBuilder{
+		baseBuilder: baseBuilderWithName(name),
+		ReqType:     req,
+		RespType:    resp,
+	}
+}
+
+func FromMethod(mtd *desc.MethodDescriptor) (*MethodBuilder, error) {
+	if fb, err := FromFile(mtd.GetFile()); err != nil {
+		return nil, err
+	} else if mtb, ok := fb.findFullyQualifiedElement(mtd.GetFullyQualifiedName()).(*MethodBuilder); ok {
+		return mtb, nil
+	} else {
+		return nil, fmt.Errorf("could not find method %s after converting file %q to builder", mtd.GetFullyQualifiedName(), mtd.GetFile().GetName())
+	}
+}
+
+func fromMethod(mtd *desc.MethodDescriptor) (*MethodBuilder, error) {
+	req := RpcTypeImportedMessage(mtd.GetInputType(), mtd.IsClientStreaming())
+	resp := RpcTypeImportedMessage(mtd.GetOutputType(), mtd.IsServerStreaming())
+	mtb := NewMethod(mtd.GetName(), req, resp)
+	mtb.Options = mtd.GetMethodOptions()
+	return mtb, nil
+}
+
+func (mtb *MethodBuilder) SetName(newName string) *MethodBuilder {
+	if err := mtb.TrySetName(newName); err != nil {
+		panic(err)
+	}
+	return mtb
+}
+
+func (mtb *MethodBuilder) TrySetName(newName string) error {
+	return mtb.baseBuilder.setName(mtb, newName)
+}
+
+func (mtb *MethodBuilder) GetChildren() []Builder {
+	// methods do not have children
+	return nil
+}
+
+func (mtb *MethodBuilder) findChild(name string) Builder {
+	// methods do not have children
+	return nil
+}
+
+func (mtb *MethodBuilder) removeChild(b Builder) {
+	// methods do not have children
+}
+
+func (mtb *MethodBuilder) renamedChild(b Builder, oldName string) error {
+	// methods do not have children
+	return nil
+}
+
+func (mtb *MethodBuilder) SetOptions(options *dpb.MethodOptions) *MethodBuilder {
+	mtb.Options = options
+	return mtb
+}
+
+func (mtb *MethodBuilder) SetRequestType(t *RpcType) *MethodBuilder {
+	mtb.ReqType = t
+	return mtb
+}
+
+func (mtb *MethodBuilder) SetResponseType(t *RpcType) *MethodBuilder {
+	mtb.RespType = t
+	return mtb
+}
+
+func (mtb *MethodBuilder) buildProto() (*dpb.MethodDescriptorProto, error) {
+	mtd := &dpb.MethodDescriptorProto{
+		Name:       proto.String(mtb.name),
+		Options:    mtb.Options,
+		InputType:  proto.String("." + mtb.ReqType.GetTypeName()),
+		OutputType: proto.String("." + mtb.RespType.GetTypeName()),
+	}
+	if mtb.ReqType.IsStream {
+		mtd.ClientStreaming = proto.Bool(true)
+	}
+	if mtb.RespType.IsStream {
+		mtd.ServerStreaming = proto.Bool(true)
+	}
+	return mtd, nil
+}
+
+func (mtb *MethodBuilder) Build() (*desc.MethodDescriptor, error) {
+	d, err := doBuild(mtb)
+	if err != nil {
+		return nil, err
+	}
+	return d.(*desc.MethodDescriptor), nil
+}
+
+func entryTypeName(fieldName string) string {
+	return initCap(jsonName(fieldName)) + "Entry"
+}
+
+func jsonName(name string) string {
+	var js []rune
+	nextUpper := false
+	for i, r := range name {
+		if r == '_' {
+			nextUpper = true
+			continue
+		}
+		if i == 0 {
+			// start lower-case
+			js = append(js, unicode.ToLower(r))
+		} else if nextUpper {
+			nextUpper = false
+			js = append(js, unicode.ToUpper(r))
+		} else {
+			js = append(js, r)
+		}
+	}
+	return string(js)
+}
+
+func initCap(name string) string {
+	return string(unicode.ToUpper(rune(name[0]))) + name[1:]
+}

--- a/desc/builder/builders_test.go
+++ b/desc/builder/builders_test.go
@@ -1,0 +1,641 @@
+package builder
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/golang/protobuf/ptypes/any"
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/golang/protobuf/ptypes/timestamp"
+
+	"github.com/jhump/protoreflect/desc"
+	_ "github.com/jhump/protoreflect/internal/testprotos"
+	"github.com/jhump/protoreflect/internal/testutil"
+)
+
+func TestSimpleDescriptorsFromScratch(t *testing.T) {
+	md, err := desc.LoadMessageDescriptorForMessage((*empty.Empty)(nil))
+	testutil.Ok(t, err)
+
+	file := NewFile("foo/bar.proto").SetPackageName("foo.bar")
+	en := NewEnum("Options").
+		AddValue(NewEnumValue("OPTION_1")).
+		AddValue(NewEnumValue("OPTION_2")).
+		AddValue(NewEnumValue("OPTION_3"))
+	file.AddEnum(en)
+
+	msg := NewMessage("FooRequest").
+		AddField(NewField("id", FieldTypeInt64())).
+		AddField(NewField("name", FieldTypeString())).
+		AddField(NewField("options", FieldTypeEnum(en)).
+			SetRepeated())
+	file.AddMessage(msg)
+
+	sb := NewService("FooService").
+		AddMethod(NewMethod("DoSomething", RpcTypeMessage(msg, false), RpcTypeMessage(msg, false))).
+		AddMethod(NewMethod("ReturnThings", RpcTypeImportedMessage(md, false), RpcTypeMessage(msg, true)))
+	file.AddService(sb)
+
+	fd, err := file.Build()
+	testutil.Ok(t, err)
+
+	testutil.Eq(t, []*desc.FileDescriptor{md.GetFile()}, fd.GetDependencies())
+	testutil.Require(t, fd.FindEnum("foo.bar.Options") != nil)
+	testutil.Eq(t, 3, len(fd.FindEnum("foo.bar.Options").GetValues()))
+	testutil.Require(t, fd.FindMessage("foo.bar.FooRequest") != nil)
+	testutil.Eq(t, 3, len(fd.FindMessage("foo.bar.FooRequest").GetFields()))
+	testutil.Require(t, fd.FindService("foo.bar.FooService") != nil)
+	testutil.Eq(t, 2, len(fd.FindService("foo.bar.FooService").GetMethods()))
+
+	// building the others produces same results
+	ed, err := en.Build()
+	testutil.Ok(t, err)
+	testutil.Require(t, proto.Equal(ed.AsProto(), fd.FindEnum("foo.bar.Options").AsProto()))
+
+	md, err = msg.Build()
+	testutil.Ok(t, err)
+	testutil.Require(t, proto.Equal(md.AsProto(), fd.FindMessage("foo.bar.FooRequest").AsProto()))
+
+	sd, err := sb.Build()
+	testutil.Ok(t, err)
+	testutil.Require(t, proto.Equal(sd.AsProto(), fd.FindService("foo.bar.FooService").AsProto()))
+}
+
+func TestSimpleDescriptorsFromScratch_SyntheticFiles(t *testing.T) {
+	md, err := desc.LoadMessageDescriptorForMessage((*empty.Empty)(nil))
+	testutil.Ok(t, err)
+
+	en := NewEnum("Options")
+	en.AddValue(NewEnumValue("OPTION_1"))
+	en.AddValue(NewEnumValue("OPTION_2"))
+	en.AddValue(NewEnumValue("OPTION_3"))
+
+	msg := NewMessage("FooRequest")
+	msg.AddField(NewField("id", FieldTypeInt64()))
+	msg.AddField(NewField("name", FieldTypeString()))
+	msg.AddField(NewField("options", FieldTypeEnum(en)).
+		SetRepeated())
+
+	sb := NewService("FooService")
+	sb.AddMethod(NewMethod("DoSomething", RpcTypeMessage(msg, false), RpcTypeMessage(msg, false)))
+	sb.AddMethod(NewMethod("ReturnThings", RpcTypeImportedMessage(md, false), RpcTypeMessage(msg, true)))
+
+	sd, err := sb.Build()
+	testutil.Ok(t, err)
+	testutil.Eq(t, "FooService", sd.GetFullyQualifiedName())
+	testutil.Eq(t, 2, len(sd.GetMethods()))
+
+	// it imports google/protobuf/empty.proto and a synthetic file that has message
+	testutil.Eq(t, 2, len(sd.GetFile().GetDependencies()))
+	fd := sd.GetFile().GetDependencies()[0]
+	testutil.Eq(t, "google/protobuf/empty.proto", fd.GetName())
+	testutil.Eq(t, md.GetFile(), fd)
+	fd = sd.GetFile().GetDependencies()[1]
+	testutil.Require(t, strings.Contains(fd.GetName(), "generated"))
+	testutil.Require(t, fd.FindMessage("FooRequest") != nil)
+	testutil.Eq(t, 3, len(fd.FindMessage("FooRequest").GetFields()))
+
+	// this one imports only a synthetic file that has enum
+	testutil.Eq(t, 1, len(fd.GetDependencies()))
+	fd2 := fd.GetDependencies()[0]
+	testutil.Require(t, fd2.FindEnum("Options") != nil)
+	testutil.Eq(t, 3, len(fd2.FindEnum("Options").GetValues()))
+
+	// building the others produces same results
+	ed, err := en.Build()
+	testutil.Ok(t, err)
+	testutil.Require(t, proto.Equal(ed.AsProto(), fd2.FindEnum("Options").AsProto()))
+
+	md, err = msg.Build()
+	testutil.Ok(t, err)
+	testutil.Require(t, proto.Equal(md.AsProto(), fd.FindMessage("FooRequest").AsProto()))
+}
+
+func TestComplexDescriptorsFromScratch(t *testing.T) {
+	mdEmpty, err := desc.LoadMessageDescriptorForMessage((*empty.Empty)(nil))
+	testutil.Ok(t, err)
+	mdAny, err := desc.LoadMessageDescriptorForMessage((*any.Any)(nil))
+	testutil.Ok(t, err)
+	mdTimestamp, err := desc.LoadMessageDescriptorForMessage((*timestamp.Timestamp)(nil))
+	testutil.Ok(t, err)
+
+	msgA := NewMessage("FooA").
+		AddField(NewField("id", FieldTypeUInt64())).
+		AddField(NewField("when", FieldTypeImportedMessage(mdTimestamp))).
+		AddField(NewField("extras", FieldTypeImportedMessage(mdAny)).
+			SetRepeated()).
+		SetExtensionRanges([]*dpb.DescriptorProto_ExtensionRange{{Start: proto.Int32(100), End: proto.Int32(201)}})
+	msgA2 := NewMessage("Nnn").
+		AddField(NewField("uid1", FieldTypeFixed64())).
+		AddField(NewField("uid2", FieldTypeFixed64()))
+	NewFile("").
+		SetPackageName("foo.bar").
+		AddMessage(msgA).
+		AddMessage(msgA2)
+
+	msgB := NewMessage("FooB").
+		AddField(NewField("foo_a", FieldTypeMessage(msgA)).
+			SetRepeated()).
+		AddField(NewField("name", FieldTypeString()))
+	NewFile("").
+		SetPackageName("foo.bar").
+		AddMessage(msgB)
+
+	enC := NewEnum("Vals").
+		AddValue(NewEnumValue("DEFAULT")).
+		AddValue(NewEnumValue("VALUE_A")).
+		AddValue(NewEnumValue("VALUE_B")).
+		AddValue(NewEnumValue("VALUE_C"))
+	msgC := NewMessage("BarBaz").
+		AddOneOf(NewOneOf("bbb").
+			AddChoice(NewField("b1", FieldTypeMessage(msgA))).
+			AddChoice(NewField("b2", FieldTypeMessage(msgB)))).
+		AddField(NewField("v", FieldTypeEnum(enC)))
+	NewFile("some/path/file.proto").
+		SetPackageName("foo.baz").
+		AddEnum(enC).
+		AddMessage(msgC)
+
+	enD := NewEnum("Ppp").
+		AddValue(NewEnumValue("P0")).
+		AddValue(NewEnumValue("P1")).
+		AddValue(NewEnumValue("P2")).
+		AddValue(NewEnumValue("P3"))
+	exD := NewExtension("ppp", 123, FieldTypeEnum(enD), msgA)
+	NewFile("some/other/path/file.proto").
+		SetPackageName("foo.biz").
+		AddEnum(enD).
+		AddExtension(exD)
+
+	msgE := NewMessage("Ppp").
+		AddField(NewField("p", FieldTypeEnum(enD))).
+		AddField(NewField("n", FieldTypeMessage(msgA2)))
+	fd, err := NewFile("").
+		SetPackageName("foo.bar").
+		AddMessage(msgE).
+		AddService(NewService("PppSvc").
+			AddMethod(NewMethod("Method1", RpcTypeMessage(msgE, false), RpcTypeImportedMessage(mdEmpty, false))).
+			AddMethod(NewMethod("Method2", RpcTypeMessage(msgB, false), RpcTypeMessage(msgC, true)))).
+		Build()
+
+	testutil.Ok(t, err)
+
+	testutil.Eq(t, 5, len(fd.GetDependencies()))
+	// dependencies sorted; those with generated names come last
+	depEmpty := fd.GetDependencies()[0]
+	testutil.Eq(t, "google/protobuf/empty.proto", depEmpty.GetName())
+	testutil.Eq(t, mdEmpty.GetFile(), depEmpty)
+	depD := fd.GetDependencies()[1]
+	testutil.Eq(t, "some/other/path/file.proto", depD.GetName())
+	depC := fd.GetDependencies()[2]
+	testutil.Eq(t, "some/path/file.proto", depC.GetName())
+	depA := fd.GetDependencies()[3]
+	testutil.Require(t, strings.Contains(depA.GetName(), "generated"))
+	depB := fd.GetDependencies()[4]
+	testutil.Require(t, strings.Contains(depB.GetName(), "generated"))
+
+	// check contents of files
+	testutil.Require(t, depA.FindMessage("foo.bar.FooA") != nil)
+	testutil.Eq(t, 3, len(depA.FindMessage("foo.bar.FooA").GetFields()))
+	testutil.Require(t, depA.FindMessage("foo.bar.Nnn") != nil)
+	testutil.Eq(t, 2, len(depA.FindMessage("foo.bar.Nnn").GetFields()))
+
+	testutil.Require(t, depB.FindMessage("foo.bar.FooB") != nil)
+	testutil.Eq(t, 2, len(depB.FindMessage("foo.bar.FooB").GetFields()))
+
+	testutil.Require(t, depC.FindMessage("foo.baz.BarBaz") != nil)
+	testutil.Eq(t, 3, len(depC.FindMessage("foo.baz.BarBaz").GetFields()))
+	testutil.Require(t, depC.FindEnum("foo.baz.Vals") != nil)
+	testutil.Eq(t, 4, len(depC.FindEnum("foo.baz.Vals").GetValues()))
+
+	testutil.Require(t, depD.FindEnum("foo.biz.Ppp") != nil)
+	testutil.Eq(t, 4, len(depD.FindEnum("foo.biz.Ppp").GetValues()))
+	testutil.Require(t, depD.FindExtensionByName("foo.biz.ppp") != nil)
+
+	testutil.Require(t, fd.FindMessage("foo.bar.Ppp") != nil)
+	testutil.Eq(t, 2, len(fd.FindMessage("foo.bar.Ppp").GetFields()))
+	testutil.Require(t, fd.FindService("foo.bar.PppSvc") != nil)
+	testutil.Eq(t, 2, len(fd.FindService("foo.bar.PppSvc").GetMethods()))
+}
+
+func TestCreatingGroupField(t *testing.T) {
+	grpMb := NewMessage("GroupA").
+		AddField(NewField("name", FieldTypeString())).
+		AddField(NewField("id", FieldTypeInt64()))
+	grpFlb := NewGroupField(grpMb)
+
+	mb := NewMessage("TestMessage").
+		AddField(NewField("foo", FieldTypeBool())).
+		AddField(grpFlb)
+	md, err := mb.Build()
+	testutil.Ok(t, err)
+
+	testutil.Require(t, md.FindFieldByName("groupa") != nil)
+	testutil.Eq(t, dpb.FieldDescriptorProto_TYPE_GROUP, md.FindFieldByName("groupa").GetType())
+	nmd := md.GetNestedMessageTypes()[0]
+	testutil.Eq(t, "GroupA", nmd.GetName())
+	testutil.Eq(t, nmd, md.FindFieldByName("groupa").GetMessageType())
+
+	// try a rename that will fail
+	err = grpMb.TrySetName("fooBarBaz")
+	testutil.Require(t, err != nil)
+	testutil.Eq(t, "group name fooBarBaz must start with capital letter", err.Error())
+	// failed rename should not have modified any state
+	md2, err := mb.Build()
+	testutil.Ok(t, err)
+	testutil.Require(t, proto.Equal(md.AsProto(), md2.AsProto()))
+	// another attempt that will fail
+	err = grpFlb.TrySetName("foobarbaz")
+	testutil.Require(t, err != nil)
+	testutil.Eq(t, "cannot change name of group field TestMessage.groupa; change name of group instead", err.Error())
+	// again, no state should have been modified
+	md2, err = mb.Build()
+	testutil.Ok(t, err)
+	testutil.Require(t, proto.Equal(md.AsProto(), md2.AsProto()))
+
+	// and a rename that succeeds
+	err = grpMb.TrySetName("FooBarBaz")
+	testutil.Ok(t, err)
+	md, err = mb.Build()
+	testutil.Ok(t, err)
+
+	// field also renamed
+	testutil.Require(t, md.FindFieldByName("foobarbaz") != nil)
+	testutil.Eq(t, dpb.FieldDescriptorProto_TYPE_GROUP, md.FindFieldByName("foobarbaz").GetType())
+	nmd = md.GetNestedMessageTypes()[0]
+	testutil.Eq(t, "FooBarBaz", nmd.GetName())
+	testutil.Eq(t, nmd, md.FindFieldByName("foobarbaz").GetMessageType())
+}
+
+func TestCreatingMapField(t *testing.T) {
+	mapFlb := NewMapField("countsByName", FieldTypeString(), FieldTypeUInt64())
+	testutil.Require(t, mapFlb.IsMap())
+
+	mb := NewMessage("TestMessage").
+		AddField(NewField("foo", FieldTypeBool())).
+		AddField(mapFlb)
+	md, err := mb.Build()
+	testutil.Ok(t, err)
+
+	testutil.Require(t, md.FindFieldByName("countsByName") != nil)
+	testutil.Require(t, md.FindFieldByName("countsByName").IsMap())
+	nmd := md.GetNestedMessageTypes()[0]
+	testutil.Eq(t, "CountsByNameEntry", nmd.GetName())
+	testutil.Eq(t, nmd, md.FindFieldByName("countsByName").GetMessageType())
+
+	// try a rename that will fail
+	err = mapFlb.GetType().localMsgType.TrySetName("fooBarBaz")
+	testutil.Require(t, err != nil)
+	testutil.Eq(t, "cannot change name of map entry TestMessage.CountsByNameEntry; change name of field instead", err.Error())
+	// failed rename should not have modified any state
+	md2, err := mb.Build()
+	testutil.Ok(t, err)
+	testutil.Require(t, proto.Equal(md.AsProto(), md2.AsProto()))
+
+	// and a rename that succeeds
+	err = mapFlb.TrySetName("fooBarBaz")
+	testutil.Ok(t, err)
+	md, err = mb.Build()
+	testutil.Ok(t, err)
+
+	// map entry also renamed
+	testutil.Require(t, md.FindFieldByName("fooBarBaz") != nil)
+	testutil.Require(t, md.FindFieldByName("fooBarBaz").IsMap())
+	nmd = md.GetNestedMessageTypes()[0]
+	testutil.Eq(t, "FooBarBazEntry", nmd.GetName())
+	testutil.Eq(t, nmd, md.FindFieldByName("fooBarBaz").GetMessageType())
+}
+
+func TestBuildersFromDescriptors(t *testing.T) {
+	for _, s := range []string{"desc_test1.proto", "desc_test2.proto", "desc_test_defaults.proto", "desc_test_options.proto", "desc_test_proto3.proto", "desc_test_wellknowntypes.proto", "nopkg/desc_test_nopkg.proto", "nopkg/desc_test_nopkg_new.proto", "pkg/desc_test_pkg.proto"} {
+		fd, err := desc.LoadFileDescriptor(s)
+		testutil.Ok(t, err)
+		roundTripFile(t, fd)
+	}
+}
+
+func roundTripFile(t *testing.T, fd *desc.FileDescriptor) {
+	// First, recursively verify that every child element can be converted to a
+	// Builder and back without loss of fidelity.
+	for _, md := range fd.GetMessageTypes() {
+		roundTripMessage(t, md)
+	}
+	for _, ed := range fd.GetEnumTypes() {
+		roundTripEnum(t, ed)
+	}
+	for _, exd := range fd.GetExtensions() {
+		roundTripField(t, exd)
+	}
+	for _, sd := range fd.GetServices() {
+		roundTripService(t, sd)
+	}
+
+	// Finally, we check the whole file itself.
+	fb, err := FromFile(fd)
+	testutil.Ok(t, err)
+
+	roundTripped, err := fb.Build()
+	testutil.Ok(t, err)
+
+	// Round tripping from a file descriptor to a builder and back will
+	// experience some minor changes (that do not impact the semantics of
+	// any of the file's contents):
+	//  1. The builder sorts dependencies. However the original file
+	//     descriptor has dependencies in the order they appear in import
+	//     statements in the source file.
+	//  2. The builder imports the actual source of all elements and never
+	//     uses public imports. The original file, on the other hand, could
+	//     used public imports and "indirectly" import other files that way.
+	//  3. The builder never emits weak imports.
+	// So we're going to modify the original descriptor in the same ways.
+	// That way, a simple proto.Equal() check will suffice to confirm that
+	// the file descriptor survived the round trip.
+
+	// The files we are testing have one occurrence of a public import. The
+	// file nopkg/desc_test_nopkg.proto declares nothing and public imports
+	// nopkg/desc_test_nopkg_new.proto. So any file that depends on the
+	// former will be updated to instead depend on the latter (since it is
+	// the actual file that declares used elements).
+	fdp := fd.AsFileDescriptorProto()
+	for i, dep := range fdp.Dependency {
+		if dep == "nopkg/desc_test_nopkg.proto" {
+			fdp.Dependency[i] = "nopkg/desc_test_nopkg_new.proto"
+		}
+		if dep == "nopkg/desc_test_nopkg_new.proto" && fdp.GetName() == "nopkg/desc_test_nopkg.proto" {
+			// The file nopkg/desc_test_nopkg.proto actually declares nothing
+			// and *only* has the public import. So the round-tripped version
+			// will have no imports (it declares nothing so it depends on
+			// nothing).
+			fdp.Dependency = append(fdp.Dependency[:i], fdp.Dependency[i+1:]...)
+		}
+	}
+
+	// Strip any public and weak imports. (The step above should have "fixed"
+	// files to handle any actual public import encountered.)
+	fdp.PublicDependency = nil
+	fdp.WeakDependency = nil
+
+	// Finally, sort the imports. That way they match the built result (which
+	// is always sorted).
+	sort.Strings(fdp.Dependency)
+
+	// Now the (now tweaked) original should match the round-tripped descriptor!
+	testutil.Require(t, proto.Equal(fdp, roundTripped.AsProto()), "File %q failed round trip.\nExpecting: %s\nGot: %s\n",
+		fd.GetName(), proto.MarshalTextString(fdp), proto.MarshalTextString(roundTripped.AsProto()))
+}
+
+func roundTripMessage(t *testing.T, md *desc.MessageDescriptor) {
+	// first recursively validate all nested elements
+	for _, fld := range md.GetFields() {
+		roundTripField(t, fld)
+	}
+	for _, ood := range md.GetOneOfs() {
+		oob, err := FromOneOf(ood)
+		testutil.Ok(t, err)
+		roundTripped, err := oob.Build()
+		testutil.Ok(t, err)
+		checkDescriptors(t, ood, roundTripped)
+	}
+	for _, nmd := range md.GetNestedMessageTypes() {
+		roundTripMessage(t, nmd)
+	}
+	for _, ed := range md.GetNestedEnumTypes() {
+		roundTripEnum(t, ed)
+	}
+	for _, exd := range md.GetNestedExtensions() {
+		roundTripField(t, exd)
+	}
+
+	mb, err := FromMessage(md)
+	testutil.Ok(t, err)
+	roundTripped, err := mb.Build()
+	testutil.Ok(t, err)
+	checkDescriptors(t, md, roundTripped)
+}
+
+func roundTripEnum(t *testing.T, ed *desc.EnumDescriptor) {
+	// first recursively validate all nested elements
+	for _, evd := range ed.GetValues() {
+		evb, err := FromEnumValue(evd)
+		testutil.Ok(t, err)
+		roundTripped, err := evb.Build()
+		testutil.Ok(t, err)
+		checkDescriptors(t, evd, roundTripped)
+	}
+
+	eb, err := FromEnum(ed)
+	testutil.Ok(t, err)
+	roundTripped, err := eb.Build()
+	testutil.Ok(t, err)
+	checkDescriptors(t, ed, roundTripped)
+}
+
+func roundTripField(t *testing.T, fld *desc.FieldDescriptor) {
+	flb, err := FromField(fld)
+	testutil.Ok(t, err)
+	roundTripped, err := flb.Build()
+	testutil.Ok(t, err)
+	checkDescriptors(t, fld, roundTripped)
+}
+
+func roundTripService(t *testing.T, sd *desc.ServiceDescriptor) {
+	// first recursively validate all nested elements
+	for _, mtd := range sd.GetMethods() {
+		mtb, err := FromMethod(mtd)
+		testutil.Ok(t, err)
+		roundTripped, err := mtb.Build()
+		testutil.Ok(t, err)
+		checkDescriptors(t, mtd, roundTripped)
+	}
+
+	sb, err := FromService(sd)
+	testutil.Ok(t, err)
+	roundTripped, err := sb.Build()
+	testutil.Ok(t, err)
+	checkDescriptors(t, sd, roundTripped)
+}
+
+func checkDescriptors(t *testing.T, d1, d2 desc.Descriptor) {
+	testutil.Eq(t, d1.GetFullyQualifiedName(), d2.GetFullyQualifiedName())
+	testutil.Require(t, proto.Equal(d1.AsProto(), d2.AsProto()), "%s failed round trip.\nExpecting: %s\nGot: %s\n",
+		d1.GetFullyQualifiedName(), proto.MarshalTextString(d1.AsProto()), proto.MarshalTextString(d2.AsProto()))
+}
+
+func TestAddBuilders(t *testing.T) {
+	// add field to one-of
+	fld1 := NewField("foo", FieldTypeInt32())
+	oo1 := NewOneOf("oofoo")
+	oo1.AddChoice(fld1)
+	checkChildren(t, oo1, fld1)
+	testutil.Eq(t, oo1.GetChoice("foo"), fld1)
+
+	// add one-of w/ field to a message
+	msg1 := NewMessage("foo")
+	msg1.AddOneOf(oo1)
+	checkChildren(t, msg1, oo1)
+	testutil.Eq(t, msg1.GetOneOf("oofoo"), oo1)
+	// field remains unchanged
+	testutil.Eq(t, fld1.GetParent(), oo1)
+	testutil.Eq(t, oo1.GetChoice("foo"), fld1)
+	// field also now registered with msg1
+	testutil.Eq(t, msg1.GetField("foo"), fld1)
+
+	// add empty one-of to message
+	oo2 := NewOneOf("oobar")
+	msg1.AddOneOf(oo2)
+	checkChildren(t, msg1, oo1, oo2)
+	testutil.Eq(t, msg1.GetOneOf("oobar"), oo2)
+	// now add field to that one-of
+	fld2 := NewField("bar", FieldTypeInt32())
+	oo2.AddChoice(fld2)
+	checkChildren(t, oo2, fld2)
+	testutil.Eq(t, oo2.GetChoice("bar"), fld2)
+	// field also now registered with msg1
+	testutil.Eq(t, msg1.GetField("bar"), fld2)
+
+	// add fails due to name collisions
+	fld1 = NewField("foo", FieldTypeInt32())
+	err := oo1.TryAddChoice(fld1)
+	checkFailedAdd(t, err, oo1, fld1, "already contains field")
+	fld2 = NewField("bar", FieldTypeInt32())
+	err = msg1.TryAddField(fld2)
+	checkFailedAdd(t, err, msg1, fld2, "already contains element")
+	msg2 := NewMessage("oofoo")
+	// name collision can be different type
+	// (here, nested message conflicts with a one-of)
+	err = msg1.TryAddNestedMessage(msg2)
+	checkFailedAdd(t, err, msg1, msg2, "already contains element")
+
+	msg2 = NewMessage("baz")
+	msg1.AddNestedMessage(msg2)
+	checkChildren(t, msg1, oo1, oo2, msg2)
+	testutil.Eq(t, msg1.GetNestedMessage("baz"), msg2)
+
+	// can't add extension, group, or map fields to one-of
+	ext1 := NewExtension("abc", 123, FieldTypeInt32(), msg1)
+	err = oo1.TryAddChoice(ext1)
+	checkFailedAdd(t, err, oo1, ext1, "is an extension, not a regular field")
+	err = msg1.TryAddField(ext1)
+	checkFailedAdd(t, err, msg1, ext1, "is an extension, not a regular field")
+	mapField := NewMapField("abc", FieldTypeInt32(), FieldTypeString())
+	err = oo1.TryAddChoice(mapField)
+	checkFailedAdd(t, err, oo1, mapField, "cannot add a group or map field")
+	groupMsg := NewMessage("Group")
+	groupField := NewGroupField(groupMsg)
+	err = oo1.TryAddChoice(groupField)
+	checkFailedAdd(t, err, oo1, groupField, "cannot add a group or map field")
+	// adding map and group to msg succeeds
+	msg1.AddField(groupField)
+	msg1.AddField(mapField)
+	checkChildren(t, msg1, oo1, oo2, msg2, groupField, mapField)
+	// messages associated with map and group fields are not children of the
+	// message, but are in its scope and accessible via GetNestedMessage
+	testutil.Eq(t, msg1.GetNestedMessage("Group"), groupMsg)
+	testutil.Eq(t, msg1.GetNestedMessage("AbcEntry"), mapField.GetType().localMsgType)
+
+	// adding extension to message
+	ext2 := NewExtension("xyz", 234, FieldTypeInt32(), msg1)
+	msg1.AddNestedExtension(ext2)
+	checkChildren(t, msg1, oo1, oo2, msg2, groupField, mapField, ext2)
+	err = msg1.TryAddNestedExtension(ext1) // name collision
+	checkFailedAdd(t, err, msg1, ext1, "already contains element")
+	fld3 := NewField("ijk", FieldTypeString())
+	err = msg1.TryAddNestedExtension(fld3)
+	checkFailedAdd(t, err, msg1, fld3, "is not an extension")
+
+	// add enum values to enum
+	enumVal1 := NewEnumValue("A")
+	enum1 := NewEnum("bazel")
+	enum1.AddValue(enumVal1)
+	checkChildren(t, enum1, enumVal1)
+	testutil.Eq(t, enum1.GetValue("A"), enumVal1)
+	enumVal2 := NewEnumValue("B")
+	enum1.AddValue(enumVal2)
+	checkChildren(t, enum1, enumVal1, enumVal2)
+	testutil.Eq(t, enum1.GetValue("B"), enumVal2)
+	// fail w/ name collision
+	enumVal3 := NewEnumValue("B")
+	err = enum1.TryAddValue(enumVal3)
+	checkFailedAdd(t, err, enum1, enumVal3, "already contains value")
+
+	msg2.AddNestedEnum(enum1)
+	checkChildren(t, msg2, enum1)
+	testutil.Eq(t, msg2.GetNestedEnum("bazel"), enum1)
+	ext3 := NewExtension("bazel", 987, FieldTypeString(), msg2)
+	err = msg2.TryAddNestedExtension(ext3)
+	checkFailedAdd(t, err, msg2, ext3, "already contains element")
+
+	// services and methods
+	mtd1 := NewMethod("foo", RpcTypeMessage(msg1, false), RpcTypeMessage(msg1, false))
+	svc1 := NewService("FooService")
+	svc1.AddMethod(mtd1)
+	checkChildren(t, svc1, mtd1)
+	testutil.Eq(t, svc1.GetMethod("foo"), mtd1)
+	mtd2 := NewMethod("foo", RpcTypeMessage(msg1, false), RpcTypeMessage(msg1, false))
+	err = svc1.TryAddMethod(mtd2)
+	checkFailedAdd(t, err, svc1, mtd2, "already contains method")
+
+	// finally, test adding things to  a file
+	fb := NewFile("")
+	fb.AddMessage(msg1)
+	checkChildren(t, fb, msg1)
+	testutil.Eq(t, fb.GetMessage("foo"), msg1)
+	fb.AddService(svc1)
+	checkChildren(t, fb, msg1, svc1)
+	testutil.Eq(t, fb.GetService("FooService"), svc1)
+	enum2 := NewEnum("fizzle")
+	fb.AddEnum(enum2)
+	checkChildren(t, fb, msg1, svc1, enum2)
+	testutil.Eq(t, fb.GetEnum("fizzle"), enum2)
+	ext3 = NewExtension("foosball", 123, FieldTypeInt32(), msg1)
+	fb.AddExtension(ext3)
+	checkChildren(t, fb, msg1, svc1, enum2, ext3)
+	testutil.Eq(t, fb.GetExtension("foosball"), ext3)
+
+	// errors and name collisions
+	err = fb.TryAddExtension(fld3)
+	checkFailedAdd(t, err, fb, fld3, "is not an extension")
+	msg3 := NewMessage("fizzle")
+	err = fb.TryAddMessage(msg3)
+	checkFailedAdd(t, err, fb, msg3, "already contains element")
+	enum3 := NewEnum("foosball")
+	err = fb.TryAddEnum(enum3)
+	checkFailedAdd(t, err, fb, enum3, "already contains element")
+}
+
+func checkChildren(t *testing.T, parent Builder, children ...Builder) {
+	testutil.Eq(t, len(children), len(parent.GetChildren()), "Wrong number of children for %s (%T)", GetFullyQualifiedName(parent), parent)
+	ch := map[Builder]struct{}{}
+	for _, child := range children {
+		testutil.Eq(t, child.GetParent(), parent, "Child %s (%T) does not report %s (%T) as its parent", child.GetName(), child, GetFullyQualifiedName(parent), parent)
+		ch[child] = struct{}{}
+	}
+	for _, child := range parent.GetChildren() {
+		_, ok := ch[child]
+		testutil.Require(t, ok, "Child %s (%T) does appear in list of children for %s (%T)", child.GetName(), child, GetFullyQualifiedName(parent), parent)
+	}
+}
+
+func checkFailedAdd(t *testing.T, err error, parent Builder, child Builder, errorMsg string) {
+	testutil.Require(t, err != nil, "Expecting error assigning %s (%T) to %s (%T)", child.GetName(), child, GetFullyQualifiedName(parent), parent)
+	testutil.Require(t, strings.Contains(err.Error(), errorMsg), "Expecting error assigning %s (%T) to %s (%T) to contain text %q: %q", child.GetName(), child, GetFullyQualifiedName(parent), parent, errorMsg, err.Error())
+	testutil.Eq(t, nil, child.GetParent(), "Child %s (%T) should not have a parent after failed add", child.GetName(), child)
+	for _, ch := range parent.GetChildren() {
+		testutil.Require(t, ch != child, "Child %s (%T) should not appear in list of children for %s (%T) but does", child.GetName(), child, GetFullyQualifiedName(parent), parent)
+	}
+}
+
+func TestMovingBuilders(t *testing.T) {
+	// TODO
+}
+
+func TestRenamingBuilders(t *testing.T) {
+	// TODO
+}
+
+func TestRenumberingFields(t *testing.T) {
+	// TODO
+}

--- a/desc/builder/doc.go
+++ b/desc/builder/doc.go
@@ -1,0 +1,193 @@
+// Package builder contains a means of building and modifying proto descriptors
+// programmatically. There are numerous factory methods to aid in constructing
+// new descriptors as are there methods for converting existing descriptors into
+// builders, for modification.
+//
+//
+// Factory Functions
+//
+// Builders are created using the numerous factory functions. Each type of
+// descriptor has two kinds of factory functions for the corresponding type of
+// builder.
+//
+// One accepts a descriptor (From*) and returns a copy of it as a builder. The
+// descriptor can be manipulated and built to produce a new variant of the
+// original. So this is useful for changing existing constructs.
+//
+// The other kind of factory function (New*) accepts basic arguments and returns
+// a new, empty builder (other than the arguments required by that function).
+// This second kind can be used to fabricate descriptors from scratch.
+//
+// Factory functions panic on bad input. Bad input includes invalid names (all
+// identifiers must begin with letter or underscore and include only letters,
+// numbers, and underscores), invalid types (for example, map field keys must be
+// an integer type, bool, or string), invalid tag numbers (anything greater than
+// 2^29-1, anything in the range 19,000->19,999, any non-positive number), and
+// nil values for required fields (such as field types, RPC method types, and
+// extendee type for extensions).
+//
+//
+// Auto-Assigning Tag Numbers and File Names
+//
+// The factory function for fields does not accept a tag number. This is because
+// tags, for fields where none is set or is explicitly set to zero, are
+// automatically assigned. The tags are assigned in the order the fields were
+// added to a message builder. Fields in one-ofs are assigned after other fields
+// that were added to the message before the one-of. Within a single one-of,
+// fields are assigned tags in the order they were added to the one-of. Across
+// one-ofs, fields are assigned in the order their one-of was added to a message
+// builder. It is fine if some fields have tags and some do not. The assigned
+// tags will start at one and proceed from there but will not conflict with tags
+// that were explicitly assigned to fields.
+//
+// Similarly, when constructing a file builder, a name is accepted but can be
+// blank. A blank name means that the file will be given a generated, unique
+// name when the descriptor is built.
+//
+// Note that extensions *must* be given a tag number. Only non-extension fields
+// can have their tags auto-assigned. If an extension is constructed with a zero
+// tag (which is not valid), the factory function will panic.
+//
+//
+// Descriptor Hierarchy
+//
+// The hierarchy for builders is mutable. A descriptor builder, such as a field,
+// can be moved from one message to another. When this is done, the field is
+// unlinked from its previous location (so the message to which it previously
+// belonged will no longer have any reference to such a field) and linked with
+// its new parent. To instead *duplicate* a descriptor builder, its struct value
+// can simply be copied. This allows for copying a descriptor from one parent to
+// another, like so:
+//
+//    msg := builder.FromMessage(someMsgDesc)
+//    field1 := msg.GetField("foo")
+//    field2 := *field1 // field2 is now a copy
+//    otherMsg.AddField(&field2)
+//
+// All descriptors have a link up the hierarchy to the file in which they were
+// declared. However, it is *not* necessary to construct this full hierarchy
+// with builders. One can create a message builder, for example, and then
+// immediately build it to get the descriptor for that message. If it was never
+// added to a file then the GetFile() method on the resulting descriptor returns
+// a synthetic file that contains only the one message.
+//
+// Note, however, that this is not true for enum values, methods, and
+// non-extension fields. These kinds of builders *must* be added to an enum, a
+// service, or a message (respectively) before they can be "built" into a
+// descriptor.
+//
+// When descriptors are created this way, they are created in the default (e.g.
+// unnamed) package. In order to put descriptors into a proper package
+// namespace, they must be added to a file that has the right package name.
+//
+//
+// Builder Pattern, Method Chaining
+//
+// Each descriptor has some special fields that can only be updated via a Set*
+// method. They also all have some exported fields that can be updated by just
+// assigning to the field. But even exported fields have accompanying Set*
+// methods in order to support a typical method-chaining flow when building
+// objects:
+//
+//    msg, err := builder.NewMessage("MyMessage").
+//        AddField(NewField("foo", FieldTypeScalar(descriptor.FieldDescriptorProto_TYPE_STRING)).
+//            SetDefaultValue("bar")).
+//        AddField(NewField("baz", FieldTypeScalar(descriptor.FieldDescriptorProto_TYPE_INT64)).
+//            SetLabel(descriptor.FieldDescriptorProto_LABEL_REPEATED).
+//            SetOptions(&descriptor.FieldOptions{Packed: proto.Bool(true)})).
+//        Build()
+//
+// So the various Set* methods all return the builder itself so that multiple
+// fields may be set in a single invocation chain.
+//
+// The Set* operations which perform validations also have a TrySet* form which
+// can return an error if validation fails. If the method-chaining Set* form is
+// used with inputs that fail validation, the Set* method will panic.
+//
+//
+// Type References and "Imported Types"
+//
+// When defining fields whose type is a message or enum and when defining
+// methods (whose request and response type are a message), the type can be set
+// to an actual descriptor (e.g. a *desc.MessageDescriptor) or to a builder for
+// the type (e.g. a *builder.MessageBuilder). Since Go does not allow method
+// overloading, the naming convention is that types referring to descriptors are
+// "imported types" (since their use will result in an import statement in the
+// resulting file descriptor, to import the file in which the type was defined.)
+//
+// When referring to other builders, it is not necessary that the referenced
+// types be in the same file. When building the descriptors, multiple file
+// descriptors may be created, so that all referenced builders are themselves
+// resolved into descriptors.
+//
+// However, it is illegal to create an import cycle. So if two messages, for
+// example, refer to each other (message Foo has a field "bar" of type Bar, and
+// message Bar has a field "foo" of type Foo), they must explicitly be assigned
+// to the same file builder. If they are not assigned to any files, they will be
+// assigned to synthetic files which would result in an import cycle (each file
+// imports the other). And the same would be true if one or both files were
+// explicitly assigned to a file, but not both to the same file.
+//
+//
+// Validations, Caveats
+//
+// Descriptors that are attained from a builder do not necessarily represent a
+// valid construct in the proto source language. There are some validations
+// enforced by protoc that are not enforced by builders, for example, ensuring
+// that there are no namespace conflicts (e.g. file "foo.proto" declares an
+// element named "pkg.bar" and so does a file that it imports). Because of this,
+// it is possible for builders to wire up references in a way that the resulting
+// descriptors are incorrect. This is mainly possible when file builders are
+// used to create files with duplicate symbols and then cross-linked. It can
+// also happen when a builder is linked to descriptors from more than one
+// version of the same file.
+//
+// When constructing descriptors using builders, applications should not attempt
+// to build invalid constructs. Even though there are many rules in the protobuf
+// language that are not enforced, those rules that are enforced can result in
+// panics when a violation is detected. Generally, builder methods that do not
+// return errors (like those used for method chaining) will panic on bad input
+// or when trying to mutate a proto into an invalid state.
+//
+// Several rules are enforced by the builders. Violating these rules will result
+// in errors (or panics for factory functions and methods that do not return
+// errors). These are the rules that are currently enforced:
+//
+//   1. Import cycles are not allowed. (See above for more details.)
+//   2. Within a single file, symbols are not allowed to have naming conflicts.
+//      This means that is not legal to create a message and an extension with
+//      the same name in the same file.
+//   3. Messages are not allowed to have multiple fields with the same tag. Note
+//      that only non-extension fields are checked when using builders. So
+//      builders will allow tag collisions for extensions. (Use caution.)
+//   4. Map keys can only be integer types, booleans, and strings.
+//   5. Fields cannot have tags in the special reserved range 19000-19999. Also
+//      the maximum allowed tag value is 536870911 (2^29 - 1). Finally, fields
+//      cannot have negative values.
+//   6. Element names should include only underscore, letters, and numbers, and
+//      must begin with an underscore or letter.
+//
+// Validation rules that are *not* enforced by builders, and thus would be
+// allowed and result in illegal constructs, include the following:
+//
+//   1.  Files with a syntax of proto3 are not allowed to have required fields.
+//   2.  Files with a syntax of proto3 are not allowed to have messages that
+//       define extension ranges.
+//   3.  Files with a syntax of proto3 are not allowed to use groups.
+//   4.  Files with a syntax of proto3 are not allowed to declare default values
+//       for fields.
+//   5.  Names are supposed to be globally unique, even across multiple files
+//       if multiple files are defined in the same package.
+//   6.  Extension fields must use tag numbers that are in an extension range
+//       defined on the extended message.
+//   7.  Multiple extensions for the same message cannot re-use tag numbers, even
+//       across multiple files.
+//   8.  Non-extension fields are not allowed to use tags that lie in a message's
+//       extension ranges or reserved ranges.
+//   9.  Non-extension fields are not allowed to use names that the message has
+//       marked as reserved.
+//   10. Extension ranges and reserved ranges must not overlap.
+//
+// This list may change in the future, as more validation rules may be
+// implemented in the builders.
+package builder

--- a/desc/builder/resolver.go
+++ b/desc/builder/resolver.go
@@ -1,0 +1,255 @@
+package builder
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/golang/protobuf/proto"
+
+	"github.com/jhump/protoreflect/desc"
+)
+
+// dependencyResolver is the work-horse for converting a tree of builders into a
+// tree of descriptors. It scans a root (usually a file builder) and recursively
+// resolves all dependencies (references to builders in other trees as well as
+// references to other already-built descriptors). The result of resolution is a
+// file descriptor (or an error).
+type dependencyResolver struct {
+	resolvedRoots map[Builder]*desc.FileDescriptor
+	seen          map[Builder]struct{}
+}
+
+func newResolver() *dependencyResolver {
+	return &dependencyResolver{
+		resolvedRoots: map[Builder]*desc.FileDescriptor{},
+		seen:          map[Builder]struct{}{},
+	}
+}
+
+func (r *dependencyResolver) resolveElement(b Builder, seen []Builder) (*desc.FileDescriptor, error) {
+	b = getRoot(b)
+
+	if fd, ok := r.resolvedRoots[b]; ok {
+		return fd, nil
+	}
+
+	for _, s := range seen {
+		if s == b {
+			names := make([]string, len(seen)+1)
+			for i, s := range seen {
+				names[i] = s.GetName()
+			}
+			names[len(seen)] = b.GetName()
+			return nil, fmt.Errorf("descriptors have cyclic dependency: %s", strings.Join(names, " ->  "))
+		}
+	}
+	seen = append(seen, b)
+
+	var fd *desc.FileDescriptor
+	var err error
+	switch b := b.(type) {
+	case *FileBuilder:
+		fd, err = r.resolveFile(b, b, seen)
+	default:
+		fd, err = r.resolveSyntheticFile(b, seen)
+	}
+	if err != nil {
+		return nil, err
+	}
+	r.resolvedRoots[b] = fd
+	return fd, nil
+}
+
+func (r *dependencyResolver) resolveFile(fb *FileBuilder, root Builder, seen []Builder) (*desc.FileDescriptor, error) {
+	deps := map[*desc.FileDescriptor]struct{}{}
+	for _, mb := range fb.messages {
+		if err := r.resolveTypesInMessage(root, seen, deps, mb); err != nil {
+			return nil, err
+		}
+	}
+	for _, exb := range fb.extensions {
+		if err := r.resolveTypesInExtension(root, seen, deps, exb); err != nil {
+			return nil, err
+		}
+	}
+	for _, sb := range fb.services {
+		if err := r.resolveTypesInService(root, seen, deps, sb); err != nil {
+			return nil, err
+		}
+	}
+
+	depSlice := make([]*desc.FileDescriptor, 0, len(deps))
+	for dep := range deps {
+		depSlice = append(depSlice, dep)
+	}
+
+	fp, err := fb.buildProto()
+	if err != nil {
+		return nil, err
+	}
+	for _, dep := range depSlice {
+		fp.Dependency = append(fp.Dependency, dep.GetName())
+	}
+	sort.Strings(fp.Dependency)
+
+	// make sure this file name doesn't collide with any of its dependencies
+	fileNames := map[string]struct{}{}
+	for _, d := range depSlice {
+		addFileNames(d, fileNames)
+		fileNames[d.GetName()] = struct{}{}
+	}
+	unique := makeUnique(fp.GetName(), fileNames)
+	if unique != fp.GetName() {
+		fp.Name = proto.String(unique)
+	}
+
+	return desc.CreateFileDescriptor(fp, depSlice...)
+}
+
+func addFileNames(fd *desc.FileDescriptor, files map[string]struct{}) {
+	if _, ok := files[fd.GetName()]; ok {
+		// already added
+		return
+	}
+	files[fd.GetName()] = struct{}{}
+	for _, d := range fd.GetDependencies() {
+		addFileNames(d, files)
+	}
+}
+
+func (r *dependencyResolver) resolveSyntheticFile(b Builder, seen []Builder) (*desc.FileDescriptor, error) {
+	// find ancestor to temporarily attach to new file
+	curr := b
+	for curr.GetParent() != nil {
+		curr = curr.GetParent()
+	}
+	f := NewFile("")
+	switch curr := curr.(type) {
+	case *MessageBuilder:
+		f.messages = append(f.messages, curr)
+	case *EnumBuilder:
+		f.enums = append(f.enums, curr)
+	case *ServiceBuilder:
+		f.services = append(f.services, curr)
+	case *FieldBuilder:
+		if curr.IsExtension() {
+			f.extensions = append(f.extensions, curr)
+		} else {
+			panic("field must be added to message before calling Build()")
+		}
+	case *OneOfBuilder:
+		if _, ok := b.(*OneOfBuilder); ok {
+			panic("one-of must be added to message before calling Build()")
+		} else {
+			// b was a child of one-of which means it must have been a field
+			panic("field must be added to message before calling Build()")
+		}
+	case *MethodBuilder:
+		panic("method must be added to service before calling Build()")
+	case *EnumValueBuilder:
+		panic("enum value must be added to enum before calling Build()")
+	default:
+		panic(fmt.Sprintf("Unrecognized kind of builder: %T", b))
+	}
+	curr.setParent(f)
+
+	// don't forget to reset when done
+	defer func() {
+		curr.setParent(nil)
+	}()
+
+	return r.resolveFile(f, b, seen)
+}
+
+func (r *dependencyResolver) resolveTypesInMessage(root Builder, seen []Builder, deps map[*desc.FileDescriptor]struct{}, mb *MessageBuilder) error {
+	for _, b := range mb.fieldsAndOneOfs {
+		if flb, ok := b.(*FieldBuilder); ok {
+			if err := r.resolveTypesInField(root, seen, flb, deps); err != nil {
+				return err
+			}
+		} else {
+			oob := b.(*OneOfBuilder)
+			for _, flb := range oob.choices {
+				if err := r.resolveTypesInField(root, seen, flb, deps); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	for _, nmb := range mb.nestedMessages {
+		if err := r.resolveTypesInMessage(root, seen, deps, nmb); err != nil {
+			return err
+		}
+	}
+	for _, exb := range mb.nestedExtensions {
+		if err := r.resolveTypesInExtension(root, seen, deps, exb); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *dependencyResolver) resolveTypesInExtension(root Builder, seen []Builder, deps map[*desc.FileDescriptor]struct{}, exb *FieldBuilder) error {
+	if err := r.resolveTypesInField(root, seen, exb, deps); err != nil {
+		return err
+	}
+	if exb.foreignExtendee != nil {
+		deps[exb.foreignExtendee.GetFile()] = struct{}{}
+	} else if err := r.resolveType(root, seen, exb.localExtendee, deps); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *dependencyResolver) resolveTypesInService(root Builder, seen []Builder, deps map[*desc.FileDescriptor]struct{}, sb *ServiceBuilder) error {
+	for _, mtb := range sb.methods {
+		if err := r.resolveRpcType(root, seen, mtb.ReqType, deps); err != nil {
+			return err
+		}
+		if err := r.resolveRpcType(root, seen, mtb.RespType, deps); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *dependencyResolver) resolveRpcType(root Builder, seen []Builder, t *RpcType, deps map[*desc.FileDescriptor]struct{}) error {
+	if t.foreignType != nil {
+		deps[t.foreignType.GetFile()] = struct{}{}
+	} else {
+		return r.resolveType(root, seen, t.localType, deps)
+	}
+	return nil
+}
+
+func (r *dependencyResolver) resolveTypesInField(root Builder, seen []Builder, flb *FieldBuilder, deps map[*desc.FileDescriptor]struct{}) error {
+	if flb.fieldType.foreignMsgType != nil {
+		deps[flb.fieldType.foreignMsgType.GetFile()] = struct{}{}
+	} else if flb.fieldType.foreignEnumType != nil {
+		deps[flb.fieldType.foreignEnumType.GetFile()] = struct{}{}
+	} else if flb.fieldType.localMsgType != nil {
+		if flb.fieldType.localMsgType == flb.msgType {
+			return r.resolveTypesInMessage(root, seen, deps, flb.msgType)
+		} else {
+			return r.resolveType(root, seen, flb.fieldType.localMsgType, deps)
+		}
+	} else if flb.fieldType.localEnumType != nil {
+		return r.resolveType(root, seen, flb.fieldType.localEnumType, deps)
+	}
+	return nil
+}
+
+func (r *dependencyResolver) resolveType(root Builder, seen []Builder, typeBuilder Builder, deps map[*desc.FileDescriptor]struct{}) error {
+	otherRoot := getRoot(typeBuilder)
+	if root == otherRoot {
+		// local reference, so it will get resolved when we finish resolving this root
+		return nil
+	}
+	fd, err := r.resolveElement(otherRoot, seen)
+	if err != nil {
+		return err
+	}
+	deps[fd] = struct{}{}
+	return nil
+}

--- a/desc/builder/types.go
+++ b/desc/builder/types.go
@@ -1,0 +1,179 @@
+package builder
+
+import (
+	"fmt"
+
+	"github.com/jhump/protoreflect/desc"
+)
+
+import (
+	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
+)
+
+type FieldType struct {
+	fieldType       dpb.FieldDescriptorProto_Type
+	foreignMsgType  *desc.MessageDescriptor
+	localMsgType    *MessageBuilder
+	foreignEnumType *desc.EnumDescriptor
+	localEnumType   *EnumBuilder
+}
+
+func (ft *FieldType) GetType() dpb.FieldDescriptorProto_Type {
+	return ft.fieldType
+}
+
+func (ft *FieldType) GetTypeName() string {
+	if ft.foreignMsgType != nil {
+		return ft.foreignMsgType.GetFullyQualifiedName()
+	} else if ft.foreignEnumType != nil {
+		return ft.foreignEnumType.GetFullyQualifiedName()
+	} else if ft.localMsgType != nil {
+		return GetFullyQualifiedName(ft.localMsgType)
+	} else if ft.localEnumType != nil {
+		return GetFullyQualifiedName(ft.localEnumType)
+	} else {
+		return ""
+	}
+}
+
+var scalarTypes = map[dpb.FieldDescriptorProto_Type]*FieldType{
+	dpb.FieldDescriptorProto_TYPE_BOOL:     {fieldType: dpb.FieldDescriptorProto_TYPE_BOOL},
+	dpb.FieldDescriptorProto_TYPE_INT32:    {fieldType: dpb.FieldDescriptorProto_TYPE_INT32},
+	dpb.FieldDescriptorProto_TYPE_INT64:    {fieldType: dpb.FieldDescriptorProto_TYPE_INT64},
+	dpb.FieldDescriptorProto_TYPE_SINT32:   {fieldType: dpb.FieldDescriptorProto_TYPE_SINT32},
+	dpb.FieldDescriptorProto_TYPE_SINT64:   {fieldType: dpb.FieldDescriptorProto_TYPE_SINT64},
+	dpb.FieldDescriptorProto_TYPE_UINT32:   {fieldType: dpb.FieldDescriptorProto_TYPE_UINT32},
+	dpb.FieldDescriptorProto_TYPE_UINT64:   {fieldType: dpb.FieldDescriptorProto_TYPE_UINT64},
+	dpb.FieldDescriptorProto_TYPE_FIXED32:  {fieldType: dpb.FieldDescriptorProto_TYPE_FIXED32},
+	dpb.FieldDescriptorProto_TYPE_FIXED64:  {fieldType: dpb.FieldDescriptorProto_TYPE_FIXED64},
+	dpb.FieldDescriptorProto_TYPE_SFIXED32: {fieldType: dpb.FieldDescriptorProto_TYPE_SFIXED32},
+	dpb.FieldDescriptorProto_TYPE_SFIXED64: {fieldType: dpb.FieldDescriptorProto_TYPE_SFIXED64},
+	dpb.FieldDescriptorProto_TYPE_FLOAT:    {fieldType: dpb.FieldDescriptorProto_TYPE_FLOAT},
+	dpb.FieldDescriptorProto_TYPE_DOUBLE:   {fieldType: dpb.FieldDescriptorProto_TYPE_DOUBLE},
+	dpb.FieldDescriptorProto_TYPE_STRING:   {fieldType: dpb.FieldDescriptorProto_TYPE_STRING},
+	dpb.FieldDescriptorProto_TYPE_BYTES:    {fieldType: dpb.FieldDescriptorProto_TYPE_BYTES},
+}
+
+func FieldTypeScalar(t dpb.FieldDescriptorProto_Type) *FieldType {
+	if ft, ok := scalarTypes[t]; ok {
+		return ft
+	}
+	panic(fmt.Sprintf("field %v is not scalar", t))
+}
+
+func FieldTypeInt32() *FieldType {
+	return FieldTypeScalar(dpb.FieldDescriptorProto_TYPE_INT32)
+}
+
+func FieldTypeUInt32() *FieldType {
+	return FieldTypeScalar(dpb.FieldDescriptorProto_TYPE_UINT32)
+}
+
+func FieldTypeSInt32() *FieldType {
+	return FieldTypeScalar(dpb.FieldDescriptorProto_TYPE_SINT32)
+}
+
+func FieldTypeFixed32() *FieldType {
+	return FieldTypeScalar(dpb.FieldDescriptorProto_TYPE_FIXED32)
+}
+
+func FieldTypeSFixed32() *FieldType {
+	return FieldTypeScalar(dpb.FieldDescriptorProto_TYPE_SFIXED32)
+}
+
+func FieldTypeInt64() *FieldType {
+	return FieldTypeScalar(dpb.FieldDescriptorProto_TYPE_INT64)
+}
+
+func FieldTypeUInt64() *FieldType {
+	return FieldTypeScalar(dpb.FieldDescriptorProto_TYPE_UINT64)
+}
+
+func FieldTypeSInt64() *FieldType {
+	return FieldTypeScalar(dpb.FieldDescriptorProto_TYPE_SINT64)
+}
+
+func FieldTypeFixed64() *FieldType {
+	return FieldTypeScalar(dpb.FieldDescriptorProto_TYPE_FIXED64)
+}
+
+func FieldTypeSFixed64() *FieldType {
+	return FieldTypeScalar(dpb.FieldDescriptorProto_TYPE_SFIXED64)
+}
+
+func FieldTypeFloat() *FieldType {
+	return FieldTypeScalar(dpb.FieldDescriptorProto_TYPE_FLOAT)
+}
+
+func FieldTypeDouble() *FieldType {
+	return FieldTypeScalar(dpb.FieldDescriptorProto_TYPE_DOUBLE)
+}
+
+func FieldTypeBool() *FieldType {
+	return FieldTypeScalar(dpb.FieldDescriptorProto_TYPE_BOOL)
+}
+
+func FieldTypeString() *FieldType {
+	return FieldTypeScalar(dpb.FieldDescriptorProto_TYPE_STRING)
+}
+
+func FieldTypeBytes() *FieldType {
+	return FieldTypeScalar(dpb.FieldDescriptorProto_TYPE_BYTES)
+}
+
+func FieldTypeMessage(mb *MessageBuilder) *FieldType {
+	return &FieldType{
+		fieldType:    dpb.FieldDescriptorProto_TYPE_MESSAGE,
+		localMsgType: mb,
+	}
+}
+
+func FieldTypeImportedMessage(md *desc.MessageDescriptor) *FieldType {
+	return &FieldType{
+		fieldType:      dpb.FieldDescriptorProto_TYPE_MESSAGE,
+		foreignMsgType: md,
+	}
+}
+
+func FieldTypeEnum(eb *EnumBuilder) *FieldType {
+	return &FieldType{
+		fieldType:     dpb.FieldDescriptorProto_TYPE_ENUM,
+		localEnumType: eb,
+	}
+}
+
+func FieldTypeImportedEnum(ed *desc.EnumDescriptor) *FieldType {
+	return &FieldType{
+		fieldType:       dpb.FieldDescriptorProto_TYPE_ENUM,
+		foreignEnumType: ed,
+	}
+}
+
+type RpcType struct {
+	IsStream bool
+
+	foreignType *desc.MessageDescriptor
+	localType   *MessageBuilder
+}
+
+func RpcTypeMessage(mb *MessageBuilder, stream bool) *RpcType {
+	return &RpcType{
+		IsStream:  stream,
+		localType: mb,
+	}
+}
+
+func RpcTypeImportedMessage(md *desc.MessageDescriptor, stream bool) *RpcType {
+	return &RpcType{
+		IsStream:    stream,
+		foreignType: md,
+	}
+}
+
+func (rt *RpcType) GetTypeName() string {
+	if rt.foreignType != nil {
+		return rt.foreignType.GetFullyQualifiedName()
+	} else {
+		return GetFullyQualifiedName(rt.localType)
+	}
+}

--- a/desc/descriptor.go
+++ b/desc/descriptor.go
@@ -81,7 +81,8 @@ type Descriptor interface {
 	GetName() string
 	// GetFullyQualifiedName returns the fully-qualified name of the object described by
 	// the descriptor. This will include the package name and any enclosing message names.
-	// For file descriptors, this indicates the package that is declared by the file.
+	// For file descriptors, this returns the path and name to the described file (same as
+	// GetName).
 	GetFullyQualifiedName() string
 	// GetParent returns the enclosing element in a proto source file. If the described
 	// object is a top-level object, this returns the file descriptor. Otherwise, it returns

--- a/desc/protoparse/parser.go
+++ b/desc/protoparse/parser.go
@@ -470,7 +470,10 @@ func asFieldDescriptor(label *dpb.FieldDescriptorProto_Label, typ, name string, 
 	return fd
 }
 
-func asGroupDescriptor(label dpb.FieldDescriptorProto_Label, name string, tag int32, body []*msgDecl) *groupDesc {
+func asGroupDescriptor(lex protoLexer, label dpb.FieldDescriptorProto_Label, name string, tag int32, body []*msgDecl) *groupDesc {
+	if !unicode.IsUpper(rune(name[0])) {
+		lex.Error(fmt.Sprintf("group %s should have a name that starts with a capital letter", name))
+	}
 	fieldName := strings.ToLower(name)
 	fd := &dpb.FieldDescriptorProto{
 		Name:     proto.String(fieldName),

--- a/desc/protoparse/proto.y
+++ b/desc/protoparse/proto.y
@@ -348,15 +348,15 @@ fieldOption: optionName '=' constant {
 
 group : _REQUIRED _GROUP name '=' _INT_LIT '{' messageBody '}' {
 		checkTag(protolex, $5)
-		$$ = asGroupDescriptor(dpb.FieldDescriptorProto_LABEL_REQUIRED, $3, int32($5), $7)
+		$$ = asGroupDescriptor(protolex, dpb.FieldDescriptorProto_LABEL_REQUIRED, $3, int32($5), $7)
 	}
 	| _OPTIONAL _GROUP name '=' _INT_LIT '{' messageBody '}' {
 		checkTag(protolex, $5)
-		$$ = asGroupDescriptor(dpb.FieldDescriptorProto_LABEL_OPTIONAL, $3, int32($5), $7)
+		$$ = asGroupDescriptor(protolex, dpb.FieldDescriptorProto_LABEL_OPTIONAL, $3, int32($5), $7)
 	}
 	| _REPEATED _GROUP name '=' _INT_LIT '{' messageBody '}' {
 		checkTag(protolex, $5)
-		$$ = asGroupDescriptor(dpb.FieldDescriptorProto_LABEL_REPEATED, $3, int32($5), $7)
+		$$ = asGroupDescriptor(protolex, dpb.FieldDescriptorProto_LABEL_REPEATED, $3, int32($5), $7)
 	}
 
 oneof : _ONEOF name '{' oneofBody '}' {

--- a/desc/protoparse/proto.y.go
+++ b/desc/protoparse/proto.y.go
@@ -1304,21 +1304,21 @@ protodefault:
 		//line proto.y:349
 		{
 			checkTag(protolex, protoDollar[5].ui)
-			protoVAL.grpd = asGroupDescriptor(dpb.FieldDescriptorProto_LABEL_REQUIRED, protoDollar[3].str, int32(protoDollar[5].ui), protoDollar[7].msgDecs)
+			protoVAL.grpd = asGroupDescriptor(protolex, dpb.FieldDescriptorProto_LABEL_REQUIRED, protoDollar[3].str, int32(protoDollar[5].ui), protoDollar[7].msgDecs)
 		}
 	case 77:
 		protoDollar = protoS[protopt-8 : protopt+1]
 		//line proto.y:353
 		{
 			checkTag(protolex, protoDollar[5].ui)
-			protoVAL.grpd = asGroupDescriptor(dpb.FieldDescriptorProto_LABEL_OPTIONAL, protoDollar[3].str, int32(protoDollar[5].ui), protoDollar[7].msgDecs)
+			protoVAL.grpd = asGroupDescriptor(protolex, dpb.FieldDescriptorProto_LABEL_OPTIONAL, protoDollar[3].str, int32(protoDollar[5].ui), protoDollar[7].msgDecs)
 		}
 	case 78:
 		protoDollar = protoS[protopt-8 : protopt+1]
 		//line proto.y:357
 		{
 			checkTag(protolex, protoDollar[5].ui)
-			protoVAL.grpd = asGroupDescriptor(dpb.FieldDescriptorProto_LABEL_REPEATED, protoDollar[3].str, int32(protoDollar[5].ui), protoDollar[7].msgDecs)
+			protoVAL.grpd = asGroupDescriptor(protolex, dpb.FieldDescriptorProto_LABEL_REPEATED, protoDollar[3].str, int32(protoDollar[5].ui), protoDollar[7].msgDecs)
 		}
 	case 79:
 		protoDollar = protoS[protopt-5 : protopt+1]


### PR DESCRIPTION
New package that allows for programmatically constructing descriptors. Without this package, this could be done by hand by constructing full trees of descriptor protos and then using the `desc` package to convert those into rich descriptors. However, the process is tedious (to say the least) and error-prone.

This provides an API that makes it easier to construct descriptors from scratch and also makes it easy to programmatically modify any existing descriptor.

The API should be mostly settled. And there is a reasonable bit of package doc written. Most doc still to write. And there are more tests to write, too, to make sure that renaming and moving descriptors works (e.g. moving means unlinking a descriptor from its parent and adding it to a new field, like moving a field from one message to another). Similarly, there is logic to handle renumbering (non-extension) fields, but it doesn't yet have test coverage.

But the basic cases, including inter-op / conversion from rich descriptors, have tests.