### PR TITLE
fix build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # TODO: run golint, errcheck
-# TODO: unused recently started failing -- re-enable it after determining root cause
+# TODO: staticcheck and unused recently started failing -- re-enable after determining root cause
 .PHONY: default
-default: deps checkgofmt vet predeclared staticcheck ineffassign test
+default: deps checkgofmt vet predeclared ineffassign test
 
 .PHONY: deps
 deps:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # TODO: run golint, errcheck
-# TODO: staticcheck recently started failing -- re-enable it after determining root cause
+# TODO: unused recently started failing -- re-enable it after determining root cause
 .PHONY: default
-default: deps checkgofmt vet predeclared unused ineffassign test
+default: deps checkgofmt vet predeclared staticcheck ineffassign test
 
 .PHONY: deps
 deps:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # TODO: run golint, errcheck
+# TODO: staticcheck recently started failing -- re-enable it after determining root cause
 .PHONY: default
-default: deps checkgofmt vet predeclared staticcheck unused ineffassign test
+default: deps checkgofmt vet predeclared unused ineffassign test
 
 .PHONY: deps
 deps:


### PR DESCRIPTION
The `staticcheck` and `unused` targets are failing in Travis with a compile error in the analyzer code itself for Go 1.7 and Go 1.8 and with an import error, unable to load `"golang.org/x/sync/errgroup"` (could also be the analyzer code itself) for Go 1.9 and up.