### PR TITLE
builders should add deps for options

### DIFF
--- a/desc/builder/builders_test.go
+++ b/desc/builder/builders_test.go
@@ -774,3 +774,7 @@ func TestRenamingBuilders(t *testing.T) {
 func TestRenumberingFields(t *testing.T) {
 	// TODO
 }
+
+func TestUseOfExtensionRegistry(t *testing.T) {
+	// TODO
+}

--- a/desc/builder/builders_test.go
+++ b/desc/builder/builders_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/golang/protobuf/ptypes/timestamp"
 
 	"github.com/jhump/protoreflect/desc"
+	"github.com/jhump/protoreflect/dynamic"
 	_ "github.com/jhump/protoreflect/internal/testprotos"
 	"github.com/jhump/protoreflect/internal/testutil"
 )
@@ -776,5 +777,185 @@ func TestRenumberingFields(t *testing.T) {
 }
 
 func TestUseOfExtensionRegistry(t *testing.T) {
-	// TODO
+	fileOptionsDesc, err := desc.LoadMessageDescriptorForMessage((*dpb.FileOptions)(nil))
+	testutil.Ok(t, err)
+	msgOptionsDesc, err := desc.LoadMessageDescriptorForMessage((*dpb.MessageOptions)(nil))
+	testutil.Ok(t, err)
+	fieldOptionsDesc, err := desc.LoadMessageDescriptorForMessage((*dpb.FieldOptions)(nil))
+	testutil.Ok(t, err)
+	oneofOptionsDesc, err := desc.LoadMessageDescriptorForMessage((*dpb.OneofOptions)(nil))
+	testutil.Ok(t, err)
+	extRangeOptionsDesc, err := desc.LoadMessageDescriptorForMessage((*dpb.ExtensionRangeOptions)(nil))
+	testutil.Ok(t, err)
+	enumOptionsDesc, err := desc.LoadMessageDescriptorForMessage((*dpb.EnumOptions)(nil))
+	testutil.Ok(t, err)
+	enumValOptionsDesc, err := desc.LoadMessageDescriptorForMessage((*dpb.EnumValueOptions)(nil))
+	testutil.Ok(t, err)
+	svcOptionsDesc, err := desc.LoadMessageDescriptorForMessage((*dpb.ServiceOptions)(nil))
+	testutil.Ok(t, err)
+	mtdOptionsDesc, err := desc.LoadMessageDescriptorForMessage((*dpb.MethodOptions)(nil))
+	testutil.Ok(t, err)
+
+	// Add option for every type to extension registry
+	var exts dynamic.ExtensionRegistry
+
+	fileOpt, err := NewExtensionImported("file_foo", 54321, FieldTypeString(), fileOptionsDesc).Build()
+	testutil.Ok(t, err)
+	err = exts.AddExtension(fileOpt)
+	testutil.Ok(t, err)
+
+	msgOpt, err := NewExtensionImported("msg_foo", 54321, FieldTypeString(), msgOptionsDesc).Build()
+	testutil.Ok(t, err)
+	err = exts.AddExtension(msgOpt)
+	testutil.Ok(t, err)
+
+	fieldOpt, err := NewExtensionImported("field_foo", 54321, FieldTypeString(), fieldOptionsDesc).Build()
+	testutil.Ok(t, err)
+	err = exts.AddExtension(fieldOpt)
+	testutil.Ok(t, err)
+
+	oneofOpt, err := NewExtensionImported("oneof_foo", 54321, FieldTypeString(), oneofOptionsDesc).Build()
+	testutil.Ok(t, err)
+	err = exts.AddExtension(oneofOpt)
+	testutil.Ok(t, err)
+
+	extRangeOpt, err := NewExtensionImported("ext_range_foo", 54321, FieldTypeString(), extRangeOptionsDesc).Build()
+	testutil.Ok(t, err)
+	err = exts.AddExtension(extRangeOpt)
+	testutil.Ok(t, err)
+
+	enumOpt, err := NewExtensionImported("enum_foo", 54321, FieldTypeString(), enumOptionsDesc).Build()
+	testutil.Ok(t, err)
+	err = exts.AddExtension(enumOpt)
+	testutil.Ok(t, err)
+
+	enumValOpt, err := NewExtensionImported("enum_val_foo", 54321, FieldTypeString(), enumValOptionsDesc).Build()
+	testutil.Ok(t, err)
+	err = exts.AddExtension(enumValOpt)
+	testutil.Ok(t, err)
+
+	svcOpt, err := NewExtensionImported("svc_foo", 54321, FieldTypeString(), svcOptionsDesc).Build()
+	testutil.Ok(t, err)
+	err = exts.AddExtension(svcOpt)
+	testutil.Ok(t, err)
+
+	mtdOpt, err := NewExtensionImported("mtd_foo", 54321, FieldTypeString(), mtdOptionsDesc).Build()
+	testutil.Ok(t, err)
+	err = exts.AddExtension(mtdOpt)
+	testutil.Ok(t, err)
+
+	// Now we can test referring to these and making sure they show up correctly
+	// in built descriptors
+
+	t.Run("file options", func(t *testing.T) {
+		fb := NewFile("foo.proto")
+		fb.Options = &dpb.FileOptions{}
+		err = dynamic.SetExtension(fb.Options, fileOpt, "fubar")
+		testutil.Ok(t, err)
+		checkBuildWithExtensions(t, &exts, fileOpt.GetFile(), fb)
+	})
+
+	t.Run("message options", func(t *testing.T) {
+		mb := NewMessage("Foo")
+		mb.Options = &dpb.MessageOptions{}
+		err = dynamic.SetExtension(mb.Options, msgOpt, "fubar")
+		testutil.Ok(t, err)
+		checkBuildWithExtensions(t, &exts, msgOpt.GetFile(), mb)
+	})
+
+	t.Run("field options", func(t *testing.T) {
+		flb := NewField("foo", FieldTypeString())
+		flb.Options = &dpb.FieldOptions{}
+		// fields must be connected to a message
+		NewMessage("Foo").AddField(flb)
+		err = dynamic.SetExtension(flb.Options, fieldOpt, "fubar")
+		testutil.Ok(t, err)
+		checkBuildWithExtensions(t, &exts, fieldOpt.GetFile(), flb)
+	})
+
+	t.Run("oneof options", func(t *testing.T) {
+		oob := NewOneOf("oo")
+		oob.Options = &dpb.OneofOptions{}
+		// oneofs must be connected to a message
+		NewMessage("Foo").AddOneOf(oob)
+		err = dynamic.SetExtension(oob.Options, oneofOpt, "fubar")
+		testutil.Ok(t, err)
+		checkBuildWithExtensions(t, &exts, oneofOpt.GetFile(), oob)
+	})
+
+	t.Run("extension range options", func(t *testing.T) {
+		var erOpts dpb.ExtensionRangeOptions
+		err = dynamic.SetExtension(&erOpts, extRangeOpt, "fubar")
+		testutil.Ok(t, err)
+		mb := NewMessage("foo").AddExtensionRangeWithOptions(100, 200, &erOpts)
+		checkBuildWithExtensions(t, &exts, extRangeOpt.GetFile(), mb)
+	})
+
+	t.Run("enum options", func(t *testing.T) {
+		eb := NewEnum("Foo")
+		eb.Options = &dpb.EnumOptions{}
+		err = dynamic.SetExtension(eb.Options, enumOpt, "fubar")
+		testutil.Ok(t, err)
+		checkBuildWithExtensions(t, &exts, enumOpt.GetFile(), eb)
+	})
+
+	t.Run("enum val options", func(t *testing.T) {
+		evb := NewEnumValue("FOO")
+		// enum values must be connected to an enum
+		NewEnum("Foo").AddValue(evb)
+		evb.Options = &dpb.EnumValueOptions{}
+		err = dynamic.SetExtension(evb.Options, enumValOpt, "fubar")
+		testutil.Ok(t, err)
+		checkBuildWithExtensions(t, &exts, enumValOpt.GetFile(), evb)
+	})
+
+	t.Run("service options", func(t *testing.T) {
+		sb := NewService("Foo")
+		sb.Options = &dpb.ServiceOptions{}
+		err = dynamic.SetExtension(sb.Options, svcOpt, "fubar")
+		testutil.Ok(t, err)
+		checkBuildWithExtensions(t, &exts, svcOpt.GetFile(), sb)
+	})
+
+	t.Run("method options", func(t *testing.T) {
+		mtb := NewMethod("Foo",
+			RpcTypeMessage(NewMessage("Request"), false),
+			RpcTypeMessage(NewMessage("Response"), false))
+		// methods must be connected to a service
+		NewService("Bar").AddMethod(mtb)
+		mtb.Options = &dpb.MethodOptions{}
+		err = dynamic.SetExtension(mtb.Options, mtdOpt, "fubar")
+		testutil.Ok(t, err)
+		checkBuildWithExtensions(t, &exts, mtdOpt.GetFile(), mtb)
+	})
+}
+
+func checkBuildWithExtensions(t *testing.T, exts *dynamic.ExtensionRegistry, expected *desc.FileDescriptor, builder Builder) {
+	// without interpreting custom option
+	d, err := builder.BuildDescriptor()
+	testutil.Ok(t, err)
+	for _, dep := range d.GetFile().GetDependencies() {
+		testutil.Neq(t, expected, dep)
+	}
+	numDeps := len(d.GetFile().GetDependencies())
+
+	// requiring options (and failing)
+	var opts BuilderOptions
+	opts.RequireInterpretedOptions = true
+	_, err = opts.Build(builder)
+	testutil.Require(t, err != nil)
+
+	// able to interpret options via extension registry
+	opts.Extensions = exts
+	d, err = opts.Build(builder)
+	testutil.Ok(t, err)
+	testutil.Eq(t, numDeps+1, len(d.GetFile().GetDependencies()))
+	found := false
+	for _, dep := range d.GetFile().GetDependencies() {
+		if expected == dep {
+			found = true
+			break
+		}
+	}
+	testutil.Require(t, found)
 }

