### PR TITLE
Optimize mapsEqual() in the case where both maps are empty

### DIFF
--- a/dynamic/equal.go
+++ b/dynamic/equal.go
@@ -116,6 +116,12 @@ func mapsEqual(a, b reflect.Value) bool {
 	if a.Len() != b.Len() {
 		return false
 	}
+	if a.Len() == 0 && b.Len() == 0 {
+		// Optimize the case where maps are frequently empty because MapKeys()
+		// function allocates heavily.
+		return true
+	}
+
 	for _, k := range a.MapKeys() {
 		av := a.MapIndex(k)
 		bv := b.MapIndex(k)


### PR DESCRIPTION
I'm actually maintaining a fork of this file because I needed FieldsEqual() to be exposed (not sure if you're open to making that public) but this small tweak made a big difference for me because MapKeys() can be expensive in tight loops (allocates a lot)