### PR TITLE
Fix issue with multiple imports

### DIFF
--- a/desc/protoparse/parser.go
+++ b/desc/protoparse/parser.go
@@ -81,8 +81,10 @@ func (p Parser) ParseFiles(filenames ...string) ([]*desc.FileDescriptor, error) 
 			var ret error
 			for _, path := range paths {
 				f, err := acc(filepath.Join(path, name))
-				if err != nil && ret == nil {
-					ret = err
+				if err != nil {
+					if ret == nil {
+						ret = err
+					}
 					continue
 				}
 				return f, nil


### PR DESCRIPTION
This closes #74. It will explore all the import ports while trying to import a file, and return error only none of the import paths contains that file.