### PR TITLE
Only set syntax if proto3

### DIFF
--- a/desc/protoparse/linker_test.go
+++ b/desc/protoparse/linker_test.go
@@ -25,12 +25,6 @@ func TestSimpleLink(t *testing.T) {
 	var files dpb.FileDescriptorSet
 	err = proto.Unmarshal(b, &files)
 	testutil.Ok(t, err)
-
-	// protoc does not set syntax field if it is proto2, but we do
-	// so set it just so we can compare apples to apples
-	if files.File[0].Syntax == nil {
-		files.File[0].Syntax = proto.String("proto2")
-	}
 	testutil.Require(t, proto.Equal(files.File[0], fds[0].AsProto()), "linked descriptor did not match output from protoc:\nwanted: %s\ngot: %s", toString(files.File[0]), toString(fds[0].AsProto()))
 }
 
@@ -52,12 +46,6 @@ func checkFiles(t *testing.T, act, exp *desc.FileDescriptor, checked map[string]
 		return
 	}
 	checked[act.GetName()] = struct{}{}
-
-	// protoc does not set syntax field if it is proto2, so modify
-	// ours to follow suit so we can compare apples to apples
-	if act.AsFileDescriptorProto().GetSyntax() == "proto2" {
-		act.AsFileDescriptorProto().Syntax = nil
-	}
 
 	testutil.Require(t, proto.Equal(exp.AsFileDescriptorProto(), act.AsProto()), "linked descriptor did not match output from protoc:\nwanted: %s\ngot: %s", toString(exp.AsProto()), toString(act.AsProto()))
 

--- a/desc/protoparse/parser.go
+++ b/desc/protoparse/parser.go
@@ -601,7 +601,7 @@ func (r *parseResult) createFileDescriptor(filename string, file *fileNode) erro
 	isProto3 := false
 	if file.syntax != nil {
 		isProto3 = file.syntax.syntax.val == "proto3"
-		// https://github.com/protocolbuffers/protobuf/blob/0c3f43a6190b77f1f68b7425d1b7e1a8257a8d0c/src/google/protobuf/descriptor.cc#L2014
+		// proto2 is the default, so no need to set unless proto3
 		if isProto3 {
 			fd.Syntax = proto.String(file.syntax.syntax.val)
 		}

--- a/desc/protoparse/parser.go
+++ b/desc/protoparse/parser.go
@@ -600,8 +600,11 @@ func (r *parseResult) createFileDescriptor(filename string, file *fileNode) erro
 
 	isProto3 := false
 	if file.syntax != nil {
-		fd.Syntax = proto.String(file.syntax.syntax.val)
 		isProto3 = file.syntax.syntax.val == "proto3"
+		// https://github.com/protocolbuffers/protobuf/blob/0c3f43a6190b77f1f68b7425d1b7e1a8257a8d0c/src/google/protobuf/descriptor.cc#L2014
+		if isProto3 {
+			fd.Syntax = proto.String(file.syntax.syntax.val)
+		}
 	}
 
 	for _, decl := range file.decls {


### PR DESCRIPTION
Using same testing methodology as in #201 but adding `--include_imports`:

```
$ cat tmp.bash
#!/usr/bin/env bash

set -eo pipefail

rm -f protoc.json goprotoc.json
prototool descriptor-set --include-imports --protoc-bin-path="$(which protoc)" --protoc-wkt-path=/usr/local/include --json | jq . > protoc.json
prototool descriptor-set --include-imports --protoc-bin-path="$(which goprotoc)" --protoc-wkt-path=/usr/local/include --json | jq . > goprotoc.json
diff protoc.json goprotoc.json
```

Then running this script:

```
bash tmp.bash
```

This produces the following result:

```diff
206637c206637,206638
<       }
---
>       },
>       "syntax": "proto2"
```

This is because the FileDescriptorProtos returned from `protoc` only have the syntax set if the syntax is `"proto3"`. See https://github.com/protocolbuffers/protobuf/blob/0c3f43a6190b77f1f68b7425d1b7e1a8257a8d0c/src/google/protobuf/descriptor.cc#L2014

This changes `desc/protoparse` to match this behavior. After applying this patch, no diff is produced from `tmp.bash` above.