### PR TITLE
adds support for parsing extended Any syntax in text format

### DIFF
--- a/dynamic/extension_registry.go
+++ b/dynamic/extension_registry.go
@@ -48,7 +48,9 @@ func (r *ExtensionRegistry) AddExtensionDesc(exts ...*proto.ExtensionDesc) error
 	return nil
 }
 
-// AddExtension adds the given extensions to the registry.
+// AddExtension adds the given extensions to the registry. The given extensions
+// will overwrite any previously added extensions that are for the same extendee
+// message and same extension tag number.
 func (r *ExtensionRegistry) AddExtension(exts ...*desc.FieldDescriptor) error {
 	for _, ext := range exts {
 		if !ext.IsExtension() {


### PR DESCRIPTION
Support is limited due to limitations in text marshaling API of proto package -- basically, the embedded message type must be linked into the program for it to be interpreted. (The text marshalling API really needs to accept an `AnyResolver` to enable more extensible resolution of message types.)