### PR TITLE
add dynamic.AsDynamicMessage*

### DIFF
--- a/dynamic/equal.go
+++ b/dynamic/equal.go
@@ -162,7 +162,7 @@ func MessagesEqual(a, b proto.Message) bool {
 		if err != nil {
 			return false
 		}
-		db = newMessageWithMessageFactory(md, da.mf)
+		db = NewMessageWithMessageFactory(md, da.mf)
 		if db.ConvertFrom(b) != nil {
 			return false
 		}
@@ -172,7 +172,7 @@ func MessagesEqual(a, b proto.Message) bool {
 		if err != nil {
 			return false
 		}
-		da = newMessageWithMessageFactory(md, db.mf)
+		da = NewMessageWithMessageFactory(md, db.mf)
 		if da.ConvertFrom(a) != nil {
 			return false
 		}

--- a/dynamic/message_factory.go
+++ b/dynamic/message_factory.go
@@ -64,7 +64,7 @@ func (f *MessageFactory) NewMessage(md *desc.MessageDescriptor) proto.Message {
 	if m := ktr.CreateIfKnown(md.GetFullyQualifiedName()); m != nil {
 		return m
 	}
-	return newMessageWithMessageFactory(md, f)
+	return NewMessageWithMessageFactory(md, f)
 }
 
 // NewDynamicMessage creates a new empty dynamic message that corresponds to the given
@@ -75,7 +75,7 @@ func (f *MessageFactory) NewMessage(md *desc.MessageDescriptor) proto.Message {
 // this factory when creating other messages, like during de-serialization of fields
 // that are themselves message types.
 func (f *MessageFactory) NewDynamicMessage(md *desc.MessageDescriptor) *Message {
-	return newMessageWithMessageFactory(md, f)
+	return NewMessageWithMessageFactory(md, f)
 }
 
 // GetKnownTypeRegistry returns the known type registry that this factory uses to

--- a/dynamic/text.go
+++ b/dynamic/text.go
@@ -711,7 +711,7 @@ func (m *Message) unmarshalFieldElementText(fd *desc.FieldDescriptor, tr *txtRea
 
 		endTok := tok.tokTyp.EndToken()
 		if endTok != tokenError {
-			dm := newMessageWithMessageFactory(fd.GetMessageType(), m.mf)
+			dm := NewMessageWithMessageFactory(fd.GetMessageType(), m.mf)
 			if err := dm.unmarshalText(tr, endTok); err != nil {
 				return err
 			}


### PR DESCRIPTION
Helper method to more easily convert generated messages to dynamic messages.
Also makes dynamic.NewMessageWithMessageFactory exported.