### PR TITLE
flesh out a few remaining Go doc lint complaints; fixes in protoprint

### DIFF
--- a/desc/protoprint/print.go
+++ b/desc/protoprint/print.go
@@ -84,7 +84,12 @@ func (p *Printer) PrintProtoFiles(fds []*desc.FileDescriptor, open func(name str
 // information, they will be relative to the given root.
 func (p *Printer) PrintProtosToFileSystem(fds []*desc.FileDescriptor, rootDir string) error {
 	return p.PrintProtoFiles(fds, func(name string) (io.WriteCloser, error) {
-		return os.OpenFile(filepath.Join(rootDir, name), os.O_CREATE|os.O_WRONLY, 0666)
+		fullPath := filepath.Join(rootDir, name)
+		dir := filepath.Dir(fullPath)
+		if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+			return nil, err
+		}
+		return os.OpenFile(fullPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
 	})
 }
 

--- a/dynamic/dynamic_message.go
+++ b/dynamic/dynamic_message.go
@@ -1321,8 +1321,8 @@ func (m *Message) getRepeatedField(fd *desc.FieldDescriptor, index int) (interfa
 	return res[index], nil
 }
 
-// AddRepeatedFieldByName appends the given value to the given repeated field.
-// It panics if an error is encountered. See TryAddRepeatedField.
+// AddRepeatedField appends the given value to the given repeated field. It
+// panics if an error is encountered. See TryAddRepeatedField.
 func (m *Message) AddRepeatedField(fd *desc.FieldDescriptor, val interface{}) {
 	if err := m.TryAddRepeatedField(fd, val); err != nil {
 		panic(err.Error())

--- a/dynamic/grpcdynamic/stub.go
+++ b/dynamic/grpcdynamic/stub.go
@@ -194,6 +194,8 @@ func (s *ServerStream) RecvMsg() (proto.Message, error) {
 	}
 }
 
+// ClientStream represents a response stream from a client. Messages in the stream can be sent
+// and, when done, the unary server message and header and trailer metadata can be queried.
 type ClientStream struct {
 	stream grpc.ClientStream
 	method *desc.MethodDescriptor
@@ -226,7 +228,7 @@ func (s *ClientStream) SendMsg(m proto.Message) error {
 	return s.stream.SendMsg(m)
 }
 
-// CloseAndRecvMsg closes the outgoing request stream and then blocks for the server's response.
+// CloseAndReceive closes the outgoing request stream and then blocks for the server's response.
 func (s *ClientStream) CloseAndReceive() (proto.Message, error) {
 	if err := s.stream.CloseSend(); err != nil {
 		return nil, err
@@ -248,9 +250,8 @@ func (s *ClientStream) CloseAndReceive() (proto.Message, error) {
 }
 
 // BidiStream represents a bi-directional stream for sending messages to and receiving
-// messages from a server. For client-streaming operations (e.g. unary response), the
-// server will send back only one message, after which subsequent invocations of RecvMsg
-// return io.EOF.
+// messages from a server. The header and trailer metadata sent by the server can also be
+// queried.
 type BidiStream struct {
 	stream   grpc.ClientStream
 	reqType  *desc.MessageDescriptor

--- a/internal/standard_files.go
+++ b/internal/standard_files.go
@@ -12,8 +12,8 @@ import (
 	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 )
 
-// These are standard protos included with protoc, but older versions of their
-// respective packages registered them using incorrect paths.
+// StdFileAliases are the standard protos included with protoc, but older versions of
+// their respective packages registered them using incorrect paths.
 var StdFileAliases = map[string]string{
 	// Files for the github.com/golang/protobuf/ptypes package at one point were
 	// registered using the path where the proto files are mirrored in GOPATH,

--- a/internal/testutil/testservice.go
+++ b/internal/testutil/testservice.go
@@ -7,19 +7,26 @@ import (
 	"google.golang.org/grpc/test/grpc_testing"
 )
 
-// very simple test service that just echos back request payloads
+// TestService is a very simple test service that just echos back request payloads
 type TestService struct{}
 
+// EmptyCall satisfies the grpc_testing.TestServiceServer interface. It always succeeds.
 func (_ TestService) EmptyCall(context.Context, *grpc_testing.Empty) (*grpc_testing.Empty, error) {
 	return &grpc_testing.Empty{}, nil
 }
 
+// UnaryCall satisfies the grpc_testing.TestServiceServer interface. It always succeeds, echoing
+// back the payload present in the request.
 func (_ TestService) UnaryCall(_ context.Context, req *grpc_testing.SimpleRequest) (*grpc_testing.SimpleResponse, error) {
 	return &grpc_testing.SimpleResponse{
 		Payload: req.Payload,
 	}, nil
 }
 
+// StreamingOutputCall satisfies the grpc_testing.TestServiceServer interface. It only fails if the
+// client cancels or disconnects (thus causing ss.Send to return an error). It echoes a number of
+// responses equal to the request's number of response parameters. The requested parameter details,
+// however, ignored. The response payload is always an echo of the request payload.
 func (_ TestService) StreamingOutputCall(req *grpc_testing.StreamingOutputCallRequest, ss grpc_testing.TestService_StreamingOutputCallServer) error {
 	for i := 0; i < len(req.GetResponseParameters()); i++ {
 		ss.Send(&grpc_testing.StreamingOutputCallResponse{
@@ -29,6 +36,8 @@ func (_ TestService) StreamingOutputCall(req *grpc_testing.StreamingOutputCallRe
 	return nil
 }
 
+// StreamingInputCall satisfies the grpc_testing.TestServiceServer interface. It always succeeds,
+// sending back the total observed size of all request payloads.
 func (_ TestService) StreamingInputCall(ss grpc_testing.TestService_StreamingInputCallServer) error {
 	sz := 0
 	for {
@@ -46,6 +55,9 @@ func (_ TestService) StreamingInputCall(ss grpc_testing.TestService_StreamingInp
 	})
 }
 
+// FullDuplexCall satisfies the grpc_testing.TestServiceServer interface. It only fails if the
+// client cancels or disconnects (thus causing ss.Send to return an error). For each request
+// message it receives, it sends back a response message with the same payload.
 func (_ TestService) FullDuplexCall(ss grpc_testing.TestService_FullDuplexCallServer) error {
 	for {
 		req, err := ss.Recv()
@@ -65,6 +77,11 @@ func (_ TestService) FullDuplexCall(ss grpc_testing.TestService_FullDuplexCallSe
 	}
 }
 
+// HalfDuplexCall satisfies the grpc_testing.TestServiceServer interface. It only fails if the
+// client cancels or disconnects (thus causing ss.Send to return an error). For each request
+// message it receives, it sends back a response message with the same payload. But since it is
+// half-duplex, all of the request payloads are buffered and responses will only be sent after
+// the request stream is half-closed.
 func (_ TestService) HalfDuplexCall(ss grpc_testing.TestService_HalfDuplexCallServer) error {
 	var data []*grpc_testing.Payload
 	for {


### PR DESCRIPTION
The protoprint fixes are to create directory (if necessary) before creating output files and also truncate any existing output files.