--- a/dynamic/dynamic_message.go
+++ b/dynamic/dynamic_message.go
@@ -402,11 +402,15 @@ func (m *Message) FindFieldDescriptorByJSONName(name string) *desc.FieldDescript
 }
 
 func (m *Message) checkField(fd *desc.FieldDescriptor) error {
-	if fd.GetOwner().GetFullyQualifiedName() != m.md.GetFullyQualifiedName() {
-		return fmt.Errorf("given field, %s, is for wrong message type: %s; expecting %s", fd.GetName(), fd.GetOwner().GetFullyQualifiedName(), m.md.GetFullyQualifiedName())
+	return checkField(fd, m.md)
+}
+
+func checkField(fd *desc.FieldDescriptor, md *desc.MessageDescriptor) error {
+	if fd.GetOwner().GetFullyQualifiedName() != md.GetFullyQualifiedName() {
+		return fmt.Errorf("given field, %s, is for wrong message type: %s; expecting %s", fd.GetName(), fd.GetOwner().GetFullyQualifiedName(), md.GetFullyQualifiedName())
 	}
-	if fd.IsExtension() && !m.md.IsExtension(fd.GetNumber()) {
-		return fmt.Errorf("given field, %s, is an extension but is not in message extension range: %v", fd.GetFullyQualifiedName(), m.md.GetExtensionRanges())
+	if fd.IsExtension() && !md.IsExtension(fd.GetNumber()) {
+		return fmt.Errorf("given field, %s, is an extension but is not in message extension range: %v", fd.GetFullyQualifiedName(), md.GetExtensionRanges())
 	}
 	return nil
 }

--- a/dynamic/extension.go
+++ b/dynamic/extension.go
@@ -1,0 +1,44 @@
+package dynamic
+
+import (
+	"fmt"
+
+	"github.com/golang/protobuf/proto"
+
+	"github.com/jhump/protoreflect/desc"
+)
+
+// SetExtension sets the given extension value. If the given message is not a
+// dynamic message, the given extension may not be recognized (or may differ
+// from the compiled and linked in version of the extension. So in that case,
+// this function will serialize the given value to bytes and then use
+// proto.SetRawExtension to set the value.
+func SetExtension(msg proto.Message, extd *desc.FieldDescriptor, val interface{}) error {
+	if !extd.IsExtension() {
+		return fmt.Errorf("given field %s is not an extension", extd.GetFullyQualifiedName())
+	}
+
+	if dm, ok := msg.(*Message); ok {
+		return dm.TrySetField(extd, val)
+	}
+
+	md, err := desc.LoadMessageDescriptorForMessage(msg)
+	if err != nil {
+		return err
+	}
+	if err := checkField(extd, md); err != nil {
+		return err
+	}
+
+	val, err = validFieldValue(extd, val)
+	if err != nil {
+		return err
+	}
+
+	var b codedBuffer
+	if err := marshalField(extd.GetNumber(), extd, val, &b, defaultDeterminism); err != nil {
+		return err
+	}
+	proto.SetRawExtension(msg, extd.GetNumber(), b.buf)
+	return nil
+}

--- a/dynamic/extension_test.go
+++ b/dynamic/extension_test.go
@@ -1,0 +1,40 @@
+package dynamic
+
+import (
+	"github.com/golang/protobuf/proto"
+	"testing"
+
+	"github.com/jhump/protoreflect/desc"
+
+	"github.com/jhump/protoreflect/internal/testprotos"
+	"github.com/jhump/protoreflect/internal/testutil"
+)
+
+func TestSetExtension(t *testing.T) {
+	extd, err := desc.LoadFieldDescriptorForExtension(testprotos.E_TestMessage_NestedMessage_AnotherNestedMessage_Flags)
+	testutil.Ok(t, err)
+
+	// with dynamic message
+	dm := NewMessage(extd.GetOwner())
+	err = SetExtension(dm, extd, []bool{true, false, true})
+	testutil.Ok(t, err)
+	testutil.Eq(t, []bool{true, false, true}, dm.GetField(extd))
+
+	// with non-dynamic message
+	var msg testprotos.AnotherTestMessage
+	err = SetExtension(&msg, extd, []bool{true, false, true})
+	testutil.Ok(t, err)
+	val, err := proto.GetExtension(&msg, testprotos.E_TestMessage_NestedMessage_AnotherNestedMessage_Flags)
+	testutil.Ok(t, err)
+	testutil.Eq(t, []bool{true, false, true}, val)
+
+	// fails with wrong value type
+	err = SetExtension(&msg, extd, "foo")
+	testutil.Require(t, err != nil)
+
+	// fails if you use wrong type of message
+	var msg2 testprotos.TestMessage
+	err = SetExtension(&msg2, extd, []bool{true, false, true})
+	testutil.Require(t, err != nil)
+
+}


### PR DESCRIPTION
This updates the `builder` package so that built descriptors properly reference the files that declare any custom options used in the file. This requires inspecting options and also adds support for using an extension registry (in the event that custom options are used that are not compiled and linked into the calling program).

Also adds a `dynamic.SetExtension` function, to ease the use of setting extension values using descriptors (e.g. `*desc.FieldDescriptor) instead of compiled-in extensions (`*proto.ExtensionDesc`). This function is used from the new test in `builder`.

Fixes #174 