### PR TITLE
[PERF] Reset maps instead of setting to nil to save allocations

### DIFF
--- a/dynamic/dynamic_message.go
+++ b/dynamic/dynamic_message.go
@@ -2058,8 +2058,12 @@ func asMessage(v reflect.Value, fieldName string) (proto.Message, error) {
 // Reset resets this message to an empty message. It removes all values set in
 // the message.
 func (m *Message) Reset() {
-	m.values = nil
-	m.unknownFields = nil
+	for k := range m.values {
+		delete(m.values, k)
+	}
+	for k := range m.unknownFields {
+		delete(m.unknownFields, k)
+	}
 }
 
 // String returns this message rendered in compact text format.


### PR DESCRIPTION
Reset currently allows callers to reuse the `*dynamic.Message` but not its internally allocated data structures. This prevents the `values` and `unknownFields` maps from having to be re-allocated.