### PR TITLE
support 'parent packages' when resolving symbols

### DIFF
--- a/desc/internal/util.go
+++ b/desc/internal/util.go
@@ -150,3 +150,39 @@ func CreateSourceInfoMap(fd *dpb.FileDescriptorProto) SourceInfoMap {
 	}
 	return res
 }
+
+// CreatePrefixList returns a list of package prefixes to search when resolving
+// a symbol name. If the given package is blank, it returns only the empty
+// string. If the given package contains only one token, e.g. "foo", it returns
+// that token and the empty string, e.g. ["foo", ""]. Otherwise, it returns
+// successively shorter prefixes of the package and then the empty string. For
+// example, for a package named "foo.bar.baz" it will return the following list:
+//   ["foo.bar.baz", "foo.bar", "foo", ""]
+func CreatePrefixList(pkg string) []string {
+	if pkg == "" {
+		return []string{""}
+	}
+
+	numDots := 0
+	// one pass to pre-allocate the returned slice
+	for i := 0; i < len(pkg); i++ {
+		if pkg[i] == '.' {
+			numDots++
+		}
+	}
+	if numDots == 0 {
+		return []string{pkg, ""}
+	}
+
+	prefixes := make([]string, numDots+2)
+	// second pass to fill in returned slice
+	for i := 0; i < len(pkg); i++ {
+		if pkg[i] == '.' {
+			prefixes[numDots] = pkg[:i]
+			numDots--
+		}
+	}
+	prefixes[0] = pkg
+
+	return prefixes
+}

--- a/desc/internal/util_test.go
+++ b/desc/internal/util_test.go
@@ -1,0 +1,18 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/jhump/protoreflect/internal/testutil"
+)
+
+func TestCreatePrefixList(t *testing.T) {
+	list := CreatePrefixList("")
+	testutil.Eq(t, []string{""}, list)
+
+	list = CreatePrefixList("pkg")
+	testutil.Eq(t, []string{"pkg", ""}, list)
+
+	list = CreatePrefixList("fully.qualified.pkg.name")
+	testutil.Eq(t, []string{"fully.qualified.pkg.name", "fully.qualified.pkg", "fully.qualified", "fully", ""}, list)
+}


### PR DESCRIPTION
This makes symbol resolution match `protoc` since  proto packages are supposed to nest like C++ namespaces (whereas previous implementation treated them more like Go or Java packages).

This will resolve #96.