### PR TITLE
restore staticcheck and unused

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ matrix:
     - go: "1.8"
     - go: "1.9"
     - go: "1.10"
+      env: VET=1
     - go: tip
 
 # accomodate forks
@@ -15,4 +16,4 @@ before_install:
   - test ! -d $GOPATH/src/github.com/jhump/protoreflect && mv $TRAVIS_BUILD_DIR $GOPATH/src/github.com/jhump/protoreflect || true
 
 script:
-  - make
+  - if [[ "$VET" = 1 ]]; then make; else make deps test; fi

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 # TODO: run golint, errcheck
-# TODO: staticcheck and unused recently started failing -- re-enable after determining root cause
 .PHONY: default
-default: deps checkgofmt vet predeclared ineffassign test
+default: deps checkgofmt vet predeclared staticcheck unused ineffassign test
 
 .PHONY: deps
 deps:
@@ -36,8 +35,8 @@ vet:
 # staticheck in a way that ignores the errors in that generated code
 .PHONY: staticcheck
 staticcheck:
-	@echo staticcheck --ignore $$(go list ./... | grep protoparse)/proto.y.go:* ./...
 	@go get honnef.co/go/tools/cmd/staticcheck
+	@echo staticcheck --ignore $$(go list ./... | grep protoparse)/proto.y.go:* ./...
 	@staticcheck --ignore $$(go list ./... | grep protoparse)/proto.y.go:* ./...
 
 .PHONY: unused


### PR DESCRIPTION
Recent changes to `staticcheck` and `unused` make them only operable with Go 1.9 or higher. Let's just skip the checks in all builds but one (Go 1.10 for now).