### PR TITLE
protoprint: all resulting descriptors should have source code info, including imports

### DIFF
--- a/desc/protoparse/parser.go
+++ b/desc/protoparse/parser.go
@@ -148,13 +148,15 @@ func (p Parser) ParseFiles(filenames ...string) ([]*desc.FileDescriptor, error) 
 	if err != nil {
 		return nil, err
 	}
+	if p.IncludeSourceCodeInfo {
+		for _, fd := range linkedProtos {
+			pr := protos[fd.GetName()]
+			fd.AsFileDescriptorProto().SourceCodeInfo = pr.generateSourceCodeInfo()
+		}
+	}
 	fds := make([]*desc.FileDescriptor, len(filenames))
 	for i, name := range filenames {
 		fd := linkedProtos[name]
-		if p.IncludeSourceCodeInfo {
-			pr := protos[name]
-			fd.AsFileDescriptorProto().SourceCodeInfo = pr.generateSourceCodeInfo()
-		}
 		fds[i] = fd
 	}
 	return fds, nil


### PR DESCRIPTION
Resolves #132.

This will fail in CI due to https://github.com/golang/protobuf/issues/644.

But it passes if I locally checkout [9f81198](https://github.com/golang/protobuf/tree/9f81198da99b79e14d70ca2c3cc1bbe44c6e69b6) of the protobuf repo (the commit before the above bug was introduced).