### PR TITLE
fix issue when putting first value in a map field

### DIFF
--- a/dynamic/dynamic_message.go
+++ b/dynamic/dynamic_message.go
@@ -721,7 +721,8 @@ func (m *Message) putMapField(fd *desc.FieldDescriptor, key interface{}, val int
 			return err
 		} else if mp == nil {
 			mp = map[interface{}]interface{}{}
-			m.internalSetField(fd, mp)
+			m.internalSetField(fd, map[interface{}]interface{}{ki: vi})
+			return nil
 		}
 	}
 	mp.(map[interface{}]interface{})[ki] = vi


### PR DESCRIPTION
This was a goof. When inserting the first value in a map field, the code was first adding the empty map and then mutating it. That doesn't work for proto3 messages since they silently ignore requests to insert empty maps: an empty map is the zero value for map fields, therefor there is no need to store it since the zero value is indistinguishable from absent in proto3.