### PR TITLE
when parsing a well-known import, we also need to recursively parse its deps

### DIFF
--- a/desc/protoparse/std_imports_test.go
+++ b/desc/protoparse/std_imports_test.go
@@ -1,0 +1,18 @@
+package protoparse
+
+import (
+	"testing"
+
+	"github.com/jhump/protoreflect/internal/testutil"
+)
+
+func TestStdImports(t *testing.T) {
+	// make sure we can successfully parse all standard imports
+	var p Parser
+	for name, proto := range standardImports {
+		fds, err := p.ParseFiles(name)
+		testutil.Ok(t, err)
+		testutil.Eq(t, 1, len(fds))
+		testutil.Eq(t, proto, fds[0].AsFileDescriptorProto())
+	}
+}

--- a/internal/testutil/asserts.go
+++ b/internal/testutil/asserts.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"bytes"
 	"fmt"
 	"math"
 	"os"
@@ -161,7 +162,7 @@ func eqscalar(expected, actual interface{}) bool {
 	// special-case simple equality for []byte (since slices aren't directly comparable)
 	if e, ok := expected.([]byte); ok {
 		a, ok := actual.([]byte)
-		return ok && string(e) == string(a)
+		return ok && bytes.Equal(e, a)
 	}
 	// and special-cases to handle NaN
 	if e, ok := expected.(float32); ok && math.IsNaN(float64(e)) {


### PR DESCRIPTION
Fixes #219. Alternative to #220.