### PR TITLE
miscellaneous changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,8 @@ test:
 
 .PHONY: generate
 generate:
-	go generate github.com/jhump/protoreflect/internal/testprotos/
+	@go get golang.org/x/tools/cmd/goyacc
+	go generate ./...
 
 .PHONY: testcover
 testcover:

--- a/desc/protoparse/parser.go
+++ b/desc/protoparse/parser.go
@@ -31,7 +31,7 @@ func init() {
 	setTokenName(_NAME, "identifier")
 	setTokenName(_FQNAME, "fully-qualified name")
 	setTokenName(_TYPENAME, "type name")
-	setTokenName(_TYPENAME, "error")
+	setTokenName(_ERROR, "error")
 	// for keywords, just show the keyword itself wrapped in quotes
 	for str, i := range keywords {
 		setTokenName(i, fmt.Sprintf(`"%s"`, str))
@@ -149,8 +149,8 @@ func (p Parser) ParseFiles(filenames ...string) ([]*desc.FileDescriptor, error) 
 		return nil, err
 	}
 	if p.IncludeSourceCodeInfo {
-		for _, fd := range linkedProtos {
-			pr := protos[fd.GetName()]
+		for name, fd := range linkedProtos {
+			pr := protos[name]
 			fd.AsFileDescriptorProto().SourceCodeInfo = pr.generateSourceCodeInfo()
 		}
 	}

--- a/dynamic/dynamic_message.go
+++ b/dynamic/dynamic_message.go
@@ -822,6 +822,27 @@ func (m *Message) TryGetOneOfField(od *desc.OneOfDescriptor) (*desc.FieldDescrip
 	return nil, nil, nil
 }
 
+// ClearOneOfField removes any value for any of the given one-of's fields. It
+// panics if an error is encountered. See TryClearOneOfField.
+func (m *Message) ClearOneOfField(od *desc.OneOfDescriptor) {
+	if err := m.TryClearOneOfField(od); err != nil {
+		panic(err.Error())
+	}
+}
+
+// TryClearOneOfField removes any value for any of the given one-of's fields. An
+// error is returned if the given one-of descriptor does not belong to the right
+// message type.
+func (m *Message) TryClearOneOfField(od *desc.OneOfDescriptor) error {
+	if od.GetOwner().GetFullyQualifiedName() != m.md.GetFullyQualifiedName() {
+		return fmt.Errorf("given one-of, %s, is for wrong message type: %s; expecting %s", od.GetName(), od.GetOwner().GetFullyQualifiedName(), m.md.GetFullyQualifiedName())
+	}
+	for _, fd := range od.GetChoices() {
+		m.clearField(fd)
+	}
+	return nil
+}
+
 // GetMapField returns the value for the given map field descriptor and given
 // key. It panics if an error is encountered. See TryGetMapField.
 func (m *Message) GetMapField(fd *desc.FieldDescriptor, key interface{}) interface{} {

--- a/internal/testprotos/desc_test_comments.pb.go
+++ b/internal/testprotos/desc_test_comments.pb.go
@@ -250,8 +250,9 @@ var _ grpc.ClientConn
 // is compatible with the grpc package it is being compiled against.
 const _ = grpc.SupportPackageIsVersion4
 
-// Client API for RpcService service
-
+// RpcServiceClient is the client API for RpcService service.
+//
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type RpcServiceClient interface {
 	// Method comment
 	StreamingRpc(ctx context.Context, opts ...grpc.CallOption) (RpcService_StreamingRpcClient, error)
@@ -267,7 +268,7 @@ func NewRpcServiceClient(cc *grpc.ClientConn) RpcServiceClient {
 }
 
 func (c *rpcServiceClient) StreamingRpc(ctx context.Context, opts ...grpc.CallOption) (RpcService_StreamingRpcClient, error) {
-	stream, err := grpc.NewClientStream(ctx, &_RpcService_serviceDesc.Streams[0], c.cc, "/foo.bar.RpcService/StreamingRpc", opts...)
+	stream, err := c.cc.NewStream(ctx, &_RpcService_serviceDesc.Streams[0], "/foo.bar.RpcService/StreamingRpc", opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -303,15 +304,14 @@ func (x *rpcServiceStreamingRpcClient) CloseAndRecv() (*Request, error) {
 // Deprecated: Do not use.
 func (c *rpcServiceClient) UnaryRpc(ctx context.Context, in *Request, opts ...grpc.CallOption) (*empty.Empty, error) {
 	out := new(empty.Empty)
-	err := grpc.Invoke(ctx, "/foo.bar.RpcService/UnaryRpc", in, out, c.cc, opts...)
+	err := c.cc.Invoke(ctx, "/foo.bar.RpcService/UnaryRpc", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-// Server API for RpcService service
-
+// RpcServiceServer is the server API for RpcService service.
 type RpcServiceServer interface {
 	// Method comment
 	StreamingRpc(RpcService_StreamingRpcServer) error

--- a/internal/testprotos/desc_test_complex.pb.go
+++ b/internal/testprotos/desc_test_complex.pb.go
@@ -1770,8 +1770,9 @@ var _ grpc.ClientConn
 // is compatible with the grpc package it is being compiled against.
 const _ = grpc.SupportPackageIsVersion4
 
-// Client API for TestTestService service
-
+// TestTestServiceClient is the client API for TestTestService service.
+//
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type TestTestServiceClient interface {
 	UserAuth(ctx context.Context, in *Test, opts ...grpc.CallOption) (*Test, error)
 	Get(ctx context.Context, in *Test, opts ...grpc.CallOption) (*Test, error)
@@ -1787,7 +1788,7 @@ func NewTestTestServiceClient(cc *grpc.ClientConn) TestTestServiceClient {
 
 func (c *testTestServiceClient) UserAuth(ctx context.Context, in *Test, opts ...grpc.CallOption) (*Test, error) {
 	out := new(Test)
-	err := grpc.Invoke(ctx, "/foo.bar.TestTestService/UserAuth", in, out, c.cc, opts...)
+	err := c.cc.Invoke(ctx, "/foo.bar.TestTestService/UserAuth", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1796,15 +1797,14 @@ func (c *testTestServiceClient) UserAuth(ctx context.Context, in *Test, opts ...
 
 func (c *testTestServiceClient) Get(ctx context.Context, in *Test, opts ...grpc.CallOption) (*Test, error) {
 	out := new(Test)
-	err := grpc.Invoke(ctx, "/foo.bar.TestTestService/Get", in, out, c.cc, opts...)
+	err := c.cc.Invoke(ctx, "/foo.bar.TestTestService/Get", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-// Server API for TestTestService service
-
+// TestTestServiceServer is the server API for TestTestService service.
 type TestTestServiceServer interface {
 	UserAuth(context.Context, *Test) (*Test, error)
 	Get(context.Context, *Test) (*Test, error)

--- a/internal/testprotos/desc_test_proto3.pb.go
+++ b/internal/testprotos/desc_test_proto3.pb.go
@@ -51,11 +51,11 @@ func (Proto3Enum) EnumDescriptor() ([]byte, []int) {
 }
 
 type TestRequest struct {
-	Foo                  []Proto3Enum                                    `protobuf:"varint,1,rep,packed,name=foo,enum=testprotos.Proto3Enum" json:"foo,omitempty"`
-	Bar                  string                                          `protobuf:"bytes,2,opt,name=bar" json:"bar,omitempty"`
-	Baz                  *TestMessage                                    `protobuf:"bytes,3,opt,name=baz" json:"baz,omitempty"`
-	Snafu                *TestMessage_NestedMessage_AnotherNestedMessage `protobuf:"bytes,4,opt,name=snafu" json:"snafu,omitempty"`
-	Flags                map[string]bool                                 `protobuf:"bytes,5,rep,name=flags" json:"flags,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
+	Foo                  []Proto3Enum                                    `protobuf:"varint,1,rep,packed,name=foo,proto3,enum=testprotos.Proto3Enum" json:"foo,omitempty"`
+	Bar                  string                                          `protobuf:"bytes,2,opt,name=bar,proto3" json:"bar,omitempty"`
+	Baz                  *TestMessage                                    `protobuf:"bytes,3,opt,name=baz,proto3" json:"baz,omitempty"`
+	Snafu                *TestMessage_NestedMessage_AnotherNestedMessage `protobuf:"bytes,4,opt,name=snafu,proto3" json:"snafu,omitempty"`
+	Flags                map[string]bool                                 `protobuf:"bytes,5,rep,name=flags,proto3" json:"flags,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"varint,2,opt,name=value,proto3"`
 	XXX_NoUnkeyedLiteral struct{}                                        `json:"-"`
 	XXX_unrecognized     []byte                                          `json:"-"`
 	XXX_sizecache        int32                                           `json:"-"`
@@ -121,8 +121,8 @@ func (m *TestRequest) GetFlags() map[string]bool {
 }
 
 type TestResponse struct {
-	Atm                  *AnotherTestMessage `protobuf:"bytes,1,opt,name=atm" json:"atm,omitempty"`
-	Vs                   []int32             `protobuf:"varint,2,rep,packed,name=vs" json:"vs,omitempty"`
+	Atm                  *AnotherTestMessage `protobuf:"bytes,1,opt,name=atm,proto3" json:"atm,omitempty"`
+	Vs                   []int32             `protobuf:"varint,2,rep,packed,name=vs,proto3" json:"vs,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}            `json:"-"`
 	XXX_unrecognized     []byte              `json:"-"`
 	XXX_sizecache        int32               `json:"-"`
@@ -181,8 +181,9 @@ var _ grpc.ClientConn
 // is compatible with the grpc package it is being compiled against.
 const _ = grpc.SupportPackageIsVersion4
 
-// Client API for TestService service
-
+// TestServiceClient is the client API for TestService service.
+//
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type TestServiceClient interface {
 	DoSomething(ctx context.Context, in *TestRequest, opts ...grpc.CallOption) (*pkg.Bar, error)
 	DoSomethingElse(ctx context.Context, opts ...grpc.CallOption) (TestService_DoSomethingElseClient, error)
@@ -200,7 +201,7 @@ func NewTestServiceClient(cc *grpc.ClientConn) TestServiceClient {
 
 func (c *testServiceClient) DoSomething(ctx context.Context, in *TestRequest, opts ...grpc.CallOption) (*pkg.Bar, error) {
 	out := new(pkg.Bar)
-	err := grpc.Invoke(ctx, "/testprotos.TestService/DoSomething", in, out, c.cc, opts...)
+	err := c.cc.Invoke(ctx, "/testprotos.TestService/DoSomething", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -208,7 +209,7 @@ func (c *testServiceClient) DoSomething(ctx context.Context, in *TestRequest, op
 }
 
 func (c *testServiceClient) DoSomethingElse(ctx context.Context, opts ...grpc.CallOption) (TestService_DoSomethingElseClient, error) {
-	stream, err := grpc.NewClientStream(ctx, &_TestService_serviceDesc.Streams[0], c.cc, "/testprotos.TestService/DoSomethingElse", opts...)
+	stream, err := c.cc.NewStream(ctx, &_TestService_serviceDesc.Streams[0], "/testprotos.TestService/DoSomethingElse", opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +243,7 @@ func (x *testServiceDoSomethingElseClient) CloseAndRecv() (*TestResponse, error)
 }
 
 func (c *testServiceClient) DoSomethingAgain(ctx context.Context, in *pkg.Bar, opts ...grpc.CallOption) (TestService_DoSomethingAgainClient, error) {
-	stream, err := grpc.NewClientStream(ctx, &_TestService_serviceDesc.Streams[1], c.cc, "/testprotos.TestService/DoSomethingAgain", opts...)
+	stream, err := c.cc.NewStream(ctx, &_TestService_serviceDesc.Streams[1], "/testprotos.TestService/DoSomethingAgain", opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -274,7 +275,7 @@ func (x *testServiceDoSomethingAgainClient) Recv() (*AnotherTestMessage, error) 
 }
 
 func (c *testServiceClient) DoSomethingForever(ctx context.Context, opts ...grpc.CallOption) (TestService_DoSomethingForeverClient, error) {
-	stream, err := grpc.NewClientStream(ctx, &_TestService_serviceDesc.Streams[2], c.cc, "/testprotos.TestService/DoSomethingForever", opts...)
+	stream, err := c.cc.NewStream(ctx, &_TestService_serviceDesc.Streams[2], "/testprotos.TestService/DoSomethingForever", opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -304,8 +305,7 @@ func (x *testServiceDoSomethingForeverClient) Recv() (*TestResponse, error) {
 	return m, nil
 }
 
-// Server API for TestService service
-
+// TestServiceServer is the server API for TestService service.
 type TestServiceServer interface {
 	DoSomething(context.Context, *TestRequest) (*pkg.Bar, error)
 	DoSomethingElse(TestService_DoSomethingElseServer) error

--- a/internal/testprotos/desc_test_wellknowntypes.pb.go
+++ b/internal/testprotos/desc_test_wellknowntypes.pb.go
@@ -24,19 +24,19 @@ var _ = math.Inf
 const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
 type TestWellKnownTypes struct {
-	StartTime            *timestamp.Timestamp  `protobuf:"bytes,1,opt,name=start_time,json=startTime" json:"start_time,omitempty"`
-	Elapsed              *duration.Duration    `protobuf:"bytes,2,opt,name=elapsed" json:"elapsed,omitempty"`
-	Dbl                  *wrappers.DoubleValue `protobuf:"bytes,3,opt,name=dbl" json:"dbl,omitempty"`
-	Flt                  *wrappers.FloatValue  `protobuf:"bytes,4,opt,name=flt" json:"flt,omitempty"`
-	Bl                   *wrappers.BoolValue   `protobuf:"bytes,5,opt,name=bl" json:"bl,omitempty"`
-	I32                  *wrappers.Int32Value  `protobuf:"bytes,6,opt,name=i32" json:"i32,omitempty"`
-	I64                  *wrappers.Int64Value  `protobuf:"bytes,7,opt,name=i64" json:"i64,omitempty"`
-	U32                  *wrappers.UInt32Value `protobuf:"bytes,8,opt,name=u32" json:"u32,omitempty"`
-	U64                  *wrappers.UInt64Value `protobuf:"bytes,9,opt,name=u64" json:"u64,omitempty"`
-	Str                  *wrappers.StringValue `protobuf:"bytes,10,opt,name=str" json:"str,omitempty"`
-	Byt                  *wrappers.BytesValue  `protobuf:"bytes,11,opt,name=byt" json:"byt,omitempty"`
-	Json                 []*_struct.Value      `protobuf:"bytes,12,rep,name=json" json:"json,omitempty"`
-	Extras               []*any.Any            `protobuf:"bytes,13,rep,name=extras" json:"extras,omitempty"`
+	StartTime            *timestamp.Timestamp  `protobuf:"bytes,1,opt,name=start_time,json=startTime,proto3" json:"start_time,omitempty"`
+	Elapsed              *duration.Duration    `protobuf:"bytes,2,opt,name=elapsed,proto3" json:"elapsed,omitempty"`
+	Dbl                  *wrappers.DoubleValue `protobuf:"bytes,3,opt,name=dbl,proto3" json:"dbl,omitempty"`
+	Flt                  *wrappers.FloatValue  `protobuf:"bytes,4,opt,name=flt,proto3" json:"flt,omitempty"`
+	Bl                   *wrappers.BoolValue   `protobuf:"bytes,5,opt,name=bl,proto3" json:"bl,omitempty"`
+	I32                  *wrappers.Int32Value  `protobuf:"bytes,6,opt,name=i32,proto3" json:"i32,omitempty"`
+	I64                  *wrappers.Int64Value  `protobuf:"bytes,7,opt,name=i64,proto3" json:"i64,omitempty"`
+	U32                  *wrappers.UInt32Value `protobuf:"bytes,8,opt,name=u32,proto3" json:"u32,omitempty"`
+	U64                  *wrappers.UInt64Value `protobuf:"bytes,9,opt,name=u64,proto3" json:"u64,omitempty"`
+	Str                  *wrappers.StringValue `protobuf:"bytes,10,opt,name=str,proto3" json:"str,omitempty"`
+	Byt                  *wrappers.BytesValue  `protobuf:"bytes,11,opt,name=byt,proto3" json:"byt,omitempty"`
+	Json                 []*_struct.Value      `protobuf:"bytes,12,rep,name=json,proto3" json:"json,omitempty"`
+	Extras               []*any.Any            `protobuf:"bytes,13,rep,name=extras,proto3" json:"extras,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}              `json:"-"`
 	XXX_unrecognized     []byte                `json:"-"`
 	XXX_sizecache        int32                 `json:"-"`


### PR DESCRIPTION
 * update generate target to first build goyacc
* run `make generate` to re-gen protos
* add `ClearOneOfField` methods to `*dynamic.Message`
* couple small other fixes in `protoparse` package

