### PR TITLE
fix dynamic message merging

### DIFF
--- a/dynamic/binary.go
+++ b/dynamic/binary.go
@@ -581,40 +581,7 @@ func (m *Message) unmarshalKnownField(fd *desc.FieldDescriptor, encoding int8, b
 		return err
 	}
 
-	if fd.IsMap() {
-		newEntry := val.(*Message)
-		k, err := newEntry.TryGetFieldByNumber(1)
-		if err != nil {
-			return err
-		}
-		v, err := newEntry.TryGetFieldByNumber(2)
-		if err != nil {
-			return err
-		}
-		if existing, ok := m.values[fd.GetNumber()]; ok {
-			mp := existing.(map[interface{}]interface{})
-			mp[k] = v
-		} else {
-			m.internalSetField(fd, map[interface{}]interface{}{k: v})
-		}
-	} else if fd.IsRepeated() {
-		t := reflect.TypeOf(val)
-		var slice []interface{}
-		if existing, ok := m.values[fd.GetNumber()]; ok {
-			slice = existing.([]interface{})
-		}
-		if t.Kind() == reflect.Slice && t != typeOfBytes {
-			// append slices if we unmarshalled a packed repeated field
-			sl := val.([]interface{})
-			slice = append(slice, sl...)
-		} else {
-			slice = append(slice, val)
-		}
-		m.internalSetField(fd, slice)
-	} else {
-		m.internalSetField(fd, val)
-	}
-	return nil
+	return mergeField(m, fd, val)
 }
 
 func (m *Message) unmarshalUnknownField(tagNumber int32, encoding int8, b *codedBuffer) error {

--- a/dynamic/json.go
+++ b/dynamic/json.go
@@ -422,7 +422,9 @@ func (m *Message) unmarshalJson(r *jsReader, opts *jsonpb.Unmarshaler) error {
 			return err
 		}
 		if v != nil {
-			m.internalSetField(fd, v)
+			if err := mergeField(m, fd, v); err != nil {
+				return err
+			}
 		} else if m.values != nil {
 			delete(m.values, fd.GetNumber())
 		}

--- a/dynamic/merge.go
+++ b/dynamic/merge.go
@@ -1,0 +1,106 @@
+package dynamic
+
+import (
+	"errors"
+	"reflect"
+
+	"github.com/golang/protobuf/proto"
+
+	"github.com/jhump/protoreflect/desc"
+)
+
+// Merge merges the given source message into the given destination message. Use this instead of proto.Merge
+// when one or both of the messages might be a dynamic message. If there is a problem merging the messages,
+// such as the two messages having different types, then this method will panic (just as proto.Merges does).
+func Merge(dst, src proto.Message) {
+	if dm, ok := dst.(*Message); ok {
+		if err := dm.MergeFrom(src); err != nil {
+			panic(err.Error())
+		}
+	} else if dm, ok := src.(*Message); ok {
+		if err := dm.MergeInto(dst); err != nil {
+			panic(err.Error())
+		}
+	} else {
+		proto.Merge(dst, src)
+	}
+}
+
+func TryMerge(dst, src proto.Message) error {
+	if dm, ok := dst.(*Message); ok {
+		if err := dm.MergeFrom(src); err != nil {
+			return err
+		}
+	} else if dm, ok := src.(*Message); ok {
+		if err := dm.MergeInto(dst); err != nil {
+			return err
+		}
+	} else {
+		// proto.Merge panics on bad input, so we first verify
+		// inputs and return error instead of panic
+		out := reflect.ValueOf(dst)
+		if out.IsNil() {
+			return errors.New("proto: nil destination")
+		}
+		in := reflect.ValueOf(src)
+		if in.Type() != out.Type() {
+			return errors.New("proto: type mismatch")
+		}
+		proto.Merge(dst, src)
+	}
+	return nil
+}
+
+func mergeField(m *Message, fd *desc.FieldDescriptor, val interface{}) error {
+	rv := reflect.ValueOf(val)
+
+	if fd.IsMap() && rv.Kind() == reflect.Map {
+		for _, k := range rv.MapKeys() {
+			if k.Kind() == reflect.Interface && !k.IsNil() {
+				k = k.Elem()
+			}
+			v := rv.MapIndex(k)
+			if v.Kind() == reflect.Interface && !v.IsNil() {
+				v = v.Elem()
+			}
+			if err := m.putMapField(fd, k.Interface(), v.Interface()); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	if fd.IsRepeated() && rv.Kind() == reflect.Slice && rv.Type() != typeOfBytes {
+		for i := 0; i < rv.Len(); i++ {
+			e := rv.Index(i)
+			if e.Kind() == reflect.Interface && !e.IsNil() {
+				e = e.Elem()
+			}
+			if err := m.addRepeatedField(fd, e.Interface()); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	if fd.IsRepeated() {
+		return m.addRepeatedField(fd, val)
+	} else if fd.GetMessageType() == nil {
+		return m.setField(fd, val)
+	}
+
+	// it's a message type, so we want to merge contents
+	var err error
+	if val, err = validFieldValue(fd, val); err != nil {
+		return err
+	}
+
+	existing, _ := m.doGetField(fd, true)
+	if existing != nil && !reflect.ValueOf(existing).IsNil() {
+		return TryMerge(existing.(proto.Message), val.(proto.Message))
+	}
+
+	// no existing message, so just set field
+	m.internalSetField(fd, val)
+	return nil
+}

--- a/dynamic/text.go
+++ b/dynamic/text.go
@@ -569,17 +569,12 @@ func textError(tok *token, format string, args ...interface{}) error {
 
 type setFunction func(*Message, *desc.FieldDescriptor, interface{}) error
 
-var (
-	setUnaryField    = (*Message).TrySetField
-	setRepeatedField = (*Message).TryAddRepeatedField
-)
-
 func (m *Message) unmarshalFieldValueText(fd *desc.FieldDescriptor, tr *txtReader) error {
 	var set setFunction
 	if fd.IsRepeated() {
-		set = setRepeatedField
+		set = (*Message).addRepeatedField
 	} else {
-		set = setUnaryField
+		set = mergeField
 	}
 	tok := tr.peek()
 	if tok.tokTyp == tokenOpenBracket {


### PR DESCRIPTION
This fixes several issues with merging of dynamic messages. When merging data into a message, only scalar fields should be overwritten. Message fields should be recursively merged, and repeated fields should be merged via union. When merging map fields that have overlapping keys, values in the merge source should replace values with the corresponding key in the merge target.

This logic was not properly implemented in the various `UnmarshalMerge*` forms. Similarly, merging one message into another (via `*dynamic.Message.MergeFrom` and `*dynamic.Message.MergeInto`) was not correctly implemented. In some cases, message fields were replaced instead of merged, and in one case (JSON de-serialization) repeated fields were also replaced instead of merged.

There was another bug in merging a `proto.Message` into `*dynamic.Message`: there was code meant to handle the case where a `proto.Message` has unknown extensions that the dynamic message (and its associated extension registry) might know about. But it was totally broken and effectively doing nothing (other than burning CPU cycles).