### PR TITLE
Fixes for dynamic.(*Message).Descriptor()

### DIFF
--- a/dynamic/dynamic_message.go
+++ b/dynamic/dynamic_message.go
@@ -158,7 +158,7 @@ func (m *Message) Descriptor() ([]byte, []int) {
 	path := []int{}
 	var d desc.Descriptor
 	name := m.md.GetFullyQualifiedName()
-	for d = m.md.GetParent(); d != nil; d = d.GetParent() {
+	for d = m.md.GetParent(); d != nil; name, d = d.GetFullyQualifiedName(), d.GetParent() {
 		found := false
 		switch d := d.(type) {
 		case (*desc.FileDescriptor):
@@ -166,9 +166,6 @@ func (m *Message) Descriptor() ([]byte, []int) {
 				if md.GetFullyQualifiedName() == name {
 					found = true
 					path = append(path, i)
-					if p := md.GetParent(); p != nil {
-						name = p.GetFullyQualifiedName()
-					}
 				}
 			}
 		case (*desc.MessageDescriptor):
@@ -176,9 +173,6 @@ func (m *Message) Descriptor() ([]byte, []int) {
 				if md.GetFullyQualifiedName() == name {
 					found = true
 					path = append(path, i)
-					if p := md.GetParent(); p != nil {
-						name = p.GetFullyQualifiedName()
-					}
 				}
 			}
 		}

--- a/dynamic/dynamic_message.go
+++ b/dynamic/dynamic_message.go
@@ -166,6 +166,9 @@ func (m *Message) Descriptor() ([]byte, []int) {
 				if md.GetFullyQualifiedName() == name {
 					found = true
 					path = append(path, i)
+					if p := md.GetParent(); p != nil {
+						name = p.GetFullyQualifiedName()
+					}
 				}
 			}
 		case (*desc.MessageDescriptor):
@@ -173,6 +176,9 @@ func (m *Message) Descriptor() ([]byte, []int) {
 				if md.GetFullyQualifiedName() == name {
 					found = true
 					path = append(path, i)
+					if p := md.GetParent(); p != nil {
+						name = p.GetFullyQualifiedName()
+					}
 				}
 			}
 		}

--- a/dynamic/dynamic_message.go
+++ b/dynamic/dynamic_message.go
@@ -149,12 +149,16 @@ func (m *Message) Descriptor() ([]byte, []int) {
 	if err != nil {
 		panic(fmt.Sprintf("Failed to get encoded descriptor for %s", m.md.GetFile().GetName()))
 	}
+	err = w.Close()
+	if err != nil {
+		panic(fmt.Sprintf("Failed to get an encoded descriptor for %s", m.md.GetFile().GetName()))
+	}
 
 	// and path to message
 	path := []int{}
 	var d desc.Descriptor
 	name := m.md.GetFullyQualifiedName()
-	for d = m.md; d != nil; d = d.GetParent() {
+	for d = m.md.GetParent(); d != nil; d = d.GetParent() {
 		found := false
 		switch d := d.(type) {
 		case (*desc.FileDescriptor):
@@ -178,7 +182,7 @@ func (m *Message) Descriptor() ([]byte, []int) {
 	}
 	// reverse the path
 	i := 0
-	j := len(path)
+	j := len(path) - 1
 	for i < j {
 		path[i], path[j] = path[j], path[i]
 		i++

--- a/dynamic/dynamic_message_test.go
+++ b/dynamic/dynamic_message_test.go
@@ -1971,6 +1971,30 @@ func TestBuiltMessage(t *testing.T) {
 	}
 }
 
+func TestBuiltNestedMessage(t *testing.T) {
+	submb := builder.NewMessage("Limb").
+		AddField(builder.NewField("length", builder.FieldTypeUInt32()))
+
+	md, err := builder.NewMessage("Person").
+		AddField(builder.NewField("name", builder.FieldTypeString())).
+		AddNestedMessage(submb).
+		Build()
+
+	if err != nil {
+		t.Fatalf("error building Person: %v", err)
+	}
+
+	nmt := md.GetNestedMessageTypes()[0]
+
+	msg := NewMessage(nmt)
+	msg.SetFieldByNumber(1, uint32(40))
+
+	_, err = desc.LoadMessageDescriptorForMessage(msg)
+	if err != nil {
+		t.Fatalf("error loading Person.Limb's message descriptor: %v", err)
+	}
+}
+
 type panicError struct {
 	panic interface{}
 }

--- a/dynamic/dynamic_message_test.go
+++ b/dynamic/dynamic_message_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/golang/protobuf/proto"
 
 	"github.com/jhump/protoreflect/desc"
+	"github.com/jhump/protoreflect/desc/builder"
 	"github.com/jhump/protoreflect/internal/testprotos"
 	"github.com/jhump/protoreflect/internal/testutil"
 )
@@ -1950,6 +1951,24 @@ func TestMergeInto(t *testing.T) {
 
 func TestMergeFrom(t *testing.T) {
 	// TODO
+}
+
+func TestBuiltMessage(t *testing.T) {
+	md, err := builder.NewMessage("Person").
+		AddField(builder.NewField("name", builder.FieldTypeString())).
+		Build()
+
+	if err != nil {
+		t.Fatalf("error building Person: %v", err)
+	}
+
+	msg := NewMessage(md)
+	msg.SetFieldByNumber(1, "Cailin")
+
+	_, err = desc.LoadMessageDescriptorForMessage(msg)
+	if err != nil {
+		t.Fatalf("error loading Person's message descriptor: %v", err)
+	}
 }
 
 type panicError struct {


### PR DESCRIPTION
Fixes #115:

1. `gzip.Writer` is now closed (flushed).
2. start path construction from `m.md`'s Parent.
3. fix path reversal code out-of-bounds access.

It's no. 2 I'm not convinced is actually a fix; will this fail for nested Message types? Probably, once it hits the file descriptor, can't find a message type within it with the full name (because `GetMessageTypes()` only returns top-level messages), and bombs. I'll add a test to that effect and see if a fix can be worked out.