### PR TITLE
can use semicolon instead of comma; colon before message value is optional

### DIFF
--- a/dynamic/text_test.go
+++ b/dynamic/text_test.go
@@ -69,18 +69,28 @@ func TestTextLenientParsing(t *testing.T) {
 			expected: expectedTestMsg,
 		},
 		{
+			// angle bracket but no colon
+			text:     `ne: VALUE1 ne: VALUE2 anm<yanm<foo:"bar" bar:42 baz:"foo">>`,
+			expected: expectedTestMsg,
+		},
+		{
 			// refer to field by tag
 			text:     `4: VALUE1 4: VALUE2 2:<1:<1:"bar" 2:42 3:"foo">>`,
 			expected: expectedTestMsg,
 		},
 		{
 			// repeated fields w/ array syntax, no commas
-			text:     `ne: [VALUE1, VALUE2] anm:<yanm:<foo:"bar" bar:42 baz:"foo">>`,
+			text:     `ne: [VALUE1 VALUE2] anm:<yanm:<foo:"bar" bar:42 baz:"foo">>`,
 			expected: expectedTestMsg,
 		},
 		{
 			// repeated fields w/ array syntax, commas
 			text:     `ne: [VALUE1, VALUE2], anm:<yanm:<foo:"bar", bar:42, baz:"foo",>>`,
+			expected: expectedTestMsg,
+		},
+		{
+			// repeated fields w/ array syntax, semicolons
+			text:     `ne: [VALUE1; VALUE2]; anm:<yanm:<foo:"bar"; bar:42; baz:"foo";>>`,
 			expected: expectedTestMsg,
 		},
 		{


### PR DESCRIPTION
Couple of small changes for greater compatibility with proto text format in `dynamic.Message`.

Following on #119, this adds some other lenience based on things in the C++ implementation:
1. Can use semicolons instead of commas
2. Colon is optional before a message value, whether it uses `<` or `{` as delimiter.