### PR TITLE
Panic if internal.LoadFileDescriptor returns error for a WKT

### DIFF
--- a/desc/protoparse/std_imports.go
+++ b/desc/protoparse/std_imports.go
@@ -42,8 +42,9 @@ func init() {
 	standardImports = map[string]*dpb.FileDescriptorProto{}
 	for _, fn := range standardFilenames {
 		fd, err := internal.LoadFileDescriptor(fn)
-		if err == nil {
-			standardImports[fn] = fd
+		if err != nil {
+			panic(err.Error())
 		}
+		standardImports[fn] = fd
 	}
 }


### PR DESCRIPTION
It would probably be better to have a `getStandardImports() (map[string]*dpb.FileDescriptorProto, error)` function that `parseProtoFiles` calls, and this function uses a `sync.Once` to do the same thing as `init()` does now, but this is the simplest change/up to you. I think that if there is an error loading a standard import, it has the possibility of resulting in an error that is very hard to trace, and it's better to explicitly alert the user that this happened.