### PR TITLE
protoparse: add source position to all error messages

### DIFF
--- a/desc/protoparse/ast.go
+++ b/desc/protoparse/ast.go
@@ -386,10 +386,11 @@ type labelNode struct {
 
 type groupNode struct {
 	basicCompositeNode
-	label *labelNode
-	name  *identNode
-	tag   *intLiteralNode
-	decls []*messageElement
+	groupKeyword *identNode
+	label        *labelNode
+	name         *identNode
+	tag          *intLiteralNode
+	decls        []*messageElement
 
 	// This field is populated after parsing, to make it easier to find them
 	// without searching decls. The parse result has a map of descriptors to

--- a/desc/protoparse/ast.go
+++ b/desc/protoparse/ast.go
@@ -10,6 +10,9 @@ type ErrorWithSourcePos struct {
 }
 
 func (e ErrorWithSourcePos) Error() string {
+	if e.Pos.Line <= 0 || e.Pos.Col <= 0 {
+		return fmt.Sprintf("%s: %v", e.Pos.Filename, e.Underlying)
+	}
 	return fmt.Sprintf("%s:%d:%d: %v", e.Pos.Filename, e.Pos.Line, e.Pos.Col, e.Underlying)
 }
 
@@ -35,6 +38,83 @@ type terminalNode interface {
 	popLeadingComment() *comment
 	pushTrailingComment(*comment)
 }
+
+var _ terminalNode = (*basicNode)(nil)
+var _ terminalNode = (*stringLiteralNode)(nil)
+var _ terminalNode = (*intLiteralNode)(nil)
+var _ terminalNode = (*floatLiteralNode)(nil)
+var _ terminalNode = (*identNode)(nil)
+
+type fileDecl interface {
+	node
+	getSyntax() node
+}
+
+var _ fileDecl = (*fileNode)(nil)
+var _ fileDecl = (*noSourceNode)(nil)
+
+type optionDecl interface {
+	node
+	getName() node
+	getValue() valueNode
+}
+
+var _ optionDecl = (*optionNode)(nil)
+var _ optionDecl = (*noSourceNode)(nil)
+
+type fieldDecl interface {
+	node
+	fieldLabel() node
+	fieldName() node
+	fieldType() node
+	fieldTag() node
+	fieldExtendee() node
+	getGroupKeyword() node
+}
+
+var _ fieldDecl = (*fieldNode)(nil)
+var _ fieldDecl = (*groupNode)(nil)
+var _ fieldDecl = (*mapFieldNode)(nil)
+var _ fieldDecl = (*syntheticMapField)(nil)
+var _ fieldDecl = (*noSourceNode)(nil)
+
+type rangeDecl interface {
+	node
+	rangeStart() node
+	rangeEnd() node
+}
+
+var _ rangeDecl = (*rangeNode)(nil)
+var _ rangeDecl = (*noSourceNode)(nil)
+
+type enumValueDecl interface {
+	node
+	getName() node
+	getNumber() node
+}
+
+var _ enumValueDecl = (*enumValueNode)(nil)
+var _ enumValueDecl = (*noSourceNode)(nil)
+
+type msgDecl interface {
+	node
+	messageName() node
+	reservedNames() []*stringLiteralNode
+}
+
+var _ msgDecl = (*messageNode)(nil)
+var _ msgDecl = (*groupNode)(nil)
+var _ msgDecl = (*mapFieldNode)(nil)
+var _ msgDecl = (*noSourceNode)(nil)
+
+type methodDecl interface {
+	node
+	getInputType() node
+	getOutputType() node
+}
+
+var _ methodDecl = (*methodNode)(nil)
+var _ methodDecl = (*noSourceNode)(nil)
 
 type posRange struct {
 	start, end *SourcePos
@@ -115,6 +195,10 @@ type fileNode struct {
 	// the file descriptor.
 	imports []*importNode
 	pkg     *packageNode
+}
+
+func (n *fileNode) getSyntax() node {
+	return n.syntax
 }
 
 type fileElement struct {
@@ -209,6 +293,14 @@ type optionNode struct {
 	val  valueNode
 }
 
+func (n *optionNode) getName() node {
+	return n.name
+}
+
+func (n *optionNode) getValue() valueNode {
+	return n.val
+}
+
 type optionNameNode struct {
 	basicCompositeNode
 	parts []*optionNamePartNode
@@ -253,6 +345,15 @@ type valueNode interface {
 	node
 	value() interface{}
 }
+
+var _ valueNode = (*stringLiteralNode)(nil)
+var _ valueNode = (*intLiteralNode)(nil)
+var _ valueNode = (*negativeIntLiteralNode)(nil)
+var _ valueNode = (*floatLiteralNode)(nil)
+var _ valueNode = (*boolLiteralNode)(nil)
+var _ valueNode = (*sliceLiteralNode)(nil)
+var _ valueNode = (*aggregateLiteralNode)(nil)
+var _ valueNode = (*noSourceNode)(nil)
 
 type stringLiteralNode struct {
 	basicNode
@@ -345,14 +446,6 @@ func (a *aggregateNameNode) value() string {
 	}
 }
 
-type fieldDecl interface {
-	node
-	fieldLabel() node
-	fieldName() *identNode
-	fieldType() *identNode
-	fieldTag() *intLiteralNode
-}
-
 type fieldNode struct {
 	basicCompositeNode
 	label   *labelNode
@@ -360,22 +453,39 @@ type fieldNode struct {
 	name    *identNode
 	tag     *intLiteralNode
 	options []*optionNode
+
+	// This field is populated after parsing, to allow lookup of extendee source
+	// locations when field extendees cannot be linked. (Otherwise, this is just
+	// stored as a string in the field descriptors defined inside the extend
+	// block).
+	extendee *extendNode
 }
 
 func (n *fieldNode) fieldLabel() node {
 	return n.label
 }
 
-func (n *fieldNode) fieldName() *identNode {
+func (n *fieldNode) fieldName() node {
 	return n.name
 }
 
-func (n *fieldNode) fieldType() *identNode {
+func (n *fieldNode) fieldType() node {
 	return n.fldType
 }
 
-func (n *fieldNode) fieldTag() *intLiteralNode {
+func (n *fieldNode) fieldTag() node {
 	return n.tag
+}
+
+func (n *fieldNode) fieldExtendee() node {
+	if n.extendee != nil {
+		return n.extendee.extendee
+	}
+	return nil
+}
+
+func (n *fieldNode) getGroupKeyword() node {
+	return nil
 }
 
 type labelNode struct {
@@ -398,25 +508,41 @@ type groupNode struct {
 	// elements do not map to descriptors -- they are just stored as strings in
 	// the message descriptor.
 	reserved []*stringLiteralNode
+	// This field is populated after parsing, to allow lookup of extendee source
+	// locations when field extendees cannot be linked. (Otherwise, this is just
+	// stored as a string in the field descriptors defined inside the extend
+	// block).
+	extendee *extendNode
 }
 
 func (n *groupNode) fieldLabel() node {
 	return n.label
 }
 
-func (n *groupNode) fieldName() *identNode {
+func (n *groupNode) fieldName() node {
 	return n.name
 }
 
-func (n *groupNode) fieldType() *identNode {
+func (n *groupNode) fieldType() node {
 	return n.name
 }
 
-func (n *groupNode) fieldTag() *intLiteralNode {
+func (n *groupNode) fieldTag() node {
 	return n.tag
 }
 
-func (n *groupNode) messageName() *identNode {
+func (n *groupNode) fieldExtendee() node {
+	if n.extendee != nil {
+		return n.extendee.extendee
+	}
+	return nil
+}
+
+func (n *groupNode) getGroupKeyword() node {
+	return n.groupKeyword
+}
+
+func (n *groupNode) messageName() node {
 	return n.name
 }
 
@@ -478,19 +604,27 @@ func (n *mapFieldNode) fieldLabel() node {
 	return n.mapKeyword
 }
 
-func (n *mapFieldNode) fieldName() *identNode {
+func (n *mapFieldNode) fieldName() node {
 	return n.name
 }
 
-func (n *mapFieldNode) fieldType() *identNode {
+func (n *mapFieldNode) fieldType() node {
 	return n.mapKeyword
 }
 
-func (n *mapFieldNode) fieldTag() *intLiteralNode {
+func (n *mapFieldNode) fieldTag() node {
 	return n.tag
 }
 
-func (n *mapFieldNode) messageName() *identNode {
+func (n *mapFieldNode) fieldExtendee() node {
+	return nil
+}
+
+func (n *mapFieldNode) getGroupKeyword() node {
+	return nil
+}
+
+func (n *mapFieldNode) messageName() node {
 	return n.name
 }
 
@@ -543,16 +677,24 @@ func (n *syntheticMapField) fieldLabel() node {
 	return n.ident
 }
 
-func (n *syntheticMapField) fieldName() *identNode {
+func (n *syntheticMapField) fieldName() node {
 	return n.ident
 }
 
-func (n *syntheticMapField) fieldType() *identNode {
+func (n *syntheticMapField) fieldType() node {
 	return n.ident
 }
 
-func (n *syntheticMapField) fieldTag() *intLiteralNode {
+func (n *syntheticMapField) fieldTag() node {
 	return n.tag
+}
+
+func (n *syntheticMapField) fieldExtendee() node {
+	return nil
+}
+
+func (n *syntheticMapField) getGroupKeyword() node {
+	return nil
 }
 
 type extensionRangeNode struct {
@@ -564,6 +706,14 @@ type extensionRangeNode struct {
 type rangeNode struct {
 	basicCompositeNode
 	st, en *intLiteralNode
+}
+
+func (n *rangeNode) rangeStart() node {
+	return n.st
+}
+
+func (n *rangeNode) rangeEnd() node {
+	return n.en
 }
 
 type reservedNode struct {
@@ -621,10 +771,15 @@ type enumValueNode struct {
 	numberN *negativeIntLiteralNode
 }
 
-type msgDecl interface {
-	node
-	messageName() *identNode
-	reservedNames() []*stringLiteralNode
+func (n *enumValueNode) getName() node {
+	return n.name
+}
+
+func (n *enumValueNode) getNumber() node {
+	if n.number != nil {
+		return n.number
+	}
+	return n.numberN
 }
 
 type messageNode struct {
@@ -640,7 +795,7 @@ type messageNode struct {
 	reserved []*stringLiteralNode
 }
 
-func (n *messageNode) messageName() *identNode {
+func (n *messageNode) messageName() node {
 	return n.name
 }
 
@@ -794,8 +949,104 @@ type methodNode struct {
 	options []*optionNode
 }
 
+func (n *methodNode) getInputType() node {
+	return n.input.msgType
+}
+
+func (n *methodNode) getOutputType() node {
+	return n.output.msgType
+}
+
 type rpcTypeNode struct {
 	basicCompositeNode
 	msgType *identNode
 	stream  bool
+}
+
+type noSourceNode struct {
+	pos *SourcePos
+}
+
+func (n noSourceNode) start() *SourcePos {
+	return n.pos
+}
+
+func (n noSourceNode) end() *SourcePos {
+	return n.pos
+}
+
+func (n noSourceNode) leadingComments() []*comment {
+	return nil
+}
+
+func (n noSourceNode) trailingComment() []*comment {
+	return nil
+}
+
+func (n noSourceNode) getSyntax() node {
+	return n
+}
+
+func (n noSourceNode) getName() node {
+	return n
+}
+
+func (n noSourceNode) getValue() valueNode {
+	return n
+}
+
+func (n noSourceNode) fieldLabel() node {
+	return n
+}
+
+func (n noSourceNode) fieldName() node {
+	return n
+}
+
+func (n noSourceNode) fieldType() node {
+	return n
+}
+
+func (n noSourceNode) fieldTag() node {
+	return n
+}
+
+func (n noSourceNode) fieldExtendee() node {
+	return n
+}
+
+func (n noSourceNode) getGroupKeyword() node {
+	return n
+}
+
+func (n noSourceNode) rangeStart() node {
+	return n
+}
+
+func (n noSourceNode) rangeEnd() node {
+	return n
+}
+
+func (n noSourceNode) getNumber() node {
+	return n
+}
+
+func (n noSourceNode) messageName() node {
+	return n
+}
+
+func (n noSourceNode) reservedNames() []*stringLiteralNode {
+	return nil
+}
+
+func (n noSourceNode) getInputType() node {
+	return n
+}
+
+func (n noSourceNode) getOutputType() node {
+	return n
+}
+
+func (n noSourceNode) value() interface{} {
+	return nil
 }

--- a/desc/protoparse/linker_test.go
+++ b/desc/protoparse/linker_test.go
@@ -162,19 +162,19 @@ func TestLinkerValidation(t *testing.T) {
 			map[string]string{
 				"foo.proto": "package fu.baz; message foobar{ repeated string a = 1 [default = \"abc\"]; }",
 			},
-			"file \"foo.proto\": default value cannot be set for field fu.baz.foobar.a because it is repeated",
+			"foo.proto:1:56: field fu.baz.foobar.a: default value cannot be set because field is repeated",
 		},
 		{
 			map[string]string{
 				"foo.proto": "package fu.baz; message foobar{ optional foobar a = 1 [default = { a: {} }]; }",
 			},
-			"file \"foo.proto\": default value cannot be set for field fu.baz.foobar.a because it is a message",
+			"foo.proto:1:56: field fu.baz.foobar.a: default value cannot be set because field is a message",
 		},
 		{
 			map[string]string{
 				"foo.proto": "package fu.baz; message foobar{ optional string a = 1 [default = { a: \"abc\" }]; }",
 			},
-			"file \"foo.proto\": default value for field fu.baz.foobar.a cannot be an aggregate",
+			"foo.proto:1:66: field fu.baz.foobar.a: default value cannot be an aggregate",
 		},
 		{
 			map[string]string{

--- a/desc/protoparse/linker_test.go
+++ b/desc/protoparse/linker_test.go
@@ -99,56 +99,56 @@ func TestLinkerValidation(t *testing.T) {
 			map[string]string{
 				"foo.proto": "message foo {} enum foo { V = 0; }",
 			},
-			"file \"foo.proto\": duplicate symbol foo: enum and message",
+			"foo.proto:1:16: duplicate symbol foo: already defined as message",
 		},
 		{
 			map[string]string{
 				"foo.proto": "message foo { optional string a = 1; optional string a = 2; }",
 			},
-			"file \"foo.proto\": duplicate symbol foo.a: field and field",
+			"foo.proto:1:38: duplicate symbol foo.a: already defined as field",
 		},
 		{
 			map[string]string{
 				"foo.proto":  "message foo {}",
 				"foo2.proto": "enum foo { V = 0; }",
 			},
-			"duplicate symbol foo: message in \"foo.proto\" and enum in \"foo2.proto\"",
+			"foo2.proto:1:1: duplicate symbol foo: already defined as message in \"foo.proto\"",
 		},
 		{
 			map[string]string{
 				"foo.proto": "message foo { optional blah a = 1; }",
 			},
-			"file \"foo.proto\": field foo.a references unknown type: blah",
+			"foo.proto:1:24: field foo.a: unknown type blah",
 		},
 		{
 			map[string]string{
 				"foo.proto": "message foo { optional bar.baz a = 1; } service bar { rpc baz (foo) returns (foo); }",
 			},
-			"file \"foo.proto\": field foo.a has invalid type: bar.baz is a method, not a message or enum",
+			"foo.proto:1:24: field foo.a: invalid type: bar.baz is a method, not a message or enum",
 		},
 		{
 			map[string]string{
 				"foo.proto": "message foo { extensions 1 to 2; } extend foo { optional string a = 1; } extend foo { optional int32 b = 1; }",
 			},
-			"file \"foo.proto\": duplicate extension for foo: a and b are both using tag 1",
+			"foo.proto:1:106: field b: duplicate extension: a and b are both using tag 1",
 		},
 		{
 			map[string]string{
 				"foo.proto": "package fu.baz; extend foobar { optional string a = 1; }",
 			},
-			"file \"foo.proto\": field fu.baz.a extends unknown type: foobar",
+			"foo.proto:1:24: unknown extendee type foobar",
 		},
 		{
 			map[string]string{
 				"foo.proto": "package fu.baz; service foobar{} extend foobar { optional string a = 1; }",
 			},
-			"file \"foo.proto\": field fu.baz.a extends invalid type: fu.baz.foobar is a service, not a message",
+			"foo.proto:1:41: extendee is invalid: fu.baz.foobar is a service, not a message",
 		},
 		{
 			map[string]string{
 				"foo.proto": "package fu.baz; message foobar{ extensions 1; } extend foobar { optional string a = 2; }",
 			},
-			"file \"foo.proto\": field fu.baz.a tag is not in valid range for extended type fu.baz.foobar: 2",
+			"foo.proto:1:85: field fu.baz.a: tag 2 is not in valid range for extended type fu.baz.foobar",
 		},
 		{
 			map[string]string{
@@ -156,7 +156,7 @@ func TestLinkerValidation(t *testing.T) {
 				"foo2.proto": "package fu.baz; import \"foo3.proto\"; message fizzle{ }",
 				"foo3.proto": "package fu.baz; message baz{ }",
 			},
-			"file \"foo.proto\": field fu.baz.foobar.a references unknown type: baz",
+			"foo.proto:1:70: field fu.baz.foobar.a: unknown type baz",
 		},
 		{
 			map[string]string{
@@ -180,31 +180,31 @@ func TestLinkerValidation(t *testing.T) {
 			map[string]string{
 				"foo.proto": "package fu.baz; message foobar{ optional string a = 1 [default = 1.234]; }",
 			},
-			"file \"foo.proto\": field fu.baz.foobar.a: option default: expecting string, got double",
+			"foo.proto:1:66: field fu.baz.foobar.a: option default: expecting string, got double",
 		},
 		{
 			map[string]string{
 				"foo.proto": "package fu.baz; enum abc { OK=0; NOK=1; } message foobar{ optional abc a = 1 [default = NACK]; }",
 			},
-			"file \"foo.proto\": field fu.baz.foobar.a: option default: enum fu.baz.abc has no value named NACK",
+			"foo.proto:1:89: field fu.baz.foobar.a: option default: enum fu.baz.abc has no value named NACK",
 		},
 		{
 			map[string]string{
 				"foo.proto": "option b = 123;",
 			},
-			"file \"foo.proto\": option b: field b of google.protobuf.FileOptions does not exist",
+			"foo.proto:1:8: option b: field b of google.protobuf.FileOptions does not exist",
 		},
 		{
 			map[string]string{
 				"foo.proto": "option (foo.bar) = 123;",
 			},
-			"file \"foo.proto\": option (foo.bar): unknown extension: foo.bar",
+			"foo.proto:1:8: unknown extension foo.bar",
 		},
 		{
 			map[string]string{
 				"foo.proto": "option uninterpreted_option = { };",
 			},
-			"file \"foo.proto\": invalid option 'uninterpreted_option'",
+			"foo.proto:1:8: invalid option 'uninterpreted_option'",
 		},
 		{
 			map[string]string{
@@ -214,7 +214,7 @@ func TestLinkerValidation(t *testing.T) {
 					"extend google.protobuf.FileOptions { optional foo f = 20000; }\n" +
 					"option (f).b = 123;",
 			},
-			"file \"foo.proto\": option (f).b: field b of foo does not exist",
+			"foo.proto:5:12: option (f).b: field b of foo does not exist",
 		},
 		{
 			map[string]string{
@@ -224,7 +224,7 @@ func TestLinkerValidation(t *testing.T) {
 					"extend google.protobuf.FileOptions { optional foo f = 20000; }\n" +
 					"option (f).a = 123;",
 			},
-			"file \"foo.proto\": option (f).a: expecting string, got integer",
+			"foo.proto:5:16: option (f).a: expecting string, got integer",
 		},
 		{
 			map[string]string{
@@ -234,7 +234,7 @@ func TestLinkerValidation(t *testing.T) {
 					"extend google.protobuf.FileOptions { optional foo f = 20000; }\n" +
 					"option (b) = 123;",
 			},
-			"file \"foo.proto\": option (b): extension b should extend google.protobuf.FileOptions but instead extends foo",
+			"foo.proto:5:8: option (b): extension b should extend google.protobuf.FileOptions but instead extends foo",
 		},
 		{
 			map[string]string{
@@ -244,7 +244,7 @@ func TestLinkerValidation(t *testing.T) {
 					"extend google.protobuf.FileOptions { optional foo f = 20000; }\n" +
 					"option (foo) = 123;",
 			},
-			"file \"foo.proto\": option (foo): invalid extension: foo is a message, not an extension",
+			"foo.proto:5:8: invalid extension: foo is a message, not an extension",
 		},
 		{
 			map[string]string{
@@ -254,7 +254,7 @@ func TestLinkerValidation(t *testing.T) {
 					"extend google.protobuf.FileOptions { optional foo f = 20000; }\n" +
 					"option (foo.a) = 123;",
 			},
-			"file \"foo.proto\": option (foo.a): invalid extension: foo.a is a field but not an extension",
+			"foo.proto:5:8: invalid extension: foo.a is a field but not an extension",
 		},
 		{
 			map[string]string{
@@ -264,7 +264,7 @@ func TestLinkerValidation(t *testing.T) {
 					"extend google.protobuf.FileOptions { optional foo f = 20000; }\n" +
 					"option (f) = { a: [ 123 ] };",
 			},
-			"file \"foo.proto\": option (f) at a: value is an array but field is not repeated",
+			"foo.proto:5:19: option (f): value is an array but field is not repeated",
 		},
 		{
 			map[string]string{
@@ -274,7 +274,7 @@ func TestLinkerValidation(t *testing.T) {
 					"extend google.protobuf.FileOptions { optional foo f = 20000; }\n" +
 					"option (f) = { a: [ \"a\", \"b\", 123 ] };",
 			},
-			"file \"foo.proto\": option (f) at a[2]: expecting string, got integer",
+			"foo.proto:5:31: option (f): expecting string, got integer",
 		},
 		{
 			map[string]string{
@@ -285,7 +285,7 @@ func TestLinkerValidation(t *testing.T) {
 					"option (f) = { a: \"a\" };\n" +
 					"option (f) = { a: \"b\" };",
 			},
-			"file \"foo.proto\": option (f): non-repeated option field f already set",
+			"foo.proto:6:8: option (f): non-repeated option field f already set",
 		},
 		{
 			map[string]string{
@@ -296,7 +296,7 @@ func TestLinkerValidation(t *testing.T) {
 					"option (f) = { a: \"a\" };\n" +
 					"option (f).a = \"b\";",
 			},
-			"file \"foo.proto\": option (f).a: non-repeated option field a already set",
+			"foo.proto:6:12: option (f).a: non-repeated option field a already set",
 		},
 		{
 			map[string]string{
@@ -307,7 +307,7 @@ func TestLinkerValidation(t *testing.T) {
 					"option (f) = { a: \"a\" };\n" +
 					"option (f).(b) = \"b\";",
 			},
-			"file \"foo.proto\": option (f).(b): expecting int32, got string/bytes",
+			"foo.proto:6:18: option (f).(b): expecting int32, got string",
 		},
 	}
 	for i, tc := range testCases {
@@ -324,7 +324,7 @@ func TestLinkerValidation(t *testing.T) {
 		}
 		_, err := Parser{Accessor: acc}.ParseFiles(names...)
 		if err == nil || !strings.Contains(err.Error(), tc.errMsg) {
-			t.Errorf("case %d: expecting validation error %q; instead got: %v", i, tc.errMsg, err)
+			t.Errorf("case %d: expecting validation error %q; instead got: %q", i, tc.errMsg, err)
 		}
 	}
 }

--- a/desc/protoparse/parser_test.go
+++ b/desc/protoparse/parser_test.go
@@ -172,39 +172,39 @@ func TestBasicValidation(t *testing.T) {
 	}{
 		{
 			contents: `syntax = "proto1";`,
-			errMsg:   `syntax value must be 'proto2' or 'proto3'`,
+			errMsg:   `test.proto:1:10: syntax value must be 'proto2' or 'proto3'`,
 		},
 		{
 			contents: `message Foo { optional string s = 5000000000; }`,
-			errMsg:   `higher than max allowed tag number`,
+			errMsg:   `test.proto:1:35: tag number 5000000000 is higher than max allowed tag number (536870911)`,
 		},
 		{
 			contents: `message Foo { optional string s = 19500; }`,
-			errMsg:   `in disallowed reserved range`,
+			errMsg:   `test.proto:1:35: tag number 19500 is in disallowed reserved range 19000-19999`,
 		},
 		{
 			contents: `enum Foo { V = 5000000000; }`,
-			errMsg:   `is out of range for int32`,
+			errMsg:   `test.proto:1:16: constant 5000000000 is out of range for int32 (-2147483648 to 2147483647)`,
 		},
 		{
 			contents: `enum Foo { V = -5000000000; }`,
-			errMsg:   `is out of range for int32`,
+			errMsg:   `test.proto:1:16: constant -5000000000 is out of range for int32 (-2147483648 to 2147483647)`,
 		},
 		{
 			contents: `enum Foo { }`,
-			errMsg:   `enums must define at least one value`,
+			errMsg:   `test.proto:1:1: enums must define at least one value`,
 		},
 		{
 			contents: `message Foo { oneof Bar { } }`,
-			errMsg:   `oneof must contain at least one field`,
+			errMsg:   `test.proto:1:15: oneof must contain at least one field`,
 		},
 		{
 			contents: `message Foo { extensions 1 to max; } extend Foo { }`,
-			errMsg:   `extend sections must define at least one extension`,
+			errMsg:   `test.proto:1:38: extend sections must define at least one extension`,
 		},
 		{
 			contents: `message Foo { option map_entry = true; }`,
-			errMsg:   `map_entry option should not be set explicitly; use map type instead`,
+			errMsg:   `test.proto:1:34: message Foo: map_entry option should not be set explicitly; use map type instead`,
 		},
 		{
 			contents: `message Foo { option map_entry = false; }`,
@@ -212,39 +212,39 @@ func TestBasicValidation(t *testing.T) {
 		},
 		{
 			contents: `syntax = "proto2"; message Foo { string s = 1; }`,
-			errMsg:   `field has no label, but proto2 must indicate 'optional' or 'required'`,
+			errMsg:   `test.proto:1:41: field Foo.s: field has no label, but proto2 must indicate 'optional' or 'required'`,
 		},
 		{
 			contents: `message Foo { string s = 1; }`, // syntax defaults to proto2
-			errMsg:   `field has no label, but proto2 must indicate 'optional' or 'required'`,
+			errMsg:   `test.proto:1:22: field Foo.s: field has no label, but proto2 must indicate 'optional' or 'required'`,
 		},
 		{
 			contents: `syntax = "proto3"; message Foo { optional string s = 1; }`,
-			errMsg:   `field has label LABEL_OPTIONAL, but proto3 should omit labels other than 'repeated'`,
+			errMsg:   `test.proto:1:34: field Foo.s: field has label LABEL_OPTIONAL, but proto3 should omit labels other than 'repeated'`,
 		},
 		{
 			contents: `syntax = "proto3"; message Foo { required string s = 1; }`,
-			errMsg:   `field has label LABEL_REQUIRED, but proto3 should omit labels other than 'repeated'`,
+			errMsg:   `test.proto:1:34: field Foo.s: field has label LABEL_REQUIRED, but proto3 should omit labels other than 'repeated'`,
 		},
 		{
 			contents: `message Foo { extensions 1 to max; } extend Foo { required string sss = 100; }`,
-			errMsg:   `extension fields cannot be 'required'`,
+			errMsg:   `test.proto:1:51: field sss: extension fields cannot be 'required'`,
 		},
 		{
 			contents: `syntax = "proto3"; message Foo { optional group Grp = 1 { } }`,
-			errMsg:   `groups are not allowed in proto3`,
+			errMsg:   `test.proto:1:43: field Foo.grp: groups are not allowed in proto3`,
 		},
 		{
 			contents: `syntax = "proto3"; message Foo { extensions 1 to max; }`,
-			errMsg:   `extension ranges are not allowed in proto3`,
+			errMsg:   `test.proto:1:45: message Foo: extension ranges are not allowed in proto3`,
 		},
 		{
 			contents: `syntax = "proto3"; message Foo { string s = 1 [default = "abcdef"]; }`,
-			errMsg:   `default values are not allowed in proto3`,
+			errMsg:   `test.proto:1:48: field Foo.s: default values are not allowed in proto3`,
 		},
 		{
 			contents: `enum Foo { V1 = 1; V2 = 1; }`,
-			errMsg:   `values V1 and V2 both have the same numeric value 1; use allow_alias option if intentional`,
+			errMsg:   `test.proto:1:25: enum Foo: values V1 and V2 both have the same numeric value 1; use allow_alias option if intentional`,
 		},
 		{
 			contents: `enum Foo { option allow_alias = true; V1 = 1; V2 = 1; }`,
@@ -252,23 +252,23 @@ func TestBasicValidation(t *testing.T) {
 		},
 		{
 			contents: `syntax = "proto3"; enum Foo { FIRST = 1; }`,
-			errMsg:   `proto3 requires that first value in enum have numeric value of 0`,
+			errMsg:   `test.proto:1:39: enum Foo: proto3 requires that first value in enum have numeric value of 0`,
 		},
 		{
 			contents: `syntax = "proto3"; message Foo { string s = 1; int32 i = 1; }`,
-			errMsg:   `fields s and i both have the same tag 1`,
+			errMsg:   `test.proto:1:58: message Foo: fields s and i both have the same tag 1`,
 		},
 		{
 			contents: `message Foo { reserved 1 to 10, 10 to 12; }`,
-			errMsg:   `reserved ranges overlap: 1 to 10 and 10 to 12`,
+			errMsg:   `test.proto:1:33: message Foo: reserved ranges overlap: 1 to 10 and 10 to 12`,
 		},
 		{
 			contents: `message Foo { extensions 1 to 10, 10 to 12; }`,
-			errMsg:   `extension ranges overlap: 1 to 10 and 10 to 12`,
+			errMsg:   `test.proto:1:35: message Foo: extension ranges overlap: 1 to 10 and 10 to 12`,
 		},
 		{
 			contents: `message Foo { reserved 1 to 10; extensions 10 to 12; }`,
-			errMsg:   `extension range 10 to 12 overlaps reserved range 1 to 10`,
+			errMsg:   `test.proto:1:44: message Foo: extension range 10 to 12 overlaps reserved range 1 to 10`,
 		},
 		{
 			contents: `message Foo { reserved 1, 2 to 10, 11 to 20; extensions 21 to 22; }`,
@@ -276,43 +276,43 @@ func TestBasicValidation(t *testing.T) {
 		},
 		{
 			contents: `message Foo { reserved 10 to 1; }`,
-			errMsg:   `range, 10 to 1, is invalid: start must be <= end`,
+			errMsg:   `test.proto:1:24: range, 10 to 1, is invalid: start must be <= end`,
 		},
 		{
 			contents: `message Foo { extensions 10 to 1; }`,
-			errMsg:   `range, 10 to 1, is invalid: start must be <= end`,
+			errMsg:   `test.proto:1:26: range, 10 to 1, is invalid: start must be <= end`,
 		},
 		{
 			contents: `message Foo { reserved 1 to 5000000000; }`,
-			errMsg:   `range end is out-of-range tag`,
+			errMsg:   `test.proto:1:29: range end is out-of-range tag: 5000000000 (should be between 0 and 536870911)`,
 		},
 		{
 			contents: `message Foo { extensions 1000000000; }`,
-			errMsg:   `range includes out-of-range tag`,
+			errMsg:   `test.proto:1:26: range includes out-of-range tag: 1000000000 (should be between 0 and 536870911)`,
 		},
 		{
 			contents: `message Foo { extensions 1000000000 to 1000000001; }`,
-			errMsg:   `range start is out-of-range tag`,
+			errMsg:   `test.proto:1:26: range start is out-of-range tag: 1000000000 (should be between 0 and 536870911)`,
 		},
 		{
 			contents: `message Foo { extensions 1000000000 to 1000000001; }`,
-			errMsg:   `range start is out-of-range tag`,
+			errMsg:   `test.proto:1:26: range start is out-of-range tag: 1000000000 (should be between 0 and 536870911)`,
 		},
 		{
 			contents: `message Foo { reserved "foo", "foo"; }`,
-			errMsg:   `field "foo" is reserved multiple times`,
+			errMsg:   `test.proto:1:31: field "foo" is reserved multiple times`,
 		},
 		{
 			contents: `message Foo { reserved "foo"; optional string foo = 1; }`,
-			errMsg:   `field foo is using a reserved name`,
+			errMsg:   `test.proto:1:47: message Foo: field foo is using a reserved name`,
 		},
 		{
 			contents: `message Foo { reserved 1 to 10; optional string foo = 1; }`,
-			errMsg:   `field foo is using tag 1 which is in reserved range 1 to 10`,
+			errMsg:   `test.proto:1:55: message Foo: field foo is using tag 1 which is in reserved range 1 to 10`,
 		},
 		{
 			contents: `message Foo { extensions 1 to 10; optional string foo = 1; }`,
-			errMsg:   `field foo is using tag 1 which is in extension range 1 to 10`,
+			errMsg:   `test.proto:1:57: message Foo: field foo is using tag 1 which is in extension range 1 to 10`,
 		},
 	}
 
@@ -322,7 +322,7 @@ func TestBasicValidation(t *testing.T) {
 			testutil.Ok(t, err, "case #%d should succeed", i)
 		} else {
 			testutil.Require(t, err != nil, "case #%d should fail", i)
-			testutil.Require(t, strings.Contains(err.Error(), tc.errMsg), "case #%d should contain %q but does not: %q", i, tc.errMsg, err.Error())
+			testutil.Eq(t, tc.errMsg, err.Error(), "case #%d bad error message", i)
 		}
 	}
 }

--- a/desc/protoparse/proto.y
+++ b/desc/protoparse/proto.y
@@ -385,48 +385,48 @@ typeIdent : ident
 	| _TYPENAME
 
 field : _REQUIRED typeIdent name '=' _INT_LIT ';' {
-		checkTag(protolex, $5.val)
+		checkTag(protolex, $5.start(), $5.val)
 		lbl := &labelNode{basicNode: $1.basicNode, required: true}
 		$$ = &fieldNode{label: lbl, fldType: $2, name: $3, tag: $5}
 		$$.setRange($1, $6)
 	}
 	| _OPTIONAL typeIdent name '=' _INT_LIT ';' {
-		checkTag(protolex, $5.val)
+		checkTag(protolex, $5.start(), $5.val)
 		lbl := &labelNode{basicNode: $1.basicNode}
 		$$ = &fieldNode{label: lbl, fldType: $2, name: $3, tag: $5}
 		$$.setRange($1, $6)
 	}
 	| _REPEATED typeIdent name '=' _INT_LIT ';' {
-		checkTag(protolex, $5.val)
+		checkTag(protolex, $5.start(), $5.val)
 		lbl := &labelNode{basicNode: $1.basicNode, repeated: true}
 		$$ = &fieldNode{label: lbl, fldType: $2, name: $3, tag: $5}
 		$$.setRange($1, $6)
 	}
 	| typeIdent name '=' _INT_LIT ';' {
-		checkTag(protolex, $4.val)
+		checkTag(protolex, $4.start(), $4.val)
 		$$ = &fieldNode{fldType: $1, name: $2, tag: $4}
 		$$.setRange($1, $5)
 	}
 	| _REQUIRED typeIdent name '=' _INT_LIT '[' fieldOptions ']' ';' {
-		checkTag(protolex, $5.val)
+		checkTag(protolex, $5.start(), $5.val)
 		lbl := &labelNode{basicNode: $1.basicNode, required: true}
 		$$ = &fieldNode{label: lbl, fldType: $2, name: $3, tag: $5, options: $7}
 		$$.setRange($1, $9)
 	}
 	| _OPTIONAL typeIdent name '=' _INT_LIT '[' fieldOptions ']' ';' {
-		checkTag(protolex, $5.val)
+		checkTag(protolex, $5.start(), $5.val)
 		lbl := &labelNode{basicNode: $1.basicNode}
 		$$ = &fieldNode{label: lbl, fldType: $2, name: $3, tag: $5, options: $7}
 		$$.setRange($1, $9)
 	}
 	| _REPEATED typeIdent name '=' _INT_LIT '[' fieldOptions ']' ';' {
-		checkTag(protolex, $5.val)
+		checkTag(protolex, $5.start(), $5.val)
 		lbl := &labelNode{basicNode: $1.basicNode, repeated: true}
 		$$ = &fieldNode{label: lbl, fldType: $2, name: $3, tag: $5, options: $7}
 		$$.setRange($1, $9)
 	}
 	| typeIdent name '=' _INT_LIT '[' fieldOptions ']' ';' {
-		checkTag(protolex, $4.val)
+		checkTag(protolex, $4.start(), $4.val)
 		$$ = &fieldNode{fldType: $1, name: $2, tag: $4, options: $6}
 		$$.setRange($1, $8)
 	}
@@ -445,30 +445,30 @@ fieldOption: optionName '=' constant {
 	}
 
 group : _REQUIRED _GROUP name '=' _INT_LIT '{' messageBody '}' {
-		checkTag(protolex, $5.val)
+		checkTag(protolex, $5.start(), $5.val)
 		if !unicode.IsUpper(rune($3.val[0])) {
 			lexError(protolex, $3.start(), fmt.Sprintf("group %s should have a name that starts with a capital letter", $3.val))
 		}
 		lbl := &labelNode{basicNode: $1.basicNode, required: true}
-		$$ = &groupNode{label: lbl, name: $3, tag: $5, decls: $7}
+		$$ = &groupNode{groupKeyword: $2, label: lbl, name: $3, tag: $5, decls: $7}
 		$$.setRange($1, $8)
 	}
 	| _OPTIONAL _GROUP name '=' _INT_LIT '{' messageBody '}' {
-		checkTag(protolex, $5.val)
+		checkTag(protolex, $5.start(), $5.val)
 		if !unicode.IsUpper(rune($3.val[0])) {
 			lexError(protolex, $3.start(), fmt.Sprintf("group %s should have a name that starts with a capital letter", $3.val))
 		}
 		lbl := &labelNode{basicNode: $1.basicNode}
-		$$ = &groupNode{label: lbl, name: $3, tag: $5, decls: $7}
+		$$ = &groupNode{groupKeyword: $2, label: lbl, name: $3, tag: $5, decls: $7}
 		$$.setRange($1, $8)
 	}
 	| _REPEATED _GROUP name '=' _INT_LIT '{' messageBody '}' {
-		checkTag(protolex, $5.val)
+		checkTag(protolex, $5.start(), $5.val)
 		if !unicode.IsUpper(rune($3.val[0])) {
 			lexError(protolex, $3.start(), fmt.Sprintf("group %s should have a name that starts with a capital letter", $3.val))
 		}
 		lbl := &labelNode{basicNode: $1.basicNode, repeated: true}
-		$$ = &groupNode{label: lbl, name: $3, tag: $5, decls: $7}
+		$$ = &groupNode{groupKeyword: $2, label: lbl, name: $3, tag: $5, decls: $7}
 		$$.setRange($1, $8)
 	}
 
@@ -505,23 +505,23 @@ oneofItem : option {
 	}
 
 oneofField : typeIdent name '=' _INT_LIT ';' {
-		checkTag(protolex, $4.val)
+		checkTag(protolex, $4.start(), $4.val)
 		$$ = &fieldNode{fldType: $1, name: $2, tag: $4}
 		$$.setRange($1, $5)
 	}
 	| typeIdent name '=' _INT_LIT '[' fieldOptions ']' ';' {
-		checkTag(protolex, $4.val)
+		checkTag(protolex, $4.start(), $4.val)
 		$$ = &fieldNode{fldType: $1, name: $2, tag: $4, options: $6}
 		$$.setRange($1, $8)
 	}
 
 mapField : _MAP '<' keyType ',' typeIdent '>' name '=' _INT_LIT ';' {
-		checkTag(protolex, $9.val)
+		checkTag(protolex, $9.start(), $9.val)
 		$$ = &mapFieldNode{mapKeyword: $1, keyType: $3, valueType: $5, name: $7, tag: $9}
 		$$.setRange($1, $10)
 	}
 	| _MAP '<' keyType ',' typeIdent '>' name '=' _INT_LIT '[' fieldOptions ']' ';' {
-		checkTag(protolex, $9.val)
+		checkTag(protolex, $9.start(), $9.val)
 		$$ = &mapFieldNode{mapKeyword: $1, keyType: $3, valueType: $5, name: $7, tag: $9, options: $11}
 		$$.setRange($1, $13)
 	}
@@ -642,22 +642,22 @@ enumItem : option {
 	}
 
 enumField : name '=' intLit ';' {
-		checkUint64InInt32Range(protolex, $3.val)
+		checkUint64InInt32Range(protolex, $3.start(), $3.val)
 		$$ = &enumValueNode{name: $1, number: $3}
 		$$.setRange($1, $4)
 	}
 	|  name '=' intLit '[' fieldOptions ']' ';' {
-		checkUint64InInt32Range(protolex, $3.val)
+		checkUint64InInt32Range(protolex, $3.start(), $3.val)
 		$$ = &enumValueNode{name: $1, number: $3, options: $5}
 		$$.setRange($1, $7)
 	}
 	| name '=' negIntLit ';' {
-		checkInt64InInt32Range(protolex, $3.val)
+		checkInt64InInt32Range(protolex, $3.start(), $3.val)
 		$$ = &enumValueNode{name: $1, numberN: $3}
 		$$.setRange($1, $4)
 	}
 	|  name '=' negIntLit '[' fieldOptions ']' ';' {
-		checkInt64InInt32Range(protolex, $3.val)
+		checkInt64InInt32Range(protolex, $3.start(), $3.val)
 		$$ = &enumValueNode{name: $1, numberN: $3, options: $5}
 		$$.setRange($1, $7)
 	}

--- a/desc/protoparse/proto.y.go
+++ b/desc/protoparse/proto.y.go
@@ -1312,7 +1312,7 @@ protodefault:
 		protoDollar = protoS[protopt-6 : protopt+1]
 		//line proto.y:387
 		{
-			checkTag(protolex, protoDollar[5].ui.val)
+			checkTag(protolex, protoDollar[5].ui.start(), protoDollar[5].ui.val)
 			lbl := &labelNode{basicNode: protoDollar[1].id.basicNode, required: true}
 			protoVAL.fld = &fieldNode{label: lbl, fldType: protoDollar[2].id, name: protoDollar[3].id, tag: protoDollar[5].ui}
 			protoVAL.fld.setRange(protoDollar[1].id, protoDollar[6].b)
@@ -1321,7 +1321,7 @@ protodefault:
 		protoDollar = protoS[protopt-6 : protopt+1]
 		//line proto.y:393
 		{
-			checkTag(protolex, protoDollar[5].ui.val)
+			checkTag(protolex, protoDollar[5].ui.start(), protoDollar[5].ui.val)
 			lbl := &labelNode{basicNode: protoDollar[1].id.basicNode}
 			protoVAL.fld = &fieldNode{label: lbl, fldType: protoDollar[2].id, name: protoDollar[3].id, tag: protoDollar[5].ui}
 			protoVAL.fld.setRange(protoDollar[1].id, protoDollar[6].b)
@@ -1330,7 +1330,7 @@ protodefault:
 		protoDollar = protoS[protopt-6 : protopt+1]
 		//line proto.y:399
 		{
-			checkTag(protolex, protoDollar[5].ui.val)
+			checkTag(protolex, protoDollar[5].ui.start(), protoDollar[5].ui.val)
 			lbl := &labelNode{basicNode: protoDollar[1].id.basicNode, repeated: true}
 			protoVAL.fld = &fieldNode{label: lbl, fldType: protoDollar[2].id, name: protoDollar[3].id, tag: protoDollar[5].ui}
 			protoVAL.fld.setRange(protoDollar[1].id, protoDollar[6].b)
@@ -1339,7 +1339,7 @@ protodefault:
 		protoDollar = protoS[protopt-5 : protopt+1]
 		//line proto.y:405
 		{
-			checkTag(protolex, protoDollar[4].ui.val)
+			checkTag(protolex, protoDollar[4].ui.start(), protoDollar[4].ui.val)
 			protoVAL.fld = &fieldNode{fldType: protoDollar[1].id, name: protoDollar[2].id, tag: protoDollar[4].ui}
 			protoVAL.fld.setRange(protoDollar[1].id, protoDollar[5].b)
 		}
@@ -1347,7 +1347,7 @@ protodefault:
 		protoDollar = protoS[protopt-9 : protopt+1]
 		//line proto.y:410
 		{
-			checkTag(protolex, protoDollar[5].ui.val)
+			checkTag(protolex, protoDollar[5].ui.start(), protoDollar[5].ui.val)
 			lbl := &labelNode{basicNode: protoDollar[1].id.basicNode, required: true}
 			protoVAL.fld = &fieldNode{label: lbl, fldType: protoDollar[2].id, name: protoDollar[3].id, tag: protoDollar[5].ui, options: protoDollar[7].opts}
 			protoVAL.fld.setRange(protoDollar[1].id, protoDollar[9].b)
@@ -1356,7 +1356,7 @@ protodefault:
 		protoDollar = protoS[protopt-9 : protopt+1]
 		//line proto.y:416
 		{
-			checkTag(protolex, protoDollar[5].ui.val)
+			checkTag(protolex, protoDollar[5].ui.start(), protoDollar[5].ui.val)
 			lbl := &labelNode{basicNode: protoDollar[1].id.basicNode}
 			protoVAL.fld = &fieldNode{label: lbl, fldType: protoDollar[2].id, name: protoDollar[3].id, tag: protoDollar[5].ui, options: protoDollar[7].opts}
 			protoVAL.fld.setRange(protoDollar[1].id, protoDollar[9].b)
@@ -1365,7 +1365,7 @@ protodefault:
 		protoDollar = protoS[protopt-9 : protopt+1]
 		//line proto.y:422
 		{
-			checkTag(protolex, protoDollar[5].ui.val)
+			checkTag(protolex, protoDollar[5].ui.start(), protoDollar[5].ui.val)
 			lbl := &labelNode{basicNode: protoDollar[1].id.basicNode, repeated: true}
 			protoVAL.fld = &fieldNode{label: lbl, fldType: protoDollar[2].id, name: protoDollar[3].id, tag: protoDollar[5].ui, options: protoDollar[7].opts}
 			protoVAL.fld.setRange(protoDollar[1].id, protoDollar[9].b)
@@ -1374,7 +1374,7 @@ protodefault:
 		protoDollar = protoS[protopt-8 : protopt+1]
 		//line proto.y:428
 		{
-			checkTag(protolex, protoDollar[4].ui.val)
+			checkTag(protolex, protoDollar[4].ui.start(), protoDollar[4].ui.val)
 			protoVAL.fld = &fieldNode{fldType: protoDollar[1].id, name: protoDollar[2].id, tag: protoDollar[4].ui, options: protoDollar[6].opts}
 			protoVAL.fld.setRange(protoDollar[1].id, protoDollar[8].b)
 		}
@@ -1398,36 +1398,36 @@ protodefault:
 		protoDollar = protoS[protopt-8 : protopt+1]
 		//line proto.y:447
 		{
-			checkTag(protolex, protoDollar[5].ui.val)
+			checkTag(protolex, protoDollar[5].ui.start(), protoDollar[5].ui.val)
 			if !unicode.IsUpper(rune(protoDollar[3].id.val[0])) {
 				lexError(protolex, protoDollar[3].id.start(), fmt.Sprintf("group %s should have a name that starts with a capital letter", protoDollar[3].id.val))
 			}
 			lbl := &labelNode{basicNode: protoDollar[1].id.basicNode, required: true}
-			protoVAL.grp = &groupNode{label: lbl, name: protoDollar[3].id, tag: protoDollar[5].ui, decls: protoDollar[7].msgDecls}
+			protoVAL.grp = &groupNode{groupKeyword: protoDollar[2].id, label: lbl, name: protoDollar[3].id, tag: protoDollar[5].ui, decls: protoDollar[7].msgDecls}
 			protoVAL.grp.setRange(protoDollar[1].id, protoDollar[8].b)
 		}
 	case 77:
 		protoDollar = protoS[protopt-8 : protopt+1]
 		//line proto.y:456
 		{
-			checkTag(protolex, protoDollar[5].ui.val)
+			checkTag(protolex, protoDollar[5].ui.start(), protoDollar[5].ui.val)
 			if !unicode.IsUpper(rune(protoDollar[3].id.val[0])) {
 				lexError(protolex, protoDollar[3].id.start(), fmt.Sprintf("group %s should have a name that starts with a capital letter", protoDollar[3].id.val))
 			}
 			lbl := &labelNode{basicNode: protoDollar[1].id.basicNode}
-			protoVAL.grp = &groupNode{label: lbl, name: protoDollar[3].id, tag: protoDollar[5].ui, decls: protoDollar[7].msgDecls}
+			protoVAL.grp = &groupNode{groupKeyword: protoDollar[2].id, label: lbl, name: protoDollar[3].id, tag: protoDollar[5].ui, decls: protoDollar[7].msgDecls}
 			protoVAL.grp.setRange(protoDollar[1].id, protoDollar[8].b)
 		}
 	case 78:
 		protoDollar = protoS[protopt-8 : protopt+1]
 		//line proto.y:465
 		{
-			checkTag(protolex, protoDollar[5].ui.val)
+			checkTag(protolex, protoDollar[5].ui.start(), protoDollar[5].ui.val)
 			if !unicode.IsUpper(rune(protoDollar[3].id.val[0])) {
 				lexError(protolex, protoDollar[3].id.start(), fmt.Sprintf("group %s should have a name that starts with a capital letter", protoDollar[3].id.val))
 			}
 			lbl := &labelNode{basicNode: protoDollar[1].id.basicNode, repeated: true}
-			protoVAL.grp = &groupNode{label: lbl, name: protoDollar[3].id, tag: protoDollar[5].ui, decls: protoDollar[7].msgDecls}
+			protoVAL.grp = &groupNode{groupKeyword: protoDollar[2].id, label: lbl, name: protoDollar[3].id, tag: protoDollar[5].ui, decls: protoDollar[7].msgDecls}
 			protoVAL.grp.setRange(protoDollar[1].id, protoDollar[8].b)
 		}
 	case 79:
@@ -1480,7 +1480,7 @@ protodefault:
 		protoDollar = protoS[protopt-5 : protopt+1]
 		//line proto.y:507
 		{
-			checkTag(protolex, protoDollar[4].ui.val)
+			checkTag(protolex, protoDollar[4].ui.start(), protoDollar[4].ui.val)
 			protoVAL.fld = &fieldNode{fldType: protoDollar[1].id, name: protoDollar[2].id, tag: protoDollar[4].ui}
 			protoVAL.fld.setRange(protoDollar[1].id, protoDollar[5].b)
 		}
@@ -1488,7 +1488,7 @@ protodefault:
 		protoDollar = protoS[protopt-8 : protopt+1]
 		//line proto.y:512
 		{
-			checkTag(protolex, protoDollar[4].ui.val)
+			checkTag(protolex, protoDollar[4].ui.start(), protoDollar[4].ui.val)
 			protoVAL.fld = &fieldNode{fldType: protoDollar[1].id, name: protoDollar[2].id, tag: protoDollar[4].ui, options: protoDollar[6].opts}
 			protoVAL.fld.setRange(protoDollar[1].id, protoDollar[8].b)
 		}
@@ -1496,7 +1496,7 @@ protodefault:
 		protoDollar = protoS[protopt-10 : protopt+1]
 		//line proto.y:518
 		{
-			checkTag(protolex, protoDollar[9].ui.val)
+			checkTag(protolex, protoDollar[9].ui.start(), protoDollar[9].ui.val)
 			protoVAL.mapFld = &mapFieldNode{mapKeyword: protoDollar[1].id, keyType: protoDollar[3].id, valueType: protoDollar[5].id, name: protoDollar[7].id, tag: protoDollar[9].ui}
 			protoVAL.mapFld.setRange(protoDollar[1].id, protoDollar[10].b)
 		}
@@ -1504,7 +1504,7 @@ protodefault:
 		protoDollar = protoS[protopt-13 : protopt+1]
 		//line proto.y:523
 		{
-			checkTag(protolex, protoDollar[9].ui.val)
+			checkTag(protolex, protoDollar[9].ui.start(), protoDollar[9].ui.val)
 			protoVAL.mapFld = &mapFieldNode{mapKeyword: protoDollar[1].id, keyType: protoDollar[3].id, valueType: protoDollar[5].id, name: protoDollar[7].id, tag: protoDollar[9].ui, options: protoDollar[11].opts}
 			protoVAL.mapFld.setRange(protoDollar[1].id, protoDollar[13].b)
 		}
@@ -1652,7 +1652,7 @@ protodefault:
 		protoDollar = protoS[protopt-4 : protopt+1]
 		//line proto.y:644
 		{
-			checkUint64InInt32Range(protolex, protoDollar[3].ui.val)
+			checkUint64InInt32Range(protolex, protoDollar[3].ui.start(), protoDollar[3].ui.val)
 			protoVAL.env = &enumValueNode{name: protoDollar[1].id, number: protoDollar[3].ui}
 			protoVAL.env.setRange(protoDollar[1].id, protoDollar[4].b)
 		}
@@ -1660,7 +1660,7 @@ protodefault:
 		protoDollar = protoS[protopt-7 : protopt+1]
 		//line proto.y:649
 		{
-			checkUint64InInt32Range(protolex, protoDollar[3].ui.val)
+			checkUint64InInt32Range(protolex, protoDollar[3].ui.start(), protoDollar[3].ui.val)
 			protoVAL.env = &enumValueNode{name: protoDollar[1].id, number: protoDollar[3].ui, options: protoDollar[5].opts}
 			protoVAL.env.setRange(protoDollar[1].id, protoDollar[7].b)
 		}
@@ -1668,7 +1668,7 @@ protodefault:
 		protoDollar = protoS[protopt-4 : protopt+1]
 		//line proto.y:654
 		{
-			checkInt64InInt32Range(protolex, protoDollar[3].i.val)
+			checkInt64InInt32Range(protolex, protoDollar[3].i.start(), protoDollar[3].i.val)
 			protoVAL.env = &enumValueNode{name: protoDollar[1].id, numberN: protoDollar[3].i}
 			protoVAL.env.setRange(protoDollar[1].id, protoDollar[4].b)
 		}
@@ -1676,7 +1676,7 @@ protodefault:
 		protoDollar = protoS[protopt-7 : protopt+1]
 		//line proto.y:659
 		{
-			checkInt64InInt32Range(protolex, protoDollar[3].i.val)
+			checkInt64InInt32Range(protolex, protoDollar[3].i.start(), protoDollar[3].i.val)
 			protoVAL.env = &enumValueNode{name: protoDollar[1].id, numberN: protoDollar[3].i, options: protoDollar[5].opts}
 			protoVAL.env.setRange(protoDollar[1].id, protoDollar[7].b)
 		}

--- a/desc/protoparse/test_pb_test.go
+++ b/desc/protoparse/test_pb_test.go
@@ -132,7 +132,7 @@ func (*Test) ExtensionRangeArray() []proto.ExtensionRange {
 	return extRange_Test
 }
 
-var Default_Test_B []byte = []byte("\x00\x01\x02\x03\x04\x05\x06\afubar!")
+var Default_Test_B []byte = []byte("\\000\\001\\002\\003\\004\\005\\006\\007fubar!")
 
 func (m *Test) GetFoo() string {
 	if m != nil && m.Foo != nil {


### PR DESCRIPTION
This is a continuation of #73 -- it makes use of source position info throughout the parsing and linking steps to provide better error messages.

The next step is to actually use this source position info to construct the `source_code_info` field of the result file descriptors.