### PR TITLE
fix: return input type rather than reflect.Value from deleteBuilder

### DIFF
--- a/desc/builder/builders.go
+++ b/desc/builder/builders.go
@@ -410,7 +410,7 @@ func deleteBuilder(name string, descs interface{}) interface{} {
 		if c.GetName() == name {
 			head := rv.Slice(0, i)
 			tail := rv.Slice(i+1, rv.Len())
-			return reflect.AppendSlice(head, tail)
+			return reflect.AppendSlice(head, tail).Interface()
 		}
 	}
 	return descs

--- a/desc/builder/builders_test.go
+++ b/desc/builder/builders_test.go
@@ -959,3 +959,18 @@ func checkBuildWithExtensions(t *testing.T, exts *dynamic.ExtensionRegistry, exp
 	}
 	testutil.Require(t, found)
 }
+
+func TestRemoveField(t *testing.T) {
+	msg := NewMessage("FancyMessage").
+		AddField(NewField("one", FieldTypeInt64())).
+		AddField(NewField("two", FieldTypeString())).
+		AddField(NewField("three", FieldTypeString()))
+
+	ok := msg.TryRemoveField("two")
+	children := msg.GetChildren()
+
+	testutil.Require(t, ok)
+	testutil.Eq(t, 2, len(children))
+	testutil.Eq(t, "one", children[0].GetName())
+	testutil.Eq(t, "three", children[1].GetName())
+}


### PR DESCRIPTION
Previously deleteBuilder returns the newly formed reflect.Value slice rather than the original interface{} type, this PR fixes that and adds a basic test case


Before patch:
```
=== RUN   TestRemoveField
--- FAIL: TestRemoveField (0.00s)
panic: interface conversion: interface {} is reflect.Value, not []builder.Builder [recovered]
	panic: interface conversion: interface {} is reflect.Value, not []builder.Builder

goroutine 5 [running]:
testing.tRunner.func1(0xc0421500f0)
	C:/Go/src/testing/testing.go:742 +0x2a4
panic(0x8d9920, 0xc042028b40)
	C:/Go/src/runtime/panic.go:502 +0x237
github.com/jhump/protoreflect/desc/builder.(*MessageBuilder).removeChild(0xc04214c240, 0x9e8240, 0xc04214a160)
	C:/Users/USERNAME/Dev/src/github.com/jhump/protoreflect/desc/builder/builders.go:1273 +0x77b
github.com/jhump/protoreflect/desc/builder.(*MessageBuilder).TryRemoveField(0xc04214c240, 0x97a560, 0x3, 0xc04214a210)
	C:/Users/USERNAME/Dev/src/github.com/jhump/protoreflect/desc/builder/builders.go:1371 +0xb7
github.com/jhump/protoreflect/desc/builder.TestRemoveField(0xc0421500f0)
	C:/Users/USERNAME/Dev/src/github.com/jhump/protoreflect/desc/builder/builders_test.go:969 +0x152
testing.tRunner(0xc0421500f0, 0x9a12f0)
	C:/Go/src/testing/testing.go:777 +0xd7
created by testing.(*T).Run
	C:/Go/src/testing/testing.go:824 +0x2e7

Process finished with exit code 1
```


Sidenote: It seems some of the tests are not compatible with Windows as they expect `/` rather than `\` when testing import paths such as in `github.com/jhump/protoreflect/desc/imports_test.go:41` which results in the failure `Expecting foo/bar.proto (string), got foo\bar.proto (string)`