### PR TITLE
dynamic: fixes to handling of oneofs and explicit nil pointers in JSON

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,12 @@ install:
 
 .PHONY: checkgofmt
 checkgofmt:
-	@if [ -n "$$(go version | awk '{ print $$3 }' | grep -v devel)" ]; then \
-		output="$$(gofmt -s -l .)" ; \
-		if [ -n "$$output"  ]; then \
-		    echo "$$output"; \
-			echo "Run gofmt on the above files!"; \
-			exit 1; \
-		fi; \
+	@echo gofmt -s -l .
+	@output="$$(gofmt -s -l .)" ; \
+	if [ -n "$$output"  ]; then \
+	    echo "$$output"; \
+		echo "Run gofmt on the above files!"; \
+		exit 1; \
 	fi
 
 # workaround https://github.com/golang/protobuf/issues/214 until in master


### PR DESCRIPTION
When emitting JSON with `EmitDefaults: true` for a message that had oneof fields, the output would incorrectly include unset fields in the oneof.

The `jsonpb` package handles these differently, explicitly because the presence of such a field in JSON triggers unmarshaling to unset the other fields. So if there are multiple fields present, the last one will be considered the "set" one (even it was just an artifact of marshaling unset fields).

This fixes the dynamic message to behave just like generated types when marshaling to and unmarshaling from JSON, with regards to how oneofs are handled. This also includes an update to attempt to preserve explicit `nil` values for oneof fields, in both marshaling to JSON and in unmarshaling. Again, this is so that dynamic message behaves like generated messages.