### PR TITLE
Drain the stream after closing it to send the right status to the server

### DIFF
--- a/grpcreflect/client.go
+++ b/grpcreflect/client.go
@@ -3,7 +3,6 @@ package grpcreflect
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"reflect"
 	"runtime"
 	"sync"
@@ -496,8 +495,8 @@ func (cr *Client) resetLocked() {
 	if cr.stream != nil {
 		cr.stream.CloseSend()
 		for {
-			_, err := cr.stream.Recv()
-			if err == io.EOF || err != nil {
+			// drain the stream, this covers io.EOF too
+			if _, err := cr.stream.Recv(); err != nil {
 				break
 			}
 		}

--- a/grpcreflect/client.go
+++ b/grpcreflect/client.go
@@ -3,6 +3,7 @@ package grpcreflect
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"reflect"
 	"runtime"
 	"sync"
@@ -494,6 +495,12 @@ func (cr *Client) Reset() {
 func (cr *Client) resetLocked() {
 	if cr.stream != nil {
 		cr.stream.CloseSend()
+		for {
+			_, err := cr.stream.Recv()
+			if err == io.EOF || err != nil {
+				break
+			}
+		}
 		cr.stream = nil
 	}
 	if cr.cancel != nil {


### PR DESCRIPTION
I'm seeing some errors in gRPC servers when using `Reset()` method of `grpcreflect.Client`. It looks like after calling `cr.stream.CloseSend()` it is also required to wait for `Recv` to return `io.EOF` (https://github.com/grpc/grpc-go/issues/1714). This change resolves this issues and I no longer see errors on server side.