### PR TITLE
[PERF] - Dont allocate string unnecessarily

### DIFF
--- a/desc/descriptor.go
+++ b/desc/descriptor.go
@@ -996,10 +996,6 @@ func (fd *FieldDescriptor) GetEnumType() *EnumDescriptor {
 	return fd.enumType
 }
 
-func (fd *FieldDescriptor) getTypeString() string {
-	return strings.ToLower(fd.proto.GetType().String())
-}
-
 // GetDefaultValue returns the default value for this field.
 //
 // If this field represents a message type, this method always returns nil (even though

--- a/desc/descriptor.go
+++ b/desc/descriptor.go
@@ -943,11 +943,6 @@ func (fd *FieldDescriptor) GetType() dpb.FieldDescriptorProto_Type {
 	return fd.proto.GetType()
 }
 
-// GetTypeString returns a lower-cased string that represents the type of this field.
-func (fd *FieldDescriptor) GetTypeString() string {
-	return strings.ToLower(fd.proto.GetType().String())
-}
-
 // GetLabel returns the label for this field. The label can be required (proto2-only),
 // optional (default for proto3), or required.
 func (fd *FieldDescriptor) GetLabel() dpb.FieldDescriptorProto_Label {
@@ -999,6 +994,10 @@ func (fd *FieldDescriptor) GetMessageType() *MessageDescriptor {
 // field is not an enum type, it returns nil.
 func (fd *FieldDescriptor) GetEnumType() *EnumDescriptor {
 	return fd.enumType
+}
+
+func (fd *FieldDescriptor) getTypeString() string {
+	return strings.ToLower(fd.proto.GetType().String())
 }
 
 // GetDefaultValue returns the default value for this field.

--- a/desc/descriptor.go
+++ b/desc/descriptor.go
@@ -943,6 +943,11 @@ func (fd *FieldDescriptor) GetType() dpb.FieldDescriptorProto_Type {
 	return fd.proto.GetType()
 }
 
+// GetTypeString returns a lower-cased string that represents the type of this field.
+func (fd *FieldDescriptor) GetTypeString() string {
+	return strings.ToLower(fd.proto.GetType().String())
+}
+
 // GetLabel returns the label for this field. The label can be required (proto2-only),
 // optional (default for proto3), or required.
 func (fd *FieldDescriptor) GetLabel() dpb.FieldDescriptorProto_Label {

--- a/dynamic/dynamic_message.go
+++ b/dynamic/dynamic_message.go
@@ -1921,44 +1921,45 @@ func validElementFieldValue(fd *desc.FieldDescriptor, val interface{}) (interfac
 
 func validElementFieldValueForRv(fd *desc.FieldDescriptor, val reflect.Value) (interface{}, error) {
 	t := fd.GetType()
-	typeName := strings.ToLower(t.String())
 	if !val.IsValid() {
-		return nil, fmt.Errorf("%s field %s is not compatible with nil value", typeName, fd.GetFullyQualifiedName())
+		return nil, fmt.Errorf(
+			"%s field %s is not compatible with nil value", fd.GetTypeString(), fd.GetFullyQualifiedName())
 	}
+
 	switch t {
 	case descriptor.FieldDescriptorProto_TYPE_SFIXED32,
 		descriptor.FieldDescriptorProto_TYPE_INT32,
 		descriptor.FieldDescriptorProto_TYPE_SINT32,
 		descriptor.FieldDescriptorProto_TYPE_ENUM:
-		return toInt32(reflect.Indirect(val), typeName, fd.GetFullyQualifiedName())
+		return toInt32(reflect.Indirect(val), fd)
 
 	case descriptor.FieldDescriptorProto_TYPE_SFIXED64,
 		descriptor.FieldDescriptorProto_TYPE_INT64,
 		descriptor.FieldDescriptorProto_TYPE_SINT64:
-		return toInt64(reflect.Indirect(val), typeName, fd.GetFullyQualifiedName())
+		return toInt64(reflect.Indirect(val), fd)
 
 	case descriptor.FieldDescriptorProto_TYPE_FIXED32,
 		descriptor.FieldDescriptorProto_TYPE_UINT32:
-		return toUint32(reflect.Indirect(val), typeName, fd.GetFullyQualifiedName())
+		return toUint32(reflect.Indirect(val), fd)
 
 	case descriptor.FieldDescriptorProto_TYPE_FIXED64,
 		descriptor.FieldDescriptorProto_TYPE_UINT64:
-		return toUint64(reflect.Indirect(val), typeName, fd.GetFullyQualifiedName())
+		return toUint64(reflect.Indirect(val), fd)
 
 	case descriptor.FieldDescriptorProto_TYPE_FLOAT:
-		return toFloat32(reflect.Indirect(val), typeName, fd.GetFullyQualifiedName())
+		return toFloat32(reflect.Indirect(val), fd)
 
 	case descriptor.FieldDescriptorProto_TYPE_DOUBLE:
-		return toFloat64(reflect.Indirect(val), typeName, fd.GetFullyQualifiedName())
+		return toFloat64(reflect.Indirect(val), fd)
 
 	case descriptor.FieldDescriptorProto_TYPE_BOOL:
-		return toBool(reflect.Indirect(val), typeName, fd.GetFullyQualifiedName())
+		return toBool(reflect.Indirect(val), fd)
 
 	case descriptor.FieldDescriptorProto_TYPE_BYTES:
-		return toBytes(reflect.Indirect(val), typeName, fd.GetFullyQualifiedName())
+		return toBytes(reflect.Indirect(val), fd)
 
 	case descriptor.FieldDescriptorProto_TYPE_STRING:
-		return toString(reflect.Indirect(val), typeName, fd.GetFullyQualifiedName())
+		return toString(reflect.Indirect(val), fd)
 
 	case descriptor.FieldDescriptorProto_TYPE_MESSAGE,
 		descriptor.FieldDescriptorProto_TYPE_GROUP:
@@ -1983,67 +1984,85 @@ func validElementFieldValueForRv(fd *desc.FieldDescriptor, val reflect.Value) (i
 	}
 }
 
-func toInt32(v reflect.Value, what string, fieldName string) (int32, error) {
+func toInt32(v reflect.Value, fd *desc.FieldDescriptor) (int32, error) {
 	if v.Kind() == reflect.Int32 {
 		return int32(v.Int()), nil
 	}
-	return 0, fmt.Errorf("%s field %s is not compatible with value of type %v", what, fieldName, v.Type())
+	return 0, fmt.Errorf(
+		"%s field %s is not compatible with value of type %v",
+		fd.GetTypeString(), fd.GetFullyQualifiedName(), v.Type())
 }
 
-func toUint32(v reflect.Value, what string, fieldName string) (uint32, error) {
+func toUint32(v reflect.Value, fd *desc.FieldDescriptor) (uint32, error) {
 	if v.Kind() == reflect.Uint32 {
 		return uint32(v.Uint()), nil
 	}
-	return 0, fmt.Errorf("%s field %s is not compatible with value of type %v", what, fieldName, v.Type())
+	return 0, fmt.Errorf(
+		"%s field %s is not compatible with value of type %v",
+		fd.GetTypeString(), fd.GetFullyQualifiedName(), v.Type())
 }
 
-func toFloat32(v reflect.Value, what string, fieldName string) (float32, error) {
+func toFloat32(v reflect.Value, fd *desc.FieldDescriptor) (float32, error) {
 	if v.Kind() == reflect.Float32 {
 		return float32(v.Float()), nil
 	}
-	return 0, fmt.Errorf("%s field %s is not compatible with value of type %v", what, fieldName, v.Type())
+	return 0, fmt.Errorf(
+		"%s field %s is not compatible with value of type %v",
+		fd.GetTypeString(), fd.GetFullyQualifiedName(), v.Type())
 }
 
-func toInt64(v reflect.Value, what string, fieldName string) (int64, error) {
+func toInt64(v reflect.Value, fd *desc.FieldDescriptor) (int64, error) {
 	if v.Kind() == reflect.Int64 || v.Kind() == reflect.Int || v.Kind() == reflect.Int32 {
 		return v.Int(), nil
 	}
-	return 0, fmt.Errorf("%s field %s is not compatible with value of type %v", what, fieldName, v.Type())
+	return 0, fmt.Errorf(
+		"%s field %s is not compatible with value of type %v",
+		fd.GetTypeString(), fd.GetFullyQualifiedName(), v.Type())
 }
 
-func toUint64(v reflect.Value, what string, fieldName string) (uint64, error) {
+func toUint64(v reflect.Value, fd *desc.FieldDescriptor) (uint64, error) {
 	if v.Kind() == reflect.Uint64 || v.Kind() == reflect.Uint || v.Kind() == reflect.Uint32 {
 		return v.Uint(), nil
 	}
-	return 0, fmt.Errorf("%s field %s is not compatible with value of type %v", what, fieldName, v.Type())
+	return 0, fmt.Errorf(
+		"%s field %s is not compatible with value of type %v",
+		fd.GetTypeString(), fd.GetFullyQualifiedName(), v.Type())
 }
 
-func toFloat64(v reflect.Value, what string, fieldName string) (float64, error) {
+func toFloat64(v reflect.Value, fd *desc.FieldDescriptor) (float64, error) {
 	if v.Kind() == reflect.Float64 || v.Kind() == reflect.Float32 {
 		return v.Float(), nil
 	}
-	return 0, fmt.Errorf("%s field %s is not compatible with value of type %v", what, fieldName, v.Type())
+	return 0, fmt.Errorf(
+		"%s field %s is not compatible with value of type %v",
+		fd.GetTypeString(), fd.GetFullyQualifiedName(), v.Type())
 }
 
-func toBool(v reflect.Value, what string, fieldName string) (bool, error) {
+func toBool(v reflect.Value, fd *desc.FieldDescriptor) (bool, error) {
 	if v.Kind() == reflect.Bool {
 		return v.Bool(), nil
 	}
-	return false, fmt.Errorf("%s field %s is not compatible with value of type %v", what, fieldName, v.Type())
+	return false, fmt.Errorf(
+		"%s field %s is not compatible with value of type %v",
+		fd.GetTypeString(), fd.GetFullyQualifiedName(), v.Type())
 }
 
-func toBytes(v reflect.Value, what string, fieldName string) ([]byte, error) {
+func toBytes(v reflect.Value, fd *desc.FieldDescriptor) ([]byte, error) {
 	if v.Kind() == reflect.Slice && v.Type().Elem().Kind() == reflect.Uint8 {
 		return v.Bytes(), nil
 	}
-	return nil, fmt.Errorf("%s field %s is not compatible with value of type %v", what, fieldName, v.Type())
+	return nil, fmt.Errorf(
+		"%s field %s is not compatible with value of type %v",
+		fd.GetTypeString(), fd.GetFullyQualifiedName(), v.Type())
 }
 
-func toString(v reflect.Value, what string, fieldName string) (string, error) {
+func toString(v reflect.Value, fd *desc.FieldDescriptor) (string, error) {
 	if v.Kind() == reflect.String {
 		return v.String(), nil
 	}
-	return "", fmt.Errorf("%s field %s is not compatible with value of type %v", what, fieldName, v.Type())
+	return "", fmt.Errorf(
+		"%s field %s is not compatible with value of type %v",
+		fd.GetTypeString(), fd.GetFullyQualifiedName(), v.Type())
 }
 
 func asMessage(v reflect.Value, fieldName string) (proto.Message, error) {

--- a/dynamic/dynamic_message.go
+++ b/dynamic/dynamic_message.go
@@ -1922,7 +1922,7 @@ func validElementFieldValue(fd *desc.FieldDescriptor, val interface{}) (interfac
 func validElementFieldValueForRv(fd *desc.FieldDescriptor, val reflect.Value) (interface{}, error) {
 	t := fd.GetType()
 	if !val.IsValid() {
-		return nil, typeError(fd, val.Type())
+		return nil, typeError(fd, nil)
 	}
 
 	switch t {

--- a/dynamic/dynamic_message.go
+++ b/dynamic/dynamic_message.go
@@ -1922,8 +1922,7 @@ func validElementFieldValue(fd *desc.FieldDescriptor, val interface{}) (interfac
 func validElementFieldValueForRv(fd *desc.FieldDescriptor, val reflect.Value) (interface{}, error) {
 	t := fd.GetType()
 	if !val.IsValid() {
-		return nil, fmt.Errorf(
-			"%s field %s is not compatible with nil value", fd.GetTypeString(), fd.GetFullyQualifiedName())
+		return nil, typeError(fd, val.Type())
 	}
 
 	switch t {
@@ -1988,81 +1987,73 @@ func toInt32(v reflect.Value, fd *desc.FieldDescriptor) (int32, error) {
 	if v.Kind() == reflect.Int32 {
 		return int32(v.Int()), nil
 	}
-	return 0, fmt.Errorf(
-		"%s field %s is not compatible with value of type %v",
-		fd.GetTypeString(), fd.GetFullyQualifiedName(), v.Type())
+	return 0, typeError(fd, v.Type())
 }
 
 func toUint32(v reflect.Value, fd *desc.FieldDescriptor) (uint32, error) {
 	if v.Kind() == reflect.Uint32 {
 		return uint32(v.Uint()), nil
 	}
-	return 0, fmt.Errorf(
-		"%s field %s is not compatible with value of type %v",
-		fd.GetTypeString(), fd.GetFullyQualifiedName(), v.Type())
+	return 0, typeError(fd, v.Type())
 }
 
 func toFloat32(v reflect.Value, fd *desc.FieldDescriptor) (float32, error) {
 	if v.Kind() == reflect.Float32 {
 		return float32(v.Float()), nil
 	}
-	return 0, fmt.Errorf(
-		"%s field %s is not compatible with value of type %v",
-		fd.GetTypeString(), fd.GetFullyQualifiedName(), v.Type())
+	return 0, typeError(fd, v.Type())
 }
 
 func toInt64(v reflect.Value, fd *desc.FieldDescriptor) (int64, error) {
 	if v.Kind() == reflect.Int64 || v.Kind() == reflect.Int || v.Kind() == reflect.Int32 {
 		return v.Int(), nil
 	}
-	return 0, fmt.Errorf(
-		"%s field %s is not compatible with value of type %v",
-		fd.GetTypeString(), fd.GetFullyQualifiedName(), v.Type())
+	return 0, typeError(fd, v.Type())
 }
 
 func toUint64(v reflect.Value, fd *desc.FieldDescriptor) (uint64, error) {
 	if v.Kind() == reflect.Uint64 || v.Kind() == reflect.Uint || v.Kind() == reflect.Uint32 {
 		return v.Uint(), nil
 	}
-	return 0, fmt.Errorf(
-		"%s field %s is not compatible with value of type %v",
-		fd.GetTypeString(), fd.GetFullyQualifiedName(), v.Type())
+	return 0, typeError(fd, v.Type())
 }
 
 func toFloat64(v reflect.Value, fd *desc.FieldDescriptor) (float64, error) {
 	if v.Kind() == reflect.Float64 || v.Kind() == reflect.Float32 {
 		return v.Float(), nil
 	}
-	return 0, fmt.Errorf(
-		"%s field %s is not compatible with value of type %v",
-		fd.GetTypeString(), fd.GetFullyQualifiedName(), v.Type())
+	return 0, typeError(fd, v.Type())
 }
 
 func toBool(v reflect.Value, fd *desc.FieldDescriptor) (bool, error) {
 	if v.Kind() == reflect.Bool {
 		return v.Bool(), nil
 	}
-	return false, fmt.Errorf(
-		"%s field %s is not compatible with value of type %v",
-		fd.GetTypeString(), fd.GetFullyQualifiedName(), v.Type())
+	return false, typeError(fd, v.Type())
 }
 
 func toBytes(v reflect.Value, fd *desc.FieldDescriptor) ([]byte, error) {
 	if v.Kind() == reflect.Slice && v.Type().Elem().Kind() == reflect.Uint8 {
 		return v.Bytes(), nil
 	}
-	return nil, fmt.Errorf(
-		"%s field %s is not compatible with value of type %v",
-		fd.GetTypeString(), fd.GetFullyQualifiedName(), v.Type())
+	return nil, typeError(fd, v.Type())
 }
 
 func toString(v reflect.Value, fd *desc.FieldDescriptor) (string, error) {
 	if v.Kind() == reflect.String {
 		return v.String(), nil
 	}
-	return "", fmt.Errorf(
+	return "", typeError(fd, v.Type())
+}
+
+func typeError(fd *desc.FieldDescriptor, t reflect.Type) error {
+	return fmt.Errorf(
 		"%s field %s is not compatible with value of type %v",
-		fd.GetTypeString(), fd.GetFullyQualifiedName(), v.Type())
+		getTypeString(fd), fd.GetFullyQualifiedName(), t)
+}
+
+func getTypeString(fd *desc.FieldDescriptor) string {
+	return strings.ToLower(fd.GetType().String())
 }
 
 func asMessage(v reflect.Value, fieldName string) (proto.Message, error) {


### PR DESCRIPTION
I've been benchmarking our usage of this library and a lot of time (and allocations) are being spent wastefully generating strings that are only used if an error occurs.

This P.R tweaks the implementation slightly to only create the strings if an error takes place, greatly increasing throughput and reducing allocations in the normal case.