### PR TITLE
tests for source position info during lexing; add attribution of trailing comments

### DIFF
--- a/desc/protoparse/ast.go
+++ b/desc/protoparse/ast.go
@@ -30,6 +30,12 @@ type node interface {
 	trailingComment() []*comment
 }
 
+type terminalNode interface {
+	node
+	popLeadingComment() *comment
+	pushTrailingComment(*comment)
+}
+
 type posRange struct {
 	start, end *SourcePos
 }
@@ -54,6 +60,16 @@ func (n *basicNode) leadingComments() []*comment {
 
 func (n *basicNode) trailingComment() []*comment {
 	return n.trailing
+}
+
+func (n *basicNode) popLeadingComment() *comment {
+	c := n.leading[0]
+	n.leading = n.leading[1:]
+	return c
+}
+
+func (n *basicNode) pushTrailingComment(c *comment) {
+	n.trailing = append(n.trailing, c)
 }
 
 type comment struct {
@@ -272,6 +288,14 @@ type floatLiteralNode struct {
 
 func (n *floatLiteralNode) value() interface{} {
 	return n.val
+}
+
+func (n *floatLiteralNode) popLeadingComment() *comment {
+	return n.first.(terminalNode).popLeadingComment()
+}
+
+func (n *floatLiteralNode) pushTrailingComment(c *comment) {
+	n.last.(terminalNode).pushTrailingComment(c)
 }
 
 type boolLiteralNode struct {

--- a/desc/protoparse/lexer_test.go
+++ b/desc/protoparse/lexer_test.go
@@ -56,68 +56,84 @@ func TestLexer(t *testing.T) {
 	12e12
 
 	Random_identifier_with_numbers_0123456789_and_letters...
+	// this is a trailing comment
+	// that spans multiple lines
+	// over two in fact!
+	/*
+	 * this is a detached comment
+	 * with lots of extra words and stuff...
+	 */
+
+	// this is an attached leading comment
+	foo
 	`))
 
+	var prev node
 	var sym protoSymType
 	expected := []struct {
-		t int
-		v interface{}
+		t          int
+		line, col  int
+		span       int
+		v          interface{}
+		comments   []string
+		trailCount int
 	}{
-		{t: _INT32, v: "int32"},
-		{t: _STRING_LIT, v: "\032\x16\n\rfoobar\"zap"},
-		{t: _STRING_LIT, v: "another\tstring's\t"},
-		{t: _SERVICE, v: "service"},
-		{t: _RPC, v: "rpc"},
-		{t: _MESSAGE, v: "message"},
-		{t: _TYPENAME, v: ".type"},
-		{t: _TYPENAME, v: ".f.q.n"},
-		{t: _NAME, v: "name"},
-		{t: _FQNAME, v: "f.q.n"},
-		{t: _FLOAT_LIT, v: 0.01},
-		{t: _FLOAT_LIT, v: 0.01e12},
-		{t: _FLOAT_LIT, v: 0.01e5},
-		{t: _FLOAT_LIT, v: 0.033e-1},
-		{t: _INT_LIT, v: uint64(12345)},
-		{t: '-', v: nil},
-		{t: _INT_LIT, v: uint64(12345)},
-		{t: _FLOAT_LIT, v: 123.1234},
-		{t: _FLOAT_LIT, v: 0.123},
-		{t: _INT_LIT, v: uint64(012345)},
-		{t: _INT_LIT, v: uint64(0x2134abcdef30)},
-		{t: '-', v: nil},
-		{t: _INT_LIT, v: uint64(0543)},
-		{t: '-', v: nil},
-		{t: _INT_LIT, v: uint64(0xff76)},
-		{t: _FLOAT_LIT, v: 101.0102},
-		{t: _FLOAT_LIT, v: 202.0203e1},
-		{t: _FLOAT_LIT, v: 304.0304e-10},
-		{t: _FLOAT_LIT, v: 3.1234e+12},
-		{t: '{', v: nil},
-		{t: '}', v: nil},
-		{t: '+', v: nil},
-		{t: '-', v: nil},
-		{t: ',', v: nil},
-		{t: ';', v: nil},
-		{t: '[', v: nil},
-		{t: _OPTION, v: "option"},
-		{t: '=', v: nil},
-		{t: _NAME, v: "foo"},
-		{t: ']', v: nil},
-		{t: _SYNTAX, v: "syntax"},
-		{t: '=', v: nil},
-		{t: _STRING_LIT, v: "proto2"},
-		{t: ';', v: nil},
-		{t: _FLOAT_LIT, v: 1.543},
-		{t: _NAME, v: "g12"},
-		{t: _FLOAT_LIT, v: 0.0},
-		{t: _FLOAT_LIT, v: 0.1234},
-		{t: _FLOAT_LIT, v: 0.5678},
-		{t: '.', v: nil},
-		{t: _FLOAT_LIT, v: 12e12},
-		{t: _NAME, v: "Random_identifier_with_numbers_0123456789_and_letters"},
-		{t: '.', v: nil},
-		{t: '.', v: nil},
-		{t: '.', v: nil},
+		{t: _INT32, line: 8, col: 2, span: 5, v: "int32", comments: []string{"// comment", "/*\n\t * block comment\n\t */", "/* inline comment */"}},
+		{t: _STRING_LIT, line: 8, col: 9, span: 25, v: "\032\x16\n\rfoobar\"zap"},
+		{t: _STRING_LIT, line: 8, col: 36, span: 22, v: "another\tstring's\t"},
+		{t: _SERVICE, line: 13, col: 2, span: 7, v: "service", comments: []string{"// another comment", "// more and more..."}},
+		{t: _RPC, line: 13, col: 10, span: 3, v: "rpc"},
+		{t: _MESSAGE, line: 13, col: 14, span: 7, v: "message"},
+		{t: _TYPENAME, line: 14, col: 2, span: 5, v: ".type"},
+		{t: _TYPENAME, line: 15, col: 2, span: 6, v: ".f.q.n"},
+		{t: _NAME, line: 16, col: 2, span: 4, v: "name"},
+		{t: _FQNAME, line: 17, col: 2, span: 5, v: "f.q.n"},
+		{t: _FLOAT_LIT, line: 19, col: 2, span: 3, v: 0.01},
+		{t: _FLOAT_LIT, line: 20, col: 2, span: 6, v: 0.01e12},
+		{t: _FLOAT_LIT, line: 21, col: 2, span: 6, v: 0.01e5},
+		{t: _FLOAT_LIT, line: 22, col: 2, span: 7, v: 0.033e-1},
+		{t: _INT_LIT, line: 24, col: 2, span: 5, v: uint64(12345)},
+		{t: '-', line: 25, col: 2, span: 1, v: nil},
+		{t: _INT_LIT, line: 25, col: 3, span: 5, v: uint64(12345)},
+		{t: _FLOAT_LIT, line: 26, col: 2, span: 8, v: 123.1234},
+		{t: _FLOAT_LIT, line: 27, col: 2, span: 5, v: 0.123},
+		{t: _INT_LIT, line: 28, col: 2, span: 6, v: uint64(012345)},
+		{t: _INT_LIT, line: 29, col: 2, span: 14, v: uint64(0x2134abcdef30)},
+		{t: '-', line: 30, col: 2, span: 1, v: nil},
+		{t: _INT_LIT, line: 30, col: 3, span: 4, v: uint64(0543)},
+		{t: '-', line: 31, col: 2, span: 1, v: nil},
+		{t: _INT_LIT, line: 31, col: 3, span: 6, v: uint64(0xff76)},
+		{t: _FLOAT_LIT, line: 32, col: 2, span: 8, v: 101.0102},
+		{t: _FLOAT_LIT, line: 33, col: 2, span: 10, v: 202.0203e1},
+		{t: _FLOAT_LIT, line: 34, col: 2, span: 12, v: 304.0304e-10},
+		{t: _FLOAT_LIT, line: 35, col: 2, span: 10, v: 3.1234e+12},
+		{t: '{', line: 37, col: 2, span: 1, v: nil},
+		{t: '}', line: 37, col: 4, span: 1, v: nil},
+		{t: '+', line: 37, col: 6, span: 1, v: nil},
+		{t: '-', line: 37, col: 8, span: 1, v: nil},
+		{t: ',', line: 37, col: 10, span: 1, v: nil},
+		{t: ';', line: 37, col: 12, span: 1, v: nil},
+		{t: '[', line: 39, col: 2, span: 1, v: nil},
+		{t: _OPTION, line: 39, col: 3, span: 6, v: "option"},
+		{t: '=', line: 39, col: 9, span: 1, v: nil},
+		{t: _NAME, line: 39, col: 10, span: 3, v: "foo"},
+		{t: ']', line: 39, col: 13, span: 1, v: nil},
+		{t: _SYNTAX, line: 40, col: 2, span: 6, v: "syntax"},
+		{t: '=', line: 40, col: 9, span: 1, v: nil},
+		{t: _STRING_LIT, line: 40, col: 11, span: 8, v: "proto2"},
+		{t: ';', line: 40, col: 19, span: 1, v: nil},
+		{t: _FLOAT_LIT, line: 43, col: 2, span: 5, v: 1.543, comments: []string{"// some strange cases"}},
+		{t: _NAME, line: 43, col: 7, span: 3, v: "g12"},
+		{t: _FLOAT_LIT, line: 44, col: 2, span: 7, v: 0.0, comments: []string{"/* trailing line comment */"}, trailCount: 1},
+		{t: _FLOAT_LIT, line: 45, col: 2, span: 6, v: 0.1234},
+		{t: _FLOAT_LIT, line: 45, col: 8, span: 5, v: 0.5678},
+		{t: '.', line: 45, col: 13, span: 1, v: nil},
+		{t: _FLOAT_LIT, line: 46, col: 2, span: 5, v: 12e12},
+		{t: _NAME, line: 48, col: 2, span: 53, v: "Random_identifier_with_numbers_0123456789_and_letters"},
+		{t: '.', line: 48, col: 55, span: 1, v: nil},
+		{t: '.', line: 48, col: 56, span: 1, v: nil},
+		{t: '.', line: 48, col: 57, span: 1, v: nil},
+		{t: _NAME, line: 58, col: 2, span: 3, v: "foo", comments: []string{"// this is a trailing comment", "// that spans multiple lines", "// over two in fact!", "/*\n\t * this is a detached comment\n\t * with lots of extra words and stuff...\n\t */", "// this is an attached leading comment"}, trailCount: 3},
 	}
 
 	for i, exp := range expected {
@@ -125,21 +141,45 @@ func TestLexer(t *testing.T) {
 		if tok == 0 {
 			t.Fatalf("lexer reported EOF but should have returned %v", exp)
 		}
+		var n node
 		var val interface{}
 		switch tok {
 		case _SYNTAX, _OPTION, _INT32, _SERVICE, _RPC, _MESSAGE, _TYPENAME, _NAME, _FQNAME:
+			n = sym.id
 			val = sym.id.val
 		case _STRING_LIT:
+			n = sym.str
 			val = sym.str.val
 		case _INT_LIT:
+			n = sym.ui
 			val = sym.ui.val
 		case _FLOAT_LIT:
+			n = sym.f
 			val = sym.f.val
 		default:
+			n = sym.b
 			val = nil
 		}
 		testutil.Eq(t, exp.t, tok, "case %d: wrong token type (case %v)", i, exp.v)
 		testutil.Eq(t, exp.v, val, "case %d: wrong token value", i)
+		testutil.Eq(t, exp.line, n.start().Line, "case %d: wrong line number", i)
+		testutil.Eq(t, exp.col, n.start().Col, "case %d: wrong column number", i)
+		testutil.Eq(t, exp.line, n.end().Line, "case %d: wrong end line number", i)
+		testutil.Eq(t, exp.col+exp.span, n.end().Col, "case %d: wrong end column number", i)
+		if exp.trailCount > 0 {
+			testutil.Eq(t, exp.trailCount, len(prev.trailingComment()), "case %d: wrong number of trailing comments", i)
+		}
+		testutil.Eq(t, len(exp.comments)-exp.trailCount, len(n.leadingComments()), "case %d: wrong number of comments", i)
+		for ci := range exp.comments {
+			var c *comment
+			if ci < exp.trailCount {
+				c = prev.trailingComment()[ci]
+			} else {
+				c = n.leadingComments()[ci-exp.trailCount]
+			}
+			testutil.Eq(t, exp.comments[ci], c.text, "case %d, comment #%d: unexpected text", i, ci+1)
+		}
+		prev = n
 	}
 	if tok := l.Lex(&sym); tok != 0 {
 		t.Fatalf("lexer reported symbol after what should have been EOF: %d", tok)


### PR DESCRIPTION
This is a small change on top of #73. It adds tests for new functionality that includes file location information in all lexed tokens. It also adds handling of trailing comments to the lexer.