### PR TITLE
fix build: staticcheck no longer supports Go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,15 @@ matrix:
   include:
     - go: "1.9"
     - go: "1.10"
-      env: VET=1
     - go: "1.11"
+      env:
+      - GO111MODULE=off
+      - VET=1
+    - go: "1.11"
+      env: GO111MODULE=on
+    - go: "1.12"
       env: GO111MODULE=off
-    - go: "1.11"
+    - go: "1.12"
       env: GO111MODULE=on
     - go: tip
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # TODO: run golint, errcheck
 .PHONY: default
-default: deps checkgofmt vet predeclared staticcheck unused ineffassign test
+default: deps checkgofmt vet predeclared staticcheck ineffassign test
 
 .PHONY: deps
 deps:
@@ -37,11 +37,6 @@ staticcheck:
 	@go get honnef.co/go/tools/cmd/staticcheck
 	@echo staticcheck --ignore $$(go list ./... | grep protoparse)/proto.y.go:* ./...
 	@staticcheck --ignore $$(go list ./... | grep protoparse)/proto.y.go:* ./...
-
-.PHONY: unused
-unused:
-	@go get honnef.co/go/tools/cmd/unused
-	unused ./...
 
 # same remarks as for staticcheck: we ignore errors in generated proto.y.go
 .PHONY: ineffassign

--- a/desc/protoparse/options.go
+++ b/desc/protoparse/options.go
@@ -370,8 +370,8 @@ func (d poorFileDescriptorish) GetServices() []svcDescriptorish {
 	for i, s := range svcs {
 		ret[i] = poorSvcDescriptorish{
 			ServiceDescriptorProto: s,
-			qual: pkg,
-			file: d,
+			qual:                   pkg,
+			file:                   d,
 		}
 	}
 	return ret
@@ -570,8 +570,8 @@ func (d poorEnumDescriptorish) GetValues() []enumValDescriptorish {
 	for i, v := range vals {
 		ret[i] = poorEnumValDescriptorish{
 			EnumValueDescriptorProto: v,
-			qual: d.GetFullyQualifiedName(),
-			file: d.file,
+			qual:                     d.GetFullyQualifiedName(),
+			file:                     d.file,
 		}
 	}
 	return ret
@@ -627,8 +627,8 @@ func (d poorSvcDescriptorish) GetMethods() []methodDescriptorish {
 	for i, m := range mtds {
 		ret[i] = poorMethodDescriptorish{
 			MethodDescriptorProto: m,
-			qual: d.GetFullyQualifiedName(),
-			file: d.file,
+			qual:                  d.GetFullyQualifiedName(),
+			file:                  d.file,
 		}
 	}
 	return ret

--- a/desc/protoprint/print_test.go
+++ b/desc/protoprint/print_test.go
@@ -28,13 +28,13 @@ const (
 
 func TestPrinter(t *testing.T) {
 	prs := map[string]*Printer{
-		"default":                  {},
-		"compact":                  {Compact: true},
-		"no-trailing-comments":     {OmitComments: CommentsTrailing},
-		"trailing-on-next-line":    {TrailingCommentsOnSeparateLine: true},
-		"only-doc-comments":        {OmitComments: CommentsNonDoc},
-		"multiline-style-comments": {Indent: "\t", PreferMultiLineStyleComments: true},
-		"sorted":                   {Indent: "   ", SortElements: true, OmitDetachedComments: true},
+		"default":                             {},
+		"compact":                             {Compact: true},
+		"no-trailing-comments":                {OmitComments: CommentsTrailing},
+		"trailing-on-next-line":               {TrailingCommentsOnSeparateLine: true},
+		"only-doc-comments":                   {OmitComments: CommentsNonDoc},
+		"multiline-style-comments":            {Indent: "\t", PreferMultiLineStyleComments: true},
+		"sorted":                              {Indent: "   ", SortElements: true, OmitDetachedComments: true},
 		"sorted-AND-multiline-style-comments": {PreferMultiLineStyleComments: true, SortElements: true},
 	}
 	files := []string{


### PR DESCRIPTION
The static check/vet tools are now run with Go 1.11.

While at it, removed `unused` check, which now reports that it has been deprecated and superceded by `staticcheck`.

The Go 1.11 version of `gofmt` is a little different, so this change involves minor format fixes, too.