### PR TITLE
fix a bug in dynamic message regarding encoding/decoding sfixed32 fields

### DIFF
--- a/dynamic/binary.go
+++ b/dynamic/binary.go
@@ -410,25 +410,24 @@ func unmarshalSimpleField(fd *desc.FieldDescriptor, v uint64) (interface{}, erro
 		return uint32(v), nil
 
 	case descriptor.FieldDescriptorProto_TYPE_INT32,
-		descriptor.FieldDescriptorProto_TYPE_SFIXED32:
+		descriptor.FieldDescriptorProto_TYPE_ENUM:
 		s := int64(v)
 		if s > math.MaxInt32 || s < math.MinInt32 {
 			return nil, NumericOverflowError
 		}
 		return int32(s), nil
 
+	case descriptor.FieldDescriptorProto_TYPE_SFIXED32:
+		if v > math.MaxUint32 {
+			return nil, NumericOverflowError
+		}
+		return int32(v), nil
+
 	case descriptor.FieldDescriptorProto_TYPE_SINT32:
 		if v > math.MaxUint32 {
 			return nil, NumericOverflowError
 		}
 		return decodeZigZag32(v), nil
-
-	case descriptor.FieldDescriptorProto_TYPE_ENUM:
-		s := int64(v)
-		if s > math.MaxInt32 || s < 0 {
-			return nil, NumericOverflowError
-		}
-		return int32(s), nil
 
 	case descriptor.FieldDescriptorProto_TYPE_UINT64,
 		descriptor.FieldDescriptorProto_TYPE_FIXED64:

--- a/dynamic/binary_test.go
+++ b/dynamic/binary_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 func TestBinaryUnaryFields(t *testing.T) {
-	binaryTranslationParty(t, unaryFieldsMsg)
+	binaryTranslationParty(t, unaryFieldsPosMsg)
+	binaryTranslationParty(t, unaryFieldsNegMsg)
 }
 
 func TestBinaryRepeatedFields(t *testing.T) {

--- a/dynamic/json_test.go
+++ b/dynamic/json_test.go
@@ -24,7 +24,8 @@ import (
 )
 
 func TestJSONUnaryFields(t *testing.T) {
-	jsonTranslationParty(t, unaryFieldsMsg)
+	jsonTranslationParty(t, unaryFieldsPosMsg)
+	jsonTranslationParty(t, unaryFieldsNegMsg)
 }
 
 func TestJSONRepeatedFields(t *testing.T) {

--- a/dynamic/marshal_test.go
+++ b/dynamic/marshal_test.go
@@ -14,7 +14,7 @@ import (
 // Shared stuff for marshalling and unmarshalling tests. This is used for the binary format, the text
 // format, and the JSON format.
 
-var unaryFieldsMsg = &testprotos.UnaryFields{
+var unaryFieldsPosMsg = &testprotos.UnaryFields{
 	I: proto.Int32(1),
 	J: proto.Int64(2),
 	K: proto.Int32(3),
@@ -31,12 +31,39 @@ var unaryFieldsMsg = &testprotos.UnaryFields{
 	V: proto.String("foobar"),
 	W: proto.Bool(true),
 	X: &testprotos.RepeatedFields{
-		I: []int32{-3},
+		I: []int32{3},
 		V: []string{"baz"},
 	},
 	Groupy: &testprotos.UnaryFields_GroupY{
 		Ya: proto.String("bedazzle"),
 		Yb: proto.Int32(42),
+	},
+	Z: testprotos.TestEnum_SECOND.Enum(),
+}
+
+var unaryFieldsNegMsg = &testprotos.UnaryFields{
+	I: proto.Int32(-1),
+	J: proto.Int64(-2),
+	K: proto.Int32(-3),
+	L: proto.Int64(-4),
+	M: proto.Uint32(5),
+	N: proto.Uint64(6),
+	O: proto.Uint32(7),
+	P: proto.Uint64(8),
+	Q: proto.Int32(-9),
+	R: proto.Int64(-10),
+	S: proto.Float32(-11),
+	T: proto.Float64(-12),
+	U: []byte{0, 1, 2, 3, 4, 5, 6, 7},
+	V: proto.String("foobar"),
+	W: proto.Bool(true),
+	X: &testprotos.RepeatedFields{
+		I: []int32{-3},
+		V: []string{"baz"},
+	},
+	Groupy: &testprotos.UnaryFields_GroupY{
+		Ya: proto.String("bedazzle"),
+		Yb: proto.Int32(-42),
 	},
 	Z: testprotos.TestEnum_SECOND.Enum(),
 }

--- a/dynamic/text_test.go
+++ b/dynamic/text_test.go
@@ -7,7 +7,8 @@ import (
 )
 
 func TestTextUnaryFields(t *testing.T) {
-	textTranslationParty(t, unaryFieldsMsg)
+	textTranslationParty(t, unaryFieldsPosMsg)
+	textTranslationParty(t, unaryFieldsNegMsg)
 }
 
 func TestTextRepeatedFields(t *testing.T) {


### PR DESCRIPTION
Also another fix in the same part of the code to allow enums with negative values (since it is allowed by proto spec).