### PR TITLE
desc gets descriptor directly from dynamic message

### DIFF
--- a/desc/descriptor.go
+++ b/desc/descriptor.go
@@ -1751,6 +1751,14 @@ func LoadMessageDescriptorForType(messageType reflect.Type) (*MessageDescriptor,
 // returned by message.Descriptor(). If the given type is not recognized, then a nil
 // descriptor is returned.
 func LoadMessageDescriptorForMessage(message proto.Message) (*MessageDescriptor, error) {
+	// efficiently handle dynamic messages
+	type descriptorable interface {
+		GetMessageDescriptor() *MessageDescriptor
+	}
+	if d, ok := message.(descriptorable); ok {
+		return d.GetMessageDescriptor(), nil
+	}
+
 	name := proto.MessageName(message)
 	if name == "" {
 		return nil, nil


### PR DESCRIPTION
Since `*dynamic.Message` provides a `Descriptor` method (which, after #116, will actually work), it is possible to use `desc.LoadMessageDescriptorForMessage(proto.Message)` with a dynamic message.

However, the `desc` package caches the results by fully-qualified name. This can be a bit dangerous in that it is possible for a dynamic message's descriptor to be cached *instead of* the actual linked in version (for cases where a dynamic message is created that has the same fully-qualified type name as a linked-in generated message type).

So, to avoid this potential "cache poisoning" and also to improve efficiency (i.e. skip the round-trip marshaling+compression followed by decompression+unmarshaling of the descriptor), we can just get the descriptor directly from the dynamic message using its `GetMessageDescriptor` method.