### PR TITLE
fix message registry base URLs

### DIFF
--- a/dynamic/msgregistry/message_registry.go
+++ b/dynamic/msgregistry/message_registry.go
@@ -675,7 +675,18 @@ func syntax(fd *desc.FileDescriptor) ptype.Syntax {
 // The given descriptor must be an enum or message descriptor. This will use any
 // registered URLs and base URLs to determine the appropriate URL for the given
 // type.
+//
+// Deprecated: This method is deprecated due to its use of non-idiomatic naming.
+// Use ComputeURL instead.
 func (r *MessageRegistry) ComputeUrl(d desc.Descriptor) string {
+	return r.ComputeURL(d)
+}
+
+// ComputeURL computes a type URL string for the element described by the given
+// descriptor. The given descriptor must be an enum or message descriptor. This
+// will use any registered URLs and base URLs to determine the appropriate URL
+// for the given type.
+func (r *MessageRegistry) ComputeURL(d desc.Descriptor) string {
 	name, pkg := d.GetFullyQualifiedName(), d.GetFile().GetPackage()
 	r.mu.RLock()
 	baseUrl := r.baseUrls[name]

--- a/dynamic/msgregistry/message_registry.go
+++ b/dynamic/msgregistry/message_registry.go
@@ -91,10 +91,11 @@ func stripTrailingSlash(url string) string {
 
 // AddMessage adds the given URL and associated message descriptor to the registry.
 func (r *MessageRegistry) AddMessage(url string, md *desc.MessageDescriptor) error {
-	if !strings.HasSuffix(url, "/"+md.GetFullyQualifiedName()) {
+	url = ensureScheme(url)
+	baseUrl := strings.TrimSuffix(url, "/"+md.GetFullyQualifiedName())
+	if url == baseUrl {
 		return fmt.Errorf("URL %s is invalid: it should end with path element %s", url, md.GetFullyQualifiedName())
 	}
-	url = ensureScheme(url)
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.types == nil {
@@ -104,16 +105,17 @@ func (r *MessageRegistry) AddMessage(url string, md *desc.MessageDescriptor) err
 	if r.baseUrls == nil {
 		r.baseUrls = map[string]string{}
 	}
-	r.baseUrls[md.GetFullyQualifiedName()] = url
+	r.baseUrls[md.GetFullyQualifiedName()] = baseUrl
 	return nil
 }
 
 // AddEnum adds the given URL and associated enum descriptor to the registry.
 func (r *MessageRegistry) AddEnum(url string, ed *desc.EnumDescriptor) error {
-	if !strings.HasSuffix(url, "/"+ed.GetFullyQualifiedName()) {
+	url = ensureScheme(url)
+	baseUrl := strings.TrimSuffix(url, "/"+ed.GetFullyQualifiedName())
+	if url == baseUrl {
 		return fmt.Errorf("URL %s is invalid: it should end with path element %s", url, ed.GetFullyQualifiedName())
 	}
-	url = ensureScheme(url)
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.types == nil {
@@ -123,7 +125,7 @@ func (r *MessageRegistry) AddEnum(url string, ed *desc.EnumDescriptor) error {
 	if r.baseUrls == nil {
 		r.baseUrls = map[string]string{}
 	}
-	r.baseUrls[ed.GetFullyQualifiedName()] = url
+	r.baseUrls[ed.GetFullyQualifiedName()] = baseUrl
 	return nil
 }
 
@@ -147,7 +149,7 @@ func (r *MessageRegistry) addEnumTypesLocked(baseUrl string, enums []*desc.EnumD
 	for _, ed := range enums {
 		url := fmt.Sprintf("%s/%s", baseUrl, ed.GetFullyQualifiedName())
 		r.types[url] = ed
-		r.baseUrls[ed.GetFullyQualifiedName()] = url
+		r.baseUrls[ed.GetFullyQualifiedName()] = baseUrl
 	}
 }
 
@@ -155,7 +157,7 @@ func (r *MessageRegistry) addMessageTypesLocked(baseUrl string, msgs []*desc.Mes
 	for _, md := range msgs {
 		url := fmt.Sprintf("%s/%s", baseUrl, md.GetFullyQualifiedName())
 		r.types[url] = md
-		r.baseUrls[md.GetFullyQualifiedName()] = url
+		r.baseUrls[md.GetFullyQualifiedName()] = baseUrl
 		r.addEnumTypesLocked(baseUrl, md.GetNestedEnumTypes())
 		r.addMessageTypesLocked(baseUrl, md.GetNestedMessageTypes())
 	}

--- a/dynamic/msgregistry/message_registry_test.go
+++ b/dynamic/msgregistry/message_registry_test.go
@@ -43,9 +43,11 @@ func TestMessageRegistry_LookupTypes(t *testing.T) {
 	msg, err := mr.FindMessageTypeByUrl("foo.bar/google.protobuf.DescriptorProto")
 	testutil.Ok(t, err)
 	testutil.Eq(t, md, msg)
+	testutil.Eq(t, "https://foo.bar/google.protobuf.DescriptorProto", mr.ComputeURL(md))
 	en, err := mr.FindEnumTypeByUrl("foo.bar/google.protobuf.FieldDescriptorProto.Type")
 	testutil.Ok(t, err)
 	testutil.Eq(t, ed, en)
+	testutil.Eq(t, "https://foo.bar/google.protobuf.FieldDescriptorProto.Type", mr.ComputeURL(ed))
 
 	// right name but wrong domain? not found
 	msg, err = mr.FindMessageTypeByUrl("type.googleapis.com/google.protobuf.DescriptorProto")
@@ -81,6 +83,32 @@ func TestMessageRegistry_LookupTypes(t *testing.T) {
 	testutil.Ok(t, err)
 	testutil.Ceq(t, dur, pm, eqm)
 	testutil.Eq(t, reflect.TypeOf((*duration.Duration)(nil)), reflect.TypeOf(pm))
+
+	fd, err := desc.LoadFileDescriptor("desc_test1.proto")
+	testutil.Ok(t, err)
+	mr.AddFile("frob.nitz/foo.bar", fd)
+	msgCount, enumCount := 0, 0
+	mds := fd.GetMessageTypes()
+	for i := 0; i < len(mds); i++ {
+		md := mds[i]
+		msgCount++
+		mds = append(mds, md.GetNestedMessageTypes()...)
+		exp := fmt.Sprintf("https://frob.nitz/foo.bar/%s", md.GetFullyQualifiedName())
+		testutil.Eq(t, exp, mr.ComputeURL(md))
+		for _, ed := range md.GetNestedEnumTypes() {
+			enumCount++
+			exp := fmt.Sprintf("https://frob.nitz/foo.bar/%s", ed.GetFullyQualifiedName())
+			testutil.Eq(t, exp, mr.ComputeURL(ed))
+		}
+	}
+	for _, ed := range fd.GetEnumTypes() {
+		enumCount++
+		exp := fmt.Sprintf("https://frob.nitz/foo.bar/%s", ed.GetFullyQualifiedName())
+		testutil.Eq(t, exp, mr.ComputeURL(ed))
+	}
+	// sanity check
+	testutil.Eq(t, 10, msgCount)
+	testutil.Eq(t, 2, enumCount)
 }
 
 func TestMessageRegistry_LookupTypes_WithDefaults(t *testing.T) {
@@ -142,7 +170,8 @@ func TestMessageRegistry_FindMessage_WithFetcher(t *testing.T) {
 	mo := &descriptor.MessageOptions{
 		Deprecated: proto.Bool(true),
 	}
-	proto.SetExtension(mo, testprotos.E_Mfubar, proto.Bool(true))
+	err = proto.SetExtension(mo, testprotos.E_Mfubar, proto.Bool(true))
+	testutil.Ok(t, err)
 	testutil.Ceq(t, mo, md.GetMessageOptions(), eqpm)
 
 	flds := md.GetFields()
@@ -156,8 +185,10 @@ func TestMessageRegistry_FindMessage_WithFetcher(t *testing.T) {
 	fo := &descriptor.FieldOptions{
 		Deprecated: proto.Bool(true),
 	}
-	proto.SetExtension(fo, testprotos.E_Ffubar, []string{"foo", "bar", "baz"})
-	proto.SetExtension(fo, testprotos.E_Ffubarb, []byte{1, 2, 3, 4, 5, 6, 7, 8})
+	err = proto.SetExtension(fo, testprotos.E_Ffubar, []string{"foo", "bar", "baz"})
+	testutil.Ok(t, err)
+	err = proto.SetExtension(fo, testprotos.E_Ffubarb, []byte{1, 2, 3, 4, 5, 6, 7, 8})
+	testutil.Ok(t, err)
 	testutil.Ceq(t, fo, flds[0].GetFieldOptions(), eqpm)
 
 	testutil.Eq(t, "b", flds[1].GetName())
@@ -344,11 +375,16 @@ func TestMessageRegistry_FindEnum_WithFetcher(t *testing.T) {
 		Deprecated: proto.Bool(true),
 		AllowAlias: proto.Bool(true),
 	}
-	proto.SetExtension(eo, testprotos.E_Efubar, proto.Int32(-42))
-	proto.SetExtension(eo, testprotos.E_Efubars, proto.Int32(-42))
-	proto.SetExtension(eo, testprotos.E_Efubarsf, proto.Int32(-42))
-	proto.SetExtension(eo, testprotos.E_Efubaru, proto.Uint32(42))
-	proto.SetExtension(eo, testprotos.E_Efubaruf, proto.Uint32(42))
+	err = proto.SetExtension(eo, testprotos.E_Efubar, proto.Int32(-42))
+	testutil.Ok(t, err)
+	err = proto.SetExtension(eo, testprotos.E_Efubars, proto.Int32(-42))
+	testutil.Ok(t, err)
+	err = proto.SetExtension(eo, testprotos.E_Efubarsf, proto.Int32(-42))
+	testutil.Ok(t, err)
+	err = proto.SetExtension(eo, testprotos.E_Efubaru, proto.Uint32(42))
+	testutil.Ok(t, err)
+	err = proto.SetExtension(eo, testprotos.E_Efubaruf, proto.Uint32(42))
+	testutil.Ok(t, err)
 	testutil.Ceq(t, eo, ed.GetEnumOptions(), eqpm)
 
 	vals := ed.GetValues()
@@ -359,11 +395,16 @@ func TestMessageRegistry_FindEnum_WithFetcher(t *testing.T) {
 	evo := &descriptor.EnumValueOptions{
 		Deprecated: proto.Bool(true),
 	}
-	proto.SetExtension(evo, testprotos.E_Evfubar, proto.Int64(-420420420420))
-	proto.SetExtension(evo, testprotos.E_Evfubars, proto.Int64(-420420420420))
-	proto.SetExtension(evo, testprotos.E_Evfubarsf, proto.Int64(-420420420420))
-	proto.SetExtension(evo, testprotos.E_Evfubaru, proto.Uint64(420420420420))
-	proto.SetExtension(evo, testprotos.E_Evfubaruf, proto.Uint64(420420420420))
+	err = proto.SetExtension(evo, testprotos.E_Evfubar, proto.Int64(-420420420420))
+	testutil.Ok(t, err)
+	err = proto.SetExtension(evo, testprotos.E_Evfubars, proto.Int64(-420420420420))
+	testutil.Ok(t, err)
+	err = proto.SetExtension(evo, testprotos.E_Evfubarsf, proto.Int64(-420420420420))
+	testutil.Ok(t, err)
+	err = proto.SetExtension(evo, testprotos.E_Evfubaru, proto.Uint64(420420420420))
+	testutil.Ok(t, err)
+	err = proto.SetExtension(evo, testprotos.E_Evfubaruf, proto.Uint64(420420420420))
+	testutil.Ok(t, err)
 	testutil.Ceq(t, evo, vals[0].GetEnumValueOptions(), eqpm)
 
 	testutil.Eq(t, "XYZ", vals[1].GetName())
@@ -609,8 +650,10 @@ func TestMessageRegistry_ResolveApiIntoServiceDescriptor(t *testing.T) {
 	so := &descriptor.ServiceOptions{
 		Deprecated: proto.Bool(true),
 	}
-	proto.SetExtension(so, testprotos.E_Sfubar, &testprotos.ReallySimpleMessage{Id: proto.Uint64(100), Name: proto.String("deuce")})
-	proto.SetExtension(so, testprotos.E_Sfubare, testprotos.ReallySimpleEnum_VALUE.Enum())
+	err = proto.SetExtension(so, testprotos.E_Sfubar, &testprotos.ReallySimpleMessage{Id: proto.Uint64(100), Name: proto.String("deuce")})
+	testutil.Ok(t, err)
+	err = proto.SetExtension(so, testprotos.E_Sfubare, testprotos.ReallySimpleEnum_VALUE.Enum())
+	testutil.Ok(t, err)
 	testutil.Ceq(t, so, sd.GetServiceOptions(), eqpm)
 
 	methods := sd.GetMethods()
@@ -622,8 +665,10 @@ func TestMessageRegistry_ResolveApiIntoServiceDescriptor(t *testing.T) {
 	mto := &descriptor.MethodOptions{
 		Deprecated: proto.Bool(true),
 	}
-	proto.SetExtension(mto, testprotos.E_Mtfubar, []float32{3.14159, 2.71828})
-	proto.SetExtension(mto, testprotos.E_Mtfubard, proto.Float64(10203040.506070809))
+	err = proto.SetExtension(mto, testprotos.E_Mtfubar, []float32{3.14159, 2.71828})
+	testutil.Ok(t, err)
+	err = proto.SetExtension(mto, testprotos.E_Mtfubard, proto.Float64(10203040.506070809))
+	testutil.Ok(t, err)
 	testutil.Ceq(t, mto, methods[0].GetMethodOptions(), eqpm)
 
 	testutil.Eq(t, "ClientStreamMethod", methods[1].GetName())
@@ -785,7 +830,8 @@ func TestMessageRegistry_MarshalAndUnmarshalAny(t *testing.T) {
 	// and that we can unmarshal it as a dynamic message, using a
 	// message registry that doesn't know about the generated type
 	mrWithoutDefaults := &MessageRegistry{}
-	mrWithoutDefaults.AddMessage("type.googleapis.com/google.protobuf.DescriptorProto", md)
+	err = mrWithoutDefaults.AddMessage("type.googleapis.com/google.protobuf.DescriptorProto", md)
+	testutil.Ok(t, err)
 	pm, err = mrWithoutDefaults.UnmarshalAny(a)
 	testutil.Ok(t, err)
 	dm, ok := pm.(*dynamic.Message)


### PR DESCRIPTION
Thanks for dropping those comments, @liortubi. Indeed, those were bugs that would cause the `ComputeUrl` function to return the wrong thing. There were actually a couple of other places where similar changes were needed. This PR also adds tests that reproduce the problems and demonstrate that these fixes are good.