### PR TITLE
Delete go 1.6 from travis CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 
 matrix:
   include:
-    - go: 1.6
     - go: 1.7
     - go: 1.8
     - go: 1.9


### PR DESCRIPTION
https://github.com/jhump/protoreflect/pull/105 failed in https://travis-ci.org/jhump/protoreflect/jobs/343863865 because https://golang.org/pkg/testing/#T.Run is not in go 1.6. It would be nice to be able to use this function. Go 1.6 is pretty old at this point by go standards (released over two years ago) and this library is significantly newer.