### PR TITLE
make tests pass against 'dev' branch of golang/protobuf repo

### DIFF
--- a/dynamic/json_test.go
+++ b/dynamic/json_test.go
@@ -347,11 +347,11 @@ func TestJSONWellKnownType(t *testing.T) {
 	// right value and type (e.g. generated well-known-type, not dynamic message)
 	ts, ok := dm.GetFieldByNumber(1).(*timestamp.Timestamp)
 	testutil.Require(t, ok)
-	testutil.Eq(t, *wkts.StartTime, *ts)
+	testutil.Ceq(t, wkts.StartTime, ts, eqpm)
 
 	dur, ok := dm.GetFieldByNumber(2).(*duration.Duration)
 	testutil.Require(t, ok)
-	testutil.Eq(t, *wkts.Elapsed, *dur)
+	testutil.Ceq(t, wkts.Elapsed, dur, eqpm)
 
 	dbl, ok := dm.GetFieldByNumber(3).(*wrappers.DoubleValue)
 	testutil.Require(t, ok)


### PR DESCRIPTION
The `dev` branch adds support for unrecognized fields to proto3 messages. This causes an error in one of the tests, which was using `==` to compare proto timestamps. That no longer works because the proto timestamps now have a `[]byte` field for storing unrecognized data (and slices are not comparable).

Easy fix: use `proto.Equal` to compare.