### PR TITLE
grpc does not support 1.6 anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 
 matrix:
   include:
-    - go: 1.6
     - go: 1.7
     - go: 1.8
     - go: 1.9


### PR DESCRIPTION
as of https://github.com/grpc/grpc-go/pull/1492