### PR TITLE
ResolveFilenames should work if some paths are relative to import path

### DIFF
--- a/desc/protoparse/parser_test.go
+++ b/desc/protoparse/parser_test.go
@@ -439,40 +439,6 @@ func TestParseFilesMessageComments(t *testing.T) {
 	testutil.Eq(t, expected, comments)
 }
 
-func TestResolveFilenames(t *testing.T) {
-	relImportPaths := []string{
-		"../../internal/testprotos/protoparse",
-	}
-	relFilePaths := []string{
-		"../../internal/testprotos/protoparse/a/b/b1.proto",
-		"../../internal/testprotos/protoparse/a/b/b2.proto",
-		"../../internal/testprotos/protoparse/c/c.proto",
-	}
-
-	absImportPaths, err := absoluteFilePaths(relImportPaths)
-	testutil.Require(t, err == nil, "%v", err)
-	absFilePaths, err := absoluteFilePaths(relFilePaths)
-	testutil.Require(t, err == nil, "%v", err)
-	relResolvedFilePaths, err := ResolveFilenames(relImportPaths, relFilePaths...)
-	testutil.Require(t, err == nil, "%v", err)
-	absResolvedFilePaths, err := ResolveFilenames(absImportPaths, absFilePaths...)
-	testutil.Require(t, err == nil, "%v", err)
-
-	p := Parser{ImportPaths: relImportPaths}
-	protos, err := p.ParseFiles(relResolvedFilePaths...)
-	testutil.Ok(t, err)
-	testutil.Eq(t, len(relFilePaths), len(protos))
-
-	p = Parser{ImportPaths: absImportPaths}
-	protos, err = p.ParseFiles(absResolvedFilePaths...)
-	testutil.Ok(t, err)
-	testutil.Eq(t, len(absFilePaths), len(protos))
-
-	_, err = ResolveFilenames([]string{}, absFilePaths...)
-	testutil.Require(t, err != nil)
-	testutil.Eq(t, errNoImportPathsForAbsoluteFilePath, err)
-}
-
 func TestParseFilesWithImportsNoImportPath(t *testing.T) {
 	relFilePaths := []string{
 		"a/b/b1.proto",

--- a/desc/protoparse/resolve_files.go
+++ b/desc/protoparse/resolve_files.go
@@ -1,0 +1,170 @@
+package protoparse
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var errNoImportPathsForAbsoluteFilePath = errors.New("must specify at least one import path if any absolute file paths are given")
+
+// ResolveFilenames tries to resolve fileNames into paths that are relative to
+// directories in the given importPaths. The returned slice has the results in
+// the same order as they are supplied in fileNames.
+//
+// The resulting names should be suitable for passing to Parser.ParseFiles.
+//
+// If no import paths are given and any file name is absolute, this returns an
+// error.  If no import paths are given and all file names are relative, this
+// returns the original file names. If a file name is already relative to one
+// of the given import paths, it will be unchanged in the returned slice. If a
+// file name given is relative to the current working directory, it will be made
+// relative to one of the given import paths; but if it cannot be made relative
+// (due to no matching import path), an error will be returned.
+func ResolveFilenames(importPaths []string, fileNames ...string) ([]string, error) {
+	if len(importPaths) == 0 {
+		if containsAbsFilePath(fileNames) {
+			// We have to do this as otherwise parseProtoFiles can result in duplicate symbols.
+			// For example, assume we import "foo/bar/bar.proto" in a file "/home/alice/dev/foo/bar/baz.proto"
+			// as we call ParseFiles("/home/alice/dev/foo/bar/bar.proto","/home/alice/dev/foo/bar/baz.proto")
+			// with "/home/alice/dev" as our current directory. Due to the recursive nature of parseProtoFiles,
+			// it will discover the import "foo/bar/bar.proto" in the input file, and call parse on this,
+			// adding "foo/bar/bar.proto" to the parsed results, as well as "/home/alice/dev/foo/bar/bar.proto"
+			// from the input file list. This will result in a
+			// 'duplicate symbol SYMBOL: already defined as field in "/home/alice/dev/foo/bar/bar.proto'
+			// error being returned from ParseFiles.
+			return nil, errNoImportPathsForAbsoluteFilePath
+		}
+		return fileNames, nil
+	}
+	absImportPaths, err := absoluteFilePaths(importPaths)
+	if err != nil {
+		return nil, err
+	}
+	resolvedFileNames := make([]string, 0, len(fileNames))
+	for _, fileName := range fileNames {
+		resolvedFileName, err := resolveFilename(absImportPaths, fileName)
+		if err != nil {
+			return nil, err
+		}
+		resolvedFileNames = append(resolvedFileNames, resolvedFileName)
+	}
+	return resolvedFileNames, nil
+}
+
+func containsAbsFilePath(filePaths []string) bool {
+	for _, filePath := range filePaths {
+		if filepath.IsAbs(filePath) {
+			return true
+		}
+	}
+	return false
+}
+
+func absoluteFilePaths(filePaths []string) ([]string, error) {
+	absFilePaths := make([]string, 0, len(filePaths))
+	for _, filePath := range filePaths {
+		absFilePath, err := canonicalize(filePath)
+		if err != nil {
+			return nil, err
+		}
+		absFilePaths = append(absFilePaths, absFilePath)
+	}
+	return absFilePaths, nil
+}
+
+func canonicalize(filePath string) (string, error) {
+	absPath, err := filepath.Abs(filePath)
+	if err != nil {
+		return "", err
+	}
+	// this is kind of gross, but it lets us construct a resolved path even if some
+	// path elements do not exist (a single call to filepath.EvalSymlinks would just
+	// return an error, ENOENT, in that case).
+	head := absPath
+	tail := ""
+	for {
+		noLinks, err := filepath.EvalSymlinks(head)
+		if err == nil {
+			if tail != "" {
+				return filepath.Join(noLinks, tail), nil
+			}
+			return noLinks, nil
+		}
+
+		if tail == "" {
+			tail = filepath.Base(head)
+		} else {
+			tail = filepath.Join(filepath.Base(head), tail)
+		}
+		head = filepath.Dir(head)
+		if head == "." {
+			// ran out of path elements to try to resolve
+			return absPath, nil
+		}
+	}
+}
+
+const dotPrefix = "." + string(filepath.Separator)
+const dotDotPrefix = ".." + string(filepath.Separator)
+
+func resolveFilename(absImportPaths []string, fileName string) (string, error) {
+	if filepath.IsAbs(fileName) {
+		return resolveAbsFilename(absImportPaths, fileName)
+	}
+
+	if !strings.HasPrefix(fileName, dotPrefix) && !strings.HasPrefix(fileName, dotDotPrefix) {
+		// Use of . and .. are assumed to be relative to current working
+		// directory. So if those aren't present, check to see if the file is
+		// relative to an import path.
+		for _, absImportPath := range absImportPaths {
+			absFileName := filepath.Join(absImportPath, fileName)
+			_, err := os.Stat(absFileName)
+			if err != nil {
+				continue
+			}
+			// found it! it was relative to this import path
+			return fileName, nil
+		}
+	}
+
+	// must be relative to current working dir
+	return resolveAbsFilename(absImportPaths, fileName)
+}
+
+func resolveAbsFilename(absImportPaths []string, fileName string) (string, error) {
+	absFileName, err := canonicalize(fileName)
+	if err != nil {
+		return "", err
+	}
+	for _, absImportPath := range absImportPaths {
+		if isDescendant(absImportPath, absFileName) {
+			resolvedPath, err := filepath.Rel(absImportPath, absFileName)
+			if err != nil {
+				return "", err
+			}
+			return resolvedPath, nil
+		}
+	}
+	return "", fmt.Errorf("%s does not reside in any import path", fileName)
+}
+
+// isDescendant returns true if file is a descendant of dir. Both dir and file must
+// be cleaned, absolute paths.
+func isDescendant(dir, file string) bool {
+	dir = filepath.Clean(dir)
+	cur := file
+	for {
+		d := filepath.Dir(cur)
+		if d == dir {
+			return true
+		}
+		if d == "." || d == cur {
+			// we've run out of path elements
+			return false
+		}
+		cur = d
+	}
+}

--- a/desc/protoparse/resolve_files_test.go
+++ b/desc/protoparse/resolve_files_test.go
@@ -1,0 +1,121 @@
+package protoparse
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jhump/protoreflect/internal/testutil"
+)
+
+func TestResolveFilenames(t *testing.T) {
+	dir, err := ioutil.TempDir("", "resolve-filenames-test")
+	testutil.Ok(t, err)
+	defer func() {
+		_ = os.RemoveAll(dir)
+	}()
+
+	testCases := []struct {
+		name        string
+		importPaths []string
+		fileNames   []string
+		files       []string
+		expectedErr string
+		results     []string
+	}{
+		{
+			name:      "no import paths",
+			fileNames: []string{"test1.proto", "test2.proto", "test3.proto"},
+			results:   []string{"test1.proto", "test2.proto", "test3.proto"},
+		},
+		{
+			name:        "no import paths; absolute file name",
+			fileNames:   []string{filepath.Join(dir, "test.proto")},
+			expectedErr: errNoImportPathsForAbsoluteFilePath.Error(),
+		},
+		{
+			name:        "import and file paths relative to cwd",
+			importPaths: []string{"./test"},
+			fileNames:   []string{"./test/a.proto", "./test/b.proto", "./test/c.proto"},
+			results:     []string{"a.proto", "b.proto", "c.proto"},
+		},
+		{
+			name:        "absolute file paths, import paths relative to cwd",
+			importPaths: []string{"./test"},
+			fileNames:   []string{filepath.Join(dir, "test/a.proto"), filepath.Join(dir, "test/b.proto"), filepath.Join(dir, "test/c.proto")},
+			results:     []string{"a.proto", "b.proto", "c.proto"},
+		},
+		{
+			name:        "absolute import paths, file paths relative to cwd",
+			importPaths: []string{filepath.Join(dir, "test")},
+			fileNames:   []string{"./test/a.proto", "./test/b.proto", "./test/c.proto"},
+			results:     []string{"a.proto", "b.proto", "c.proto"},
+		},
+		{
+			name:        "file path relative to cwd not in import path",
+			importPaths: []string{filepath.Join(dir, "test")},
+			fileNames:   []string{"./test/a.proto", "./test/b.proto", "./foo/c.proto"},
+			expectedErr: "./foo/c.proto does not reside in any import path",
+		},
+		{
+			name:        "absolute file path not in import path",
+			importPaths: []string{filepath.Join(dir, "test")},
+			fileNames:   []string{"./test/a.proto", "./test/b.proto", filepath.Join(dir, "foo/c.proto")},
+			expectedErr: filepath.Join(dir, "foo/c.proto") + " does not reside in any import path",
+		},
+		{
+			name:        "relative paths, files relative to import path",
+			files:       []string{"test/a.proto", "test/b.proto", "test/c.proto"},
+			importPaths: []string{"test"},
+			fileNames:   []string{"a.proto", "b.proto", "c.proto"},
+			results:     []string{"a.proto", "b.proto", "c.proto"},
+		},
+		{
+			name:        "relative paths, files relative to mix",
+			files:       []string{"test/a.proto", "test/b.proto", "test/c.proto"},
+			importPaths: []string{"test"},
+			fileNames:   []string{"test/a.proto", "b.proto", "test/c.proto"},
+			results:     []string{"a.proto", "b.proto", "c.proto"},
+		},
+	}
+
+	origCwd, err := os.Getwd()
+	testutil.Ok(t, err)
+
+	err = os.Chdir(dir)
+	testutil.Ok(t, err)
+	defer func() {
+		_ = os.Chdir(origCwd)
+	}()
+
+	for _, tc := range testCases {
+		// setup any test files
+		for _, f := range tc.files {
+			subDir := filepath.Dir(f)
+			if subDir != "." {
+				err := os.MkdirAll(filepath.Join(dir, subDir), os.ModePerm)
+				testutil.Ok(t, err)
+			}
+			err := ioutil.WriteFile(filepath.Join(dir, f), nil, 0666)
+			testutil.Ok(t, err)
+		}
+
+		// run the function under test
+		res, err := ResolveFilenames(tc.importPaths, tc.fileNames...)
+		// assert outcome
+		if tc.expectedErr != "" {
+			testutil.Nok(t, err, "%s", tc.name)
+			testutil.Eq(t, tc.expectedErr, err.Error(), "%s", tc.name)
+		} else {
+			testutil.Ok(t, err, "%s", tc.name)
+			testutil.Eq(t, tc.results, res, "%s", tc.name)
+		}
+
+		// remove test files
+		for _, f := range tc.files {
+			err := os.Remove(filepath.Join(dir, f))
+			testutil.Ok(t, err)
+		}
+	}
+}


### PR DESCRIPTION
Also moves the `ResolveFilenames` function and its helpers into a separate file, since `parser.go` is so big.

Previously, the function assumed all input files were relative to the current working directory. But they could also be already relative to given import paths.

This should fix https://github.com/fullstorydev/grpcurl/issues/108.