### PR TITLE
builders discover custom options from dependencies

### DIFF
--- a/desc/builder/builders.go
+++ b/desc/builder/builders.go
@@ -1022,7 +1022,7 @@ func (fb *FileBuilder) SetProto3(isProto3 bool) *FileBuilder {
 	return fb
 }
 
-func (fb *FileBuilder) buildProto() (*dpb.FileDescriptorProto, error) {
+func (fb *FileBuilder) buildProto(deps []*desc.FileDescriptor) (*dpb.FileDescriptorProto, error) {
 	name := fb.name
 	if name == "" {
 		name = uniqueFileName()
@@ -1041,6 +1041,12 @@ func (fb *FileBuilder) buildProto() (*dpb.FileDescriptorProto, error) {
 	addCommentsTo(&sourceInfo, path, &fb.comments)
 	addCommentsTo(&sourceInfo, append(path, internal.File_syntaxTag), &fb.SyntaxComments)
 	addCommentsTo(&sourceInfo, append(path, internal.File_packageTag), &fb.PackageComments)
+
+	imports := make([]string, 0, len(deps))
+	for _, dep := range deps {
+		imports = append(imports, dep.GetName())
+	}
+	sort.Strings(imports)
 
 	messages := make([]*dpb.DescriptorProto, 0, len(fb.messages))
 	for _, mb := range fb.messages {
@@ -1085,6 +1091,7 @@ func (fb *FileBuilder) buildProto() (*dpb.FileDescriptorProto, error) {
 	return &dpb.FileDescriptorProto{
 		Name:           proto.String(name),
 		Package:        pkg,
+		Dependency:     imports,
 		Options:        fb.Options,
 		Syntax:         syntax,
 		MessageType:    messages,

--- a/desc/builder/builders_test.go
+++ b/desc/builder/builders_test.go
@@ -777,26 +777,409 @@ func TestRenumberingFields(t *testing.T) {
 	// TODO
 }
 
-func TestUseOfExtensionRegistry(t *testing.T) {
-	fileOptionsDesc, err := desc.LoadMessageDescriptorForMessage((*dpb.FileOptions)(nil))
+var (
+	fileOptionsDesc, msgOptionsDesc, fieldOptionsDesc, oneofOptionsDesc, extRangeOptionsDesc,
+	enumOptionsDesc, enumValOptionsDesc, svcOptionsDesc, mtdOptionsDesc *desc.MessageDescriptor
+)
+
+func init() {
+	var err error
+	fileOptionsDesc, err = desc.LoadMessageDescriptorForMessage((*dpb.FileOptions)(nil))
+	if err != nil {
+		panic(err)
+	}
+	msgOptionsDesc, err = desc.LoadMessageDescriptorForMessage((*dpb.MessageOptions)(nil))
+	if err != nil {
+		panic(err)
+	}
+	fieldOptionsDesc, err = desc.LoadMessageDescriptorForMessage((*dpb.FieldOptions)(nil))
+	if err != nil {
+		panic(err)
+	}
+	oneofOptionsDesc, err = desc.LoadMessageDescriptorForMessage((*dpb.OneofOptions)(nil))
+	if err != nil {
+		panic(err)
+	}
+	extRangeOptionsDesc, err = desc.LoadMessageDescriptorForMessage((*dpb.ExtensionRangeOptions)(nil))
+	if err != nil {
+		panic(err)
+	}
+	enumOptionsDesc, err = desc.LoadMessageDescriptorForMessage((*dpb.EnumOptions)(nil))
+	if err != nil {
+		panic(err)
+	}
+	enumValOptionsDesc, err = desc.LoadMessageDescriptorForMessage((*dpb.EnumValueOptions)(nil))
+	if err != nil {
+		panic(err)
+	}
+	svcOptionsDesc, err = desc.LoadMessageDescriptorForMessage((*dpb.ServiceOptions)(nil))
+	if err != nil {
+		panic(err)
+	}
+	mtdOptionsDesc, err = desc.LoadMessageDescriptorForMessage((*dpb.MethodOptions)(nil))
+	if err != nil {
+		panic(err)
+	}
+}
+
+func TestCustomOptionsDiscoveredInSameFile(t *testing.T) {
+	// Add option for every type to file
+	file := NewFile("foo.proto")
+
+	fileOpt := NewExtensionImported("file_foo", 54321, FieldTypeString(), fileOptionsDesc)
+	file.AddExtension(fileOpt)
+
+	msgOpt := NewExtensionImported("msg_foo", 54321, FieldTypeString(), msgOptionsDesc)
+	file.AddExtension(msgOpt)
+
+	fieldOpt := NewExtensionImported("field_foo", 54321, FieldTypeString(), fieldOptionsDesc)
+	file.AddExtension(fieldOpt)
+
+	oneofOpt := NewExtensionImported("oneof_foo", 54321, FieldTypeString(), oneofOptionsDesc)
+	file.AddExtension(oneofOpt)
+
+	extRangeOpt := NewExtensionImported("ext_range_foo", 54321, FieldTypeString(), extRangeOptionsDesc)
+	file.AddExtension(extRangeOpt)
+
+	enumOpt := NewExtensionImported("enum_foo", 54321, FieldTypeString(), enumOptionsDesc)
+	file.AddExtension(enumOpt)
+
+	enumValOpt := NewExtensionImported("enum_val_foo", 54321, FieldTypeString(), enumValOptionsDesc)
+	file.AddExtension(enumValOpt)
+
+	svcOpt := NewExtensionImported("svc_foo", 54321, FieldTypeString(), svcOptionsDesc)
+	file.AddExtension(svcOpt)
+
+	mtdOpt := NewExtensionImported("mtd_foo", 54321, FieldTypeString(), mtdOptionsDesc)
+	file.AddExtension(mtdOpt)
+
+	// Now we can test referring to these and making sure they show up correctly
+	// in built descriptors
+
+	t.Run("file options", func(t *testing.T) {
+		fb := clone(t, file)
+		fb.Options = &dpb.FileOptions{}
+		ext, err := fileOpt.Build()
+		testutil.Ok(t, err)
+		err = dynamic.SetExtension(fb.Options, ext, "fubar")
+		testutil.Ok(t, err)
+		checkBuildWithLocalExtensions(t, fb)
+	})
+
+	t.Run("message options", func(t *testing.T) {
+		mb := NewMessage("Foo")
+		mb.Options = &dpb.MessageOptions{}
+		ext, err := msgOpt.Build()
+		testutil.Ok(t, err)
+		err = dynamic.SetExtension(mb.Options, ext, "fubar")
+		testutil.Ok(t, err)
+
+		fb := clone(t, file)
+		fb.AddMessage(mb)
+		checkBuildWithLocalExtensions(t, mb)
+	})
+
+	t.Run("field options", func(t *testing.T) {
+		flb := NewField("foo", FieldTypeString())
+		flb.Options = &dpb.FieldOptions{}
+		// fields must be connected to a message
+		mb := NewMessage("Foo").AddField(flb)
+		ext, err := fieldOpt.Build()
+		testutil.Ok(t, err)
+		err = dynamic.SetExtension(flb.Options, ext, "fubar")
+		testutil.Ok(t, err)
+
+		fb := clone(t, file)
+		fb.AddMessage(mb)
+		checkBuildWithLocalExtensions(t, flb)
+	})
+
+	t.Run("oneof options", func(t *testing.T) {
+		oob := NewOneOf("oo")
+		oob.Options = &dpb.OneofOptions{}
+		// oneofs must be connected to a message
+		mb := NewMessage("Foo").AddOneOf(oob)
+		ext, err := oneofOpt.Build()
+		testutil.Ok(t, err)
+		err = dynamic.SetExtension(oob.Options, ext, "fubar")
+		testutil.Ok(t, err)
+
+		fb := clone(t, file)
+		fb.AddMessage(mb)
+		checkBuildWithLocalExtensions(t, oob)
+	})
+
+	t.Run("extension range options", func(t *testing.T) {
+		var erOpts dpb.ExtensionRangeOptions
+		ext, err := extRangeOpt.Build()
+		testutil.Ok(t, err)
+		err = dynamic.SetExtension(&erOpts, ext, "fubar")
+		testutil.Ok(t, err)
+		mb := NewMessage("foo").AddExtensionRangeWithOptions(100, 200, &erOpts)
+
+		fb := clone(t, file)
+		fb.AddMessage(mb)
+		checkBuildWithLocalExtensions(t, mb)
+	})
+
+	t.Run("enum options", func(t *testing.T) {
+		eb := NewEnum("Foo")
+		eb.Options = &dpb.EnumOptions{}
+		ext, err := enumOpt.Build()
+		testutil.Ok(t, err)
+		err = dynamic.SetExtension(eb.Options, ext, "fubar")
+		testutil.Ok(t, err)
+
+		fb := clone(t, file)
+		fb.AddEnum(eb)
+		checkBuildWithLocalExtensions(t, eb)
+	})
+
+	t.Run("enum val options", func(t *testing.T) {
+		evb := NewEnumValue("FOO")
+		// enum values must be connected to an enum
+		eb := NewEnum("Foo").AddValue(evb)
+		evb.Options = &dpb.EnumValueOptions{}
+		ext, err := enumValOpt.Build()
+		testutil.Ok(t, err)
+		err = dynamic.SetExtension(evb.Options, ext, "fubar")
+		testutil.Ok(t, err)
+
+		fb := clone(t, file)
+		fb.AddEnum(eb)
+		checkBuildWithLocalExtensions(t, evb)
+	})
+
+	t.Run("service options", func(t *testing.T) {
+		sb := NewService("Foo")
+		sb.Options = &dpb.ServiceOptions{}
+		ext, err := svcOpt.Build()
+		testutil.Ok(t, err)
+		err = dynamic.SetExtension(sb.Options, ext, "fubar")
+		testutil.Ok(t, err)
+
+		fb := clone(t, file)
+		fb.AddService(sb)
+		checkBuildWithLocalExtensions(t, sb)
+	})
+
+	t.Run("method options", func(t *testing.T) {
+		req := NewMessage("Request")
+		resp := NewMessage("Response")
+		mtb := NewMethod("Foo",
+			RpcTypeMessage(req, false),
+			RpcTypeMessage(resp, false))
+		// methods must be connected to a service
+		sb := NewService("Bar").AddMethod(mtb)
+		mtb.Options = &dpb.MethodOptions{}
+		ext, err := mtdOpt.Build()
+		testutil.Ok(t, err)
+		err = dynamic.SetExtension(mtb.Options, ext, "fubar")
+		testutil.Ok(t, err)
+
+		fb := clone(t, file)
+		fb.AddService(sb).AddMessage(req).AddMessage(resp)
+		checkBuildWithLocalExtensions(t, mtb)
+	})
+}
+
+func checkBuildWithLocalExtensions(t *testing.T, builder Builder) {
+	// requiring options and succeeding (since they are defined locally)
+	var opts BuilderOptions
+	opts.RequireInterpretedOptions = true
+	d, err := opts.Build(builder)
 	testutil.Ok(t, err)
-	msgOptionsDesc, err := desc.LoadMessageDescriptorForMessage((*dpb.MessageOptions)(nil))
-	testutil.Ok(t, err)
-	fieldOptionsDesc, err := desc.LoadMessageDescriptorForMessage((*dpb.FieldOptions)(nil))
-	testutil.Ok(t, err)
-	oneofOptionsDesc, err := desc.LoadMessageDescriptorForMessage((*dpb.OneofOptions)(nil))
-	testutil.Ok(t, err)
-	extRangeOptionsDesc, err := desc.LoadMessageDescriptorForMessage((*dpb.ExtensionRangeOptions)(nil))
-	testutil.Ok(t, err)
-	enumOptionsDesc, err := desc.LoadMessageDescriptorForMessage((*dpb.EnumOptions)(nil))
-	testutil.Ok(t, err)
-	enumValOptionsDesc, err := desc.LoadMessageDescriptorForMessage((*dpb.EnumValueOptions)(nil))
-	testutil.Ok(t, err)
-	svcOptionsDesc, err := desc.LoadMessageDescriptorForMessage((*dpb.ServiceOptions)(nil))
-	testutil.Ok(t, err)
-	mtdOptionsDesc, err := desc.LoadMessageDescriptorForMessage((*dpb.MethodOptions)(nil))
+	// since they are defined locally, no extra imports
+	testutil.Eq(t, []string{"google/protobuf/descriptor.proto"}, d.GetFile().AsFileDescriptorProto().GetDependency())
+}
+
+func TestCustomOptionsDiscoveredInDependencies(t *testing.T) {
+	// Add option for every type to file
+	file := NewFile("options.proto")
+
+	fileOpt := NewExtensionImported("file_foo", 54321, FieldTypeString(), fileOptionsDesc)
+	file.AddExtension(fileOpt)
+
+	msgOpt := NewExtensionImported("msg_foo", 54321, FieldTypeString(), msgOptionsDesc)
+	file.AddExtension(msgOpt)
+
+	fieldOpt := NewExtensionImported("field_foo", 54321, FieldTypeString(), fieldOptionsDesc)
+	file.AddExtension(fieldOpt)
+
+	oneofOpt := NewExtensionImported("oneof_foo", 54321, FieldTypeString(), oneofOptionsDesc)
+	file.AddExtension(oneofOpt)
+
+	extRangeOpt := NewExtensionImported("ext_range_foo", 54321, FieldTypeString(), extRangeOptionsDesc)
+	file.AddExtension(extRangeOpt)
+
+	enumOpt := NewExtensionImported("enum_foo", 54321, FieldTypeString(), enumOptionsDesc)
+	file.AddExtension(enumOpt)
+
+	enumValOpt := NewExtensionImported("enum_val_foo", 54321, FieldTypeString(), enumValOptionsDesc)
+	file.AddExtension(enumValOpt)
+
+	svcOpt := NewExtensionImported("svc_foo", 54321, FieldTypeString(), svcOptionsDesc)
+	file.AddExtension(svcOpt)
+
+	mtdOpt := NewExtensionImported("mtd_foo", 54321, FieldTypeString(), mtdOptionsDesc)
+	file.AddExtension(mtdOpt)
+
+	fileDesc, err := file.Build()
 	testutil.Ok(t, err)
 
+	// Now we can test referring to these and making sure they show up correctly
+	// in built descriptors
+	for name, useBuilder := range map[string]bool{"descriptor": false, "builder": true} {
+		newFile := func() *FileBuilder {
+			fb := NewFile("foo.proto")
+			if useBuilder {
+				fb.AddDependency(file)
+			} else {
+				fb.AddImportedDependency(fileDesc)
+			}
+			return fb
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Run("file options", func(t *testing.T) {
+				fb := newFile()
+				fb.Options = &dpb.FileOptions{}
+				ext, err := fileOpt.Build()
+				testutil.Ok(t, err)
+				err = dynamic.SetExtension(fb.Options, ext, "fubar")
+				testutil.Ok(t, err)
+				checkBuildWithImportedExtensions(t, fb)
+			})
+
+			t.Run("message options", func(t *testing.T) {
+				mb := NewMessage("Foo")
+				mb.Options = &dpb.MessageOptions{}
+				ext, err := msgOpt.Build()
+				testutil.Ok(t, err)
+				err = dynamic.SetExtension(mb.Options, ext, "fubar")
+				testutil.Ok(t, err)
+
+				fb := newFile()
+				fb.AddMessage(mb)
+				checkBuildWithImportedExtensions(t, mb)
+			})
+
+			t.Run("field options", func(t *testing.T) {
+				flb := NewField("foo", FieldTypeString())
+				flb.Options = &dpb.FieldOptions{}
+				// fields must be connected to a message
+				mb := NewMessage("Foo").AddField(flb)
+				ext, err := fieldOpt.Build()
+				testutil.Ok(t, err)
+				err = dynamic.SetExtension(flb.Options, ext, "fubar")
+				testutil.Ok(t, err)
+
+				fb := newFile()
+				fb.AddMessage(mb)
+				checkBuildWithImportedExtensions(t, flb)
+			})
+
+			t.Run("oneof options", func(t *testing.T) {
+				oob := NewOneOf("oo")
+				oob.Options = &dpb.OneofOptions{}
+				// oneofs must be connected to a message
+				mb := NewMessage("Foo").AddOneOf(oob)
+				ext, err := oneofOpt.Build()
+				testutil.Ok(t, err)
+				err = dynamic.SetExtension(oob.Options, ext, "fubar")
+				testutil.Ok(t, err)
+
+				fb := newFile()
+				fb.AddMessage(mb)
+				checkBuildWithImportedExtensions(t, oob)
+			})
+
+			t.Run("extension range options", func(t *testing.T) {
+				var erOpts dpb.ExtensionRangeOptions
+				ext, err := extRangeOpt.Build()
+				testutil.Ok(t, err)
+				err = dynamic.SetExtension(&erOpts, ext, "fubar")
+				testutil.Ok(t, err)
+				mb := NewMessage("foo").AddExtensionRangeWithOptions(100, 200, &erOpts)
+
+				fb := newFile()
+				fb.AddMessage(mb)
+				checkBuildWithImportedExtensions(t, mb)
+			})
+
+			t.Run("enum options", func(t *testing.T) {
+				eb := NewEnum("Foo")
+				eb.Options = &dpb.EnumOptions{}
+				ext, err := enumOpt.Build()
+				testutil.Ok(t, err)
+				err = dynamic.SetExtension(eb.Options, ext, "fubar")
+				testutil.Ok(t, err)
+
+				fb := newFile()
+				fb.AddEnum(eb)
+				checkBuildWithImportedExtensions(t, eb)
+			})
+
+			t.Run("enum val options", func(t *testing.T) {
+				evb := NewEnumValue("FOO")
+				// enum values must be connected to an enum
+				eb := NewEnum("Foo").AddValue(evb)
+				evb.Options = &dpb.EnumValueOptions{}
+				ext, err := enumValOpt.Build()
+				testutil.Ok(t, err)
+				err = dynamic.SetExtension(evb.Options, ext, "fubar")
+				testutil.Ok(t, err)
+
+				fb := newFile()
+				fb.AddEnum(eb)
+				checkBuildWithImportedExtensions(t, evb)
+			})
+
+			t.Run("service options", func(t *testing.T) {
+				sb := NewService("Foo")
+				sb.Options = &dpb.ServiceOptions{}
+				ext, err := svcOpt.Build()
+				testutil.Ok(t, err)
+				err = dynamic.SetExtension(sb.Options, ext, "fubar")
+				testutil.Ok(t, err)
+
+				fb := newFile()
+				fb.AddService(sb)
+				checkBuildWithImportedExtensions(t, sb)
+			})
+
+			t.Run("method options", func(t *testing.T) {
+				req := NewMessage("Request")
+				resp := NewMessage("Response")
+				mtb := NewMethod("Foo",
+					RpcTypeMessage(req, false),
+					RpcTypeMessage(resp, false))
+				// methods must be connected to a service
+				sb := NewService("Bar").AddMethod(mtb)
+				mtb.Options = &dpb.MethodOptions{}
+				ext, err := mtdOpt.Build()
+				testutil.Ok(t, err)
+				err = dynamic.SetExtension(mtb.Options, ext, "fubar")
+				testutil.Ok(t, err)
+
+				fb := newFile()
+				fb.AddService(sb).AddMessage(req).AddMessage(resp)
+				checkBuildWithImportedExtensions(t, mtb)
+			})
+		})
+	}
+}
+
+func checkBuildWithImportedExtensions(t *testing.T, builder Builder) {
+	// requiring options and succeeding (since they are defined in explicit import)
+	var opts BuilderOptions
+	opts.RequireInterpretedOptions = true
+	d, err := opts.Build(builder)
+	testutil.Ok(t, err)
+	// the only import is for the custom options
+	testutil.Eq(t, []string{"options.proto"}, d.GetFile().AsFileDescriptorProto().GetDependency())
+}
+
+func TestUseOfExtensionRegistry(t *testing.T) {
 	// Add option for every type to extension registry
 	var exts dynamic.ExtensionRegistry
 
@@ -974,4 +1357,12 @@ func TestRemoveField(t *testing.T) {
 	testutil.Eq(t, 2, len(children))
 	testutil.Eq(t, "one", children[0].GetName())
 	testutil.Eq(t, "three", children[1].GetName())
+}
+
+func clone(t *testing.T, fb *FileBuilder) *FileBuilder {
+	fd, err := fb.Build()
+	testutil.Ok(t, err)
+	fb, err = FromFile(fd)
+	testutil.Ok(t, err)
+	return fb
 }

--- a/desc/builder/builders_test.go
+++ b/desc/builder/builders_test.go
@@ -494,17 +494,18 @@ func roundTripFile(t *testing.T, fd *desc.FileDescriptor) {
 	// former will be updated to instead depend on the latter (since it is
 	// the actual file that declares used elements).
 	fdp := fd.AsFileDescriptorProto()
-	for i, dep := range fdp.Dependency {
+	needsNopkgNew := false
+	hasNoPkgNew := false
+	for _, dep := range fdp.Dependency {
 		if dep == "nopkg/desc_test_nopkg.proto" {
-			fdp.Dependency[i] = "nopkg/desc_test_nopkg_new.proto"
+			needsNopkgNew = true
 		}
-		if dep == "nopkg/desc_test_nopkg_new.proto" && fdp.GetName() == "nopkg/desc_test_nopkg.proto" {
-			// The file nopkg/desc_test_nopkg.proto actually declares nothing
-			// and *only* has the public import. So the round-tripped version
-			// will have no imports (it declares nothing so it depends on
-			// nothing).
-			fdp.Dependency = append(fdp.Dependency[:i], fdp.Dependency[i+1:]...)
+		if dep == "nopkg/desc_test_nopkg_new.proto" {
+			hasNoPkgNew = false
 		}
+	}
+	if needsNopkgNew && !hasNoPkgNew {
+		fdp.Dependency = append(fdp.Dependency, "nopkg/desc_test_nopkg_new.proto")
 	}
 
 	// Strip any public and weak imports. (The step above should have "fixed"

--- a/desc/builder/resolver.go
+++ b/desc/builder/resolver.go
@@ -2,6 +2,7 @@ package builder
 
 import (
 	"fmt"
+	"github.com/jhump/protoreflect/dynamic"
 	"reflect"
 	"sort"
 	"strings"
@@ -10,6 +11,26 @@ import (
 
 	"github.com/jhump/protoreflect/desc"
 )
+
+type dependencies struct {
+	descs map[*desc.FileDescriptor]struct{}
+	exts  dynamic.ExtensionRegistry
+}
+
+func newDependencies() *dependencies {
+	return &dependencies{
+		descs: map[*desc.FileDescriptor]struct{}{},
+	}
+}
+
+func (d *dependencies) add(fd *desc.FileDescriptor) {
+	if _, ok := d.descs[fd]; ok {
+		// already added
+		return
+	}
+	d.descs[fd] = struct{}{}
+	d.exts.AddExtensionsFromFile(fd)
+}
 
 // dependencyResolver is the work-horse for converting a tree of builders into a
 // tree of descriptors. It scans a root (usually a file builder) and recursively
@@ -65,14 +86,25 @@ func (r *dependencyResolver) resolveElement(b Builder, seen []Builder) (*desc.Fi
 }
 
 func (r *dependencyResolver) resolveFile(fb *FileBuilder, root Builder, seen []Builder) (*desc.FileDescriptor, error) {
-	deps := map[*desc.FileDescriptor]struct{}{}
-	for _, mb := range fb.messages {
-		if err := r.resolveTypesInMessage(root, seen, deps, mb); err != nil {
+	deps := newDependencies()
+	// add explicit imports first
+	for fd := range fb.explicitImports {
+		deps.add(fd)
+	}
+	for dep := range fb.explicitDeps {
+		if dep == fb {
+			// ignore erroneous self references
+			continue
+		}
+		fd, err := r.resolveElement(dep, seen)
+		if err != nil {
 			return nil, err
 		}
+		deps.add(fd)
 	}
-	for _, eb := range fb.enums {
-		if err := r.resolveTypesInEnum(root, seen, deps, eb); err != nil {
+	// now accumulate implicit dependencies based on other types referenced
+	for _, mb := range fb.messages {
+		if err := r.resolveTypesInMessage(root, seen, deps, mb); err != nil {
 			return nil, err
 		}
 	}
@@ -87,12 +119,14 @@ func (r *dependencyResolver) resolveFile(fb *FileBuilder, root Builder, seen []B
 		}
 	}
 
-	if err := r.resolveTypesInOptions(root, fb.Options, deps); err != nil {
+	// finally, resolve custom options (which may refer to deps already
+	// computed above)
+	if err := r.resolveTypesInFileOptions(root, deps, fb); err != nil {
 		return nil, err
 	}
 
-	depSlice := make([]*desc.FileDescriptor, 0, len(deps))
-	for dep := range deps {
+	depSlice := make([]*desc.FileDescriptor, 0, len(deps.descs))
+	for dep := range deps.descs {
 		depSlice = append(depSlice, dep)
 	}
 
@@ -174,32 +208,19 @@ func (r *dependencyResolver) resolveSyntheticFile(b Builder, seen []Builder) (*d
 	return r.resolveFile(f, b, seen)
 }
 
-func (r *dependencyResolver) resolveTypesInMessage(root Builder, seen []Builder, deps map[*desc.FileDescriptor]struct{}, mb *MessageBuilder) error {
+func (r *dependencyResolver) resolveTypesInMessage(root Builder, seen []Builder, deps *dependencies, mb *MessageBuilder) error {
 	for _, b := range mb.fieldsAndOneOfs {
 		if flb, ok := b.(*FieldBuilder); ok {
-			if err := r.resolveTypesInField(root, seen, flb, deps); err != nil {
+			if err := r.resolveTypesInField(root, seen, deps, flb); err != nil {
 				return err
 			}
 		} else {
 			oob := b.(*OneOfBuilder)
 			for _, flb := range oob.choices {
-				if err := r.resolveTypesInField(root, seen, flb, deps); err != nil {
+				if err := r.resolveTypesInField(root, seen, deps, flb); err != nil {
 					return err
 				}
 			}
-			if err := r.resolveTypesInOptions(root, oob.Options, deps); err != nil {
-				return err
-			}
-		}
-	}
-	for _, extr := range mb.ExtensionRanges {
-		if err := r.resolveTypesInOptions(root, extr.Options, deps); err != nil {
-			return err
-		}
-	}
-	for _, eb := range mb.nestedEnums {
-		if err := r.resolveTypesInEnum(root, seen, deps, eb); err != nil {
-			return err
 		}
 	}
 	for _, nmb := range mb.nestedMessages {
@@ -212,25 +233,22 @@ func (r *dependencyResolver) resolveTypesInMessage(root Builder, seen []Builder,
 			return err
 		}
 	}
-	if err := r.resolveTypesInOptions(root, mb.Options, deps); err != nil {
-		return err
-	}
 	return nil
 }
 
-func (r *dependencyResolver) resolveTypesInExtension(root Builder, seen []Builder, deps map[*desc.FileDescriptor]struct{}, exb *FieldBuilder) error {
-	if err := r.resolveTypesInField(root, seen, exb, deps); err != nil {
+func (r *dependencyResolver) resolveTypesInExtension(root Builder, seen []Builder, deps *dependencies, exb *FieldBuilder) error {
+	if err := r.resolveTypesInField(root, seen, deps, exb); err != nil {
 		return err
 	}
 	if exb.foreignExtendee != nil {
-		deps[exb.foreignExtendee.GetFile()] = struct{}{}
+		deps.add(exb.foreignExtendee.GetFile())
 	} else if err := r.resolveType(root, seen, exb.localExtendee, deps); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (r *dependencyResolver) resolveTypesInService(root Builder, seen []Builder, deps map[*desc.FileDescriptor]struct{}, sb *ServiceBuilder) error {
+func (r *dependencyResolver) resolveTypesInService(root Builder, seen []Builder, deps *dependencies, sb *ServiceBuilder) error {
 	for _, mtb := range sb.methods {
 		if err := r.resolveRpcType(root, seen, mtb.ReqType, deps); err != nil {
 			return err
@@ -238,33 +256,24 @@ func (r *dependencyResolver) resolveTypesInService(root Builder, seen []Builder,
 		if err := r.resolveRpcType(root, seen, mtb.RespType, deps); err != nil {
 			return err
 		}
-		if err := r.resolveTypesInOptions(root, mtb.Options, deps); err != nil {
-			return err
-		}
-	}
-	if err := r.resolveTypesInOptions(root, sb.Options, deps); err != nil {
-		return err
 	}
 	return nil
 }
 
-func (r *dependencyResolver) resolveRpcType(root Builder, seen []Builder, t *RpcType, deps map[*desc.FileDescriptor]struct{}) error {
+func (r *dependencyResolver) resolveRpcType(root Builder, seen []Builder, t *RpcType, deps *dependencies) error {
 	if t.foreignType != nil {
-		deps[t.foreignType.GetFile()] = struct{}{}
+		deps.add(t.foreignType.GetFile())
 	} else {
 		return r.resolveType(root, seen, t.localType, deps)
 	}
 	return nil
 }
 
-func (r *dependencyResolver) resolveTypesInField(root Builder, seen []Builder, flb *FieldBuilder, deps map[*desc.FileDescriptor]struct{}) error {
-	if err := r.resolveTypesInOptions(root, flb.Options, deps); err != nil {
-		return err
-	}
+func (r *dependencyResolver) resolveTypesInField(root Builder, seen []Builder, deps *dependencies, flb *FieldBuilder) error {
 	if flb.fieldType.foreignMsgType != nil {
-		deps[flb.fieldType.foreignMsgType.GetFile()] = struct{}{}
+		deps.add(flb.fieldType.foreignMsgType.GetFile())
 	} else if flb.fieldType.foreignEnumType != nil {
-		deps[flb.fieldType.foreignEnumType.GetFile()] = struct{}{}
+		deps.add(flb.fieldType.foreignEnumType.GetFile())
 	} else if flb.fieldType.localMsgType != nil {
 		if flb.fieldType.localMsgType == flb.msgType {
 			return r.resolveTypesInMessage(root, seen, deps, flb.msgType)
@@ -277,19 +286,106 @@ func (r *dependencyResolver) resolveTypesInField(root Builder, seen []Builder, f
 	return nil
 }
 
-func (r *dependencyResolver) resolveTypesInEnum(root Builder, seen []Builder, deps map[*desc.FileDescriptor]struct{}, eb *EnumBuilder) error {
-	for _, evb := range eb.values {
-		if err := r.resolveTypesInOptions(root, evb.Options, deps); err != nil {
+func (r *dependencyResolver) resolveType(root Builder, seen []Builder, typeBuilder Builder, deps *dependencies) error {
+	otherRoot := getRoot(typeBuilder)
+	if root == otherRoot {
+		// local reference, so it will get resolved when we finish resolving this root
+		return nil
+	}
+	fd, err := r.resolveElement(otherRoot, seen)
+	if err != nil {
+		return err
+	}
+	deps.add(fd)
+	return nil
+}
+
+func (r *dependencyResolver) resolveTypesInFileOptions(root Builder, deps *dependencies, fb *FileBuilder) error {
+	for _, mb := range fb.messages {
+		if err := r.resolveTypesInMessageOptions(root, deps, mb); err != nil {
 			return err
 		}
 	}
-	if err := r.resolveTypesInOptions(root, eb.Options, deps); err != nil {
+	for _, eb := range fb.enums {
+		if err := r.resolveTypesInEnumOptions(root, deps, eb); err != nil {
+			return err
+		}
+	}
+	for _, exb := range fb.extensions {
+		if err := r.resolveTypesInOptions(root, deps, exb.Options); err != nil {
+			return err
+		}
+	}
+	for _, sb := range fb.services {
+		for _, mtb := range sb.methods {
+			if err := r.resolveTypesInOptions(root, deps, mtb.Options); err != nil {
+				return err
+			}
+		}
+		if err := r.resolveTypesInOptions(root, deps, sb.Options); err != nil {
+			return err
+		}
+	}
+	return r.resolveTypesInOptions(root, deps, fb.Options)
+}
+
+func (r *dependencyResolver) resolveTypesInMessageOptions(root Builder, deps *dependencies, mb *MessageBuilder) error {
+	for _, b := range mb.fieldsAndOneOfs {
+		if flb, ok := b.(*FieldBuilder); ok {
+			if err := r.resolveTypesInOptions(root, deps, flb.Options); err != nil {
+				return err
+			}
+		} else {
+			oob := b.(*OneOfBuilder)
+			for _, flb := range oob.choices {
+				if err := r.resolveTypesInOptions(root, deps, flb.Options); err != nil {
+					return err
+				}
+			}
+			if err := r.resolveTypesInOptions(root, deps, oob.Options); err != nil {
+				return err
+			}
+		}
+	}
+	for _, extr := range mb.ExtensionRanges {
+		if err := r.resolveTypesInOptions(root, deps, extr.Options); err != nil {
+			return err
+		}
+	}
+	for _, eb := range mb.nestedEnums {
+		if err := r.resolveTypesInEnumOptions(root, deps, eb); err != nil {
+			return err
+		}
+	}
+	for _, nmb := range mb.nestedMessages {
+		if err := r.resolveTypesInMessageOptions(root, deps, nmb); err != nil {
+			return err
+		}
+	}
+	for _, exb := range mb.nestedExtensions {
+		if err := r.resolveTypesInOptions(root, deps, exb.Options); err != nil {
+			return err
+		}
+	}
+	if err := r.resolveTypesInOptions(root, deps, mb.Options); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (r *dependencyResolver) resolveTypesInOptions(root Builder, opts proto.Message, deps map[*desc.FileDescriptor]struct{}) error {
+func (r *dependencyResolver) resolveTypesInEnumOptions(root Builder, deps *dependencies, eb *EnumBuilder) error {
+	for _, evb := range eb.values {
+		if err := r.resolveTypesInOptions(root, deps, evb.Options); err != nil {
+			return err
+		}
+	}
+	if err := r.resolveTypesInOptions(root, deps, eb.Options); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *dependencyResolver) resolveTypesInOptions(root Builder, deps *dependencies, opts proto.Message) error {
 	// nothing to see if opts is nil
 	if opts == nil {
 		return nil
@@ -305,10 +401,22 @@ func (r *dependencyResolver) resolveTypesInOptions(root Builder, opts proto.Mess
 		return err
 	}
 	for _, ed := range extdescs {
-		extd := r.opts.Extensions.FindExtension(msgName, ed.Field)
+		// see if known dependencies have this option
+		extd := deps.exts.FindExtension(msgName, ed.Field)
+		if extd != nil {
+			// yep! nothing else to do
+			continue
+		}
+		// see if this extension is defined in *this* builder
+		if findExtension(root, msgName, ed.Field) {
+			// yep!
+			continue
+		}
+		// see if configured extension registry knows about it
+		extd = r.opts.Extensions.FindExtension(msgName, ed.Field)
 		if extd != nil {
 			// extension registry recognized it!
-			deps[extd.GetFile()] = struct{}{}
+			deps.add(extd.GetFile())
 		} else if ed.Filename != "" {
 			// if filename is filled in, then this extension is a known
 			// extension (registered in proto package)
@@ -316,7 +424,7 @@ func (r *dependencyResolver) resolveTypesInOptions(root Builder, opts proto.Mess
 			if err != nil {
 				return err
 			}
-			deps[fd] = struct{}{}
+			deps.add(fd)
 		} else if r.opts.RequireInterpretedOptions {
 			// we require options to be interpreted but are not able to!
 			return fmt.Errorf("could not interpret custom option for %s, tag %d", msgName, ed.Field)
@@ -325,16 +433,40 @@ func (r *dependencyResolver) resolveTypesInOptions(root Builder, opts proto.Mess
 	return nil
 }
 
-func (r *dependencyResolver) resolveType(root Builder, seen []Builder, typeBuilder Builder, deps map[*desc.FileDescriptor]struct{}) error {
-	otherRoot := getRoot(typeBuilder)
-	if root == otherRoot {
-		// local reference, so it will get resolved when we finish resolving this root
-		return nil
+func findExtension(b Builder, messageName string, extTag int32) bool {
+	if fb, ok := b.(*FileBuilder); ok && findExtensionInFile(fb, messageName, extTag) {
+		return true
 	}
-	fd, err := r.resolveElement(otherRoot, seen)
-	if err != nil {
-		return err
+	if mb, ok := b.(*MessageBuilder); ok && findExtensionInMessage(mb, messageName, extTag) {
+		return true
 	}
-	deps[fd] = struct{}{}
-	return nil
+	return false
+}
+
+func findExtensionInFile(fb *FileBuilder, messageName string, extTag int32) bool {
+	for _, extb := range fb.extensions {
+		if extb.GetExtendeeTypeName() == messageName && extb.number == extTag {
+			return true
+		}
+	}
+	for _, mb := range fb.messages {
+		if findExtensionInMessage(mb, messageName, extTag) {
+			return true
+		}
+	}
+	return false
+}
+
+func findExtensionInMessage(mb *MessageBuilder, messageName string, extTag int32) bool {
+	for _, extb := range mb.nestedExtensions {
+		if extb.GetExtendeeTypeName() == messageName && extb.number == extTag {
+			return true
+		}
+	}
+	for _, mb := range mb.nestedMessages {
+		if findExtensionInMessage(mb, messageName, extTag) {
+			return true
+		}
+	}
+	return false
 }

--- a/desc/builder/resolver.go
+++ b/desc/builder/resolver.go
@@ -2,14 +2,13 @@ package builder
 
 import (
 	"fmt"
-	"github.com/jhump/protoreflect/dynamic"
 	"reflect"
-	"sort"
 	"strings"
 
 	"github.com/golang/protobuf/proto"
 
 	"github.com/jhump/protoreflect/desc"
+	"github.com/jhump/protoreflect/dynamic"
 )
 
 type dependencies struct {
@@ -130,14 +129,10 @@ func (r *dependencyResolver) resolveFile(fb *FileBuilder, root Builder, seen []B
 		depSlice = append(depSlice, dep)
 	}
 
-	fp, err := fb.buildProto()
+	fp, err := fb.buildProto(depSlice)
 	if err != nil {
 		return nil, err
 	}
-	for _, dep := range depSlice {
-		fp.Dependency = append(fp.Dependency, dep.GetName())
-	}
-	sort.Strings(fp.Dependency)
 
 	// make sure this file name doesn't collide with any of its dependencies
 	fileNames := map[string]struct{}{}

--- a/desc/protoprint/testfiles/desc_test1-compact.proto
+++ b/desc/protoprint/testfiles/desc_test1-compact.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
-option go_package = "github.com/jhump/protoreflect/internal/testprotos";
 package testprotos;
+option go_package = "github.com/jhump/protoreflect/internal/testprotos";
 // Comment for TestMessage
 message TestMessage {
   // Comment for NestedMessage

--- a/desc/protoprint/testfiles/desc_test1-default.proto
+++ b/desc/protoprint/testfiles/desc_test1-default.proto
@@ -1,8 +1,8 @@
 syntax = "proto2";
 
-option go_package = "github.com/jhump/protoreflect/internal/testprotos";
-
 package testprotos;
+
+option go_package = "github.com/jhump/protoreflect/internal/testprotos";
 
 // Comment for TestMessage
 message TestMessage {

--- a/desc/protoprint/testfiles/desc_test1-multiline-style-comments.proto
+++ b/desc/protoprint/testfiles/desc_test1-multiline-style-comments.proto
@@ -1,8 +1,8 @@
 syntax = "proto2";
 
-option go_package = "github.com/jhump/protoreflect/internal/testprotos";
-
 package testprotos;
+
+option go_package = "github.com/jhump/protoreflect/internal/testprotos";
 
 /* Comment for TestMessage */
 message TestMessage {

--- a/desc/protoprint/testfiles/desc_test1-no-trailing-comments.proto
+++ b/desc/protoprint/testfiles/desc_test1-no-trailing-comments.proto
@@ -1,8 +1,8 @@
 syntax = "proto2";
 
-option go_package = "github.com/jhump/protoreflect/internal/testprotos";
-
 package testprotos;
+
+option go_package = "github.com/jhump/protoreflect/internal/testprotos";
 
 // Comment for TestMessage
 message TestMessage {

--- a/desc/protoprint/testfiles/desc_test1-only-doc-comments.proto
+++ b/desc/protoprint/testfiles/desc_test1-only-doc-comments.proto
@@ -1,8 +1,8 @@
 syntax = "proto2";
 
-option go_package = "github.com/jhump/protoreflect/internal/testprotos";
-
 package testprotos;
+
+option go_package = "github.com/jhump/protoreflect/internal/testprotos";
 
 // Comment for TestMessage
 message TestMessage {

--- a/desc/protoprint/testfiles/desc_test1-trailing-on-next-line.proto
+++ b/desc/protoprint/testfiles/desc_test1-trailing-on-next-line.proto
@@ -1,8 +1,8 @@
 syntax = "proto2";
 
-option go_package = "github.com/jhump/protoreflect/internal/testprotos";
-
 package testprotos;
+
+option go_package = "github.com/jhump/protoreflect/internal/testprotos";
 
 // Comment for TestMessage
 message TestMessage {

--- a/desc/protoprint/testfiles/desc_test_comments-compact.proto
+++ b/desc/protoprint/testfiles/desc_test_comments-compact.proto
@@ -3,11 +3,11 @@
 // This is a third.
 // Syntax comment...
 syntax = "proto2"; // Syntax trailer.
-option go_package = "github.com/jhump/protoreflect/internal/testprotos";
 // And now the package declaration
 package foo.bar;
 import "google/protobuf/empty.proto";
 import "desc_test_options.proto";
+option go_package = "github.com/jhump/protoreflect/internal/testprotos";
 // Multiple white space lines (like above) cannot
 // be preserved...
 // We need a request for our RPC service below.

--- a/desc/protoprint/testfiles/desc_test_comments-default.proto
+++ b/desc/protoprint/testfiles/desc_test_comments-default.proto
@@ -7,14 +7,14 @@
 // Syntax comment...
 syntax = "proto2"; // Syntax trailer.
 
-option go_package = "github.com/jhump/protoreflect/internal/testprotos";
-
 // And now the package declaration
 package foo.bar;
 
 import "google/protobuf/empty.proto";
 
 import "desc_test_options.proto";
+
+option go_package = "github.com/jhump/protoreflect/internal/testprotos";
 
 // Multiple white space lines (like above) cannot
 // be preserved...

--- a/desc/protoprint/testfiles/desc_test_comments-multiline-style-comments.proto
+++ b/desc/protoprint/testfiles/desc_test_comments-multiline-style-comments.proto
@@ -7,14 +7,14 @@
 /* Syntax comment... */
 syntax = "proto2"; /* Syntax trailer. */
 
-option go_package = "github.com/jhump/protoreflect/internal/testprotos";
-
 /* And now the package declaration */
 package foo.bar;
 
 import "google/protobuf/empty.proto";
 
 import "desc_test_options.proto";
+
+option go_package = "github.com/jhump/protoreflect/internal/testprotos";
 
 /*
  * Multiple white space lines (like above) cannot

--- a/desc/protoprint/testfiles/desc_test_comments-no-trailing-comments.proto
+++ b/desc/protoprint/testfiles/desc_test_comments-no-trailing-comments.proto
@@ -7,14 +7,14 @@
 // Syntax comment...
 syntax = "proto2";
 
-option go_package = "github.com/jhump/protoreflect/internal/testprotos";
-
 // And now the package declaration
 package foo.bar;
 
 import "google/protobuf/empty.proto";
 
 import "desc_test_options.proto";
+
+option go_package = "github.com/jhump/protoreflect/internal/testprotos";
 
 // Multiple white space lines (like above) cannot
 // be preserved...

--- a/desc/protoprint/testfiles/desc_test_comments-only-doc-comments.proto
+++ b/desc/protoprint/testfiles/desc_test_comments-only-doc-comments.proto
@@ -1,12 +1,12 @@
 syntax = "proto2";
 
-option go_package = "github.com/jhump/protoreflect/internal/testprotos";
-
 package foo.bar;
 
 import "google/protobuf/empty.proto";
 
 import "desc_test_options.proto";
+
+option go_package = "github.com/jhump/protoreflect/internal/testprotos";
 
 // We need a request for our RPC service below.
 message Request {

--- a/desc/protoprint/testfiles/desc_test_comments-trailing-on-next-line.proto
+++ b/desc/protoprint/testfiles/desc_test_comments-trailing-on-next-line.proto
@@ -8,14 +8,14 @@
 syntax = "proto2";
 // Syntax trailer.
 
-option go_package = "github.com/jhump/protoreflect/internal/testprotos";
-
 // And now the package declaration
 package foo.bar;
 
 import "google/protobuf/empty.proto";
 
 import "desc_test_options.proto";
+
+option go_package = "github.com/jhump/protoreflect/internal/testprotos";
 
 // Multiple white space lines (like above) cannot
 // be preserved...

--- a/desc/protoprint/testfiles/desc_test_complex_source_info-compact.proto
+++ b/desc/protoprint/testfiles/desc_test_complex_source_info-compact.proto
@@ -1,7 +1,7 @@
 syntax = "proto2";
-option go_package = "github.com/jhump/protoreflect/internal/testprotos";
 package foo.bar;
 import "google/protobuf/descriptor.proto";
+option go_package = "github.com/jhump/protoreflect/internal/testprotos";
 message Simple {
   optional string name = 1;
   optional uint64 id = 2;

--- a/desc/protoprint/testfiles/desc_test_complex_source_info-default.proto
+++ b/desc/protoprint/testfiles/desc_test_complex_source_info-default.proto
@@ -1,10 +1,10 @@
 syntax = "proto2";
 
-option go_package = "github.com/jhump/protoreflect/internal/testprotos";
-
 package foo.bar;
 
 import "google/protobuf/descriptor.proto";
+
+option go_package = "github.com/jhump/protoreflect/internal/testprotos";
 
 message Simple {
   optional string name = 1;

--- a/desc/protoprint/testfiles/desc_test_complex_source_info-multiline-style-comments.proto
+++ b/desc/protoprint/testfiles/desc_test_complex_source_info-multiline-style-comments.proto
@@ -1,10 +1,10 @@
 syntax = "proto2";
 
-option go_package = "github.com/jhump/protoreflect/internal/testprotos";
-
 package foo.bar;
 
 import "google/protobuf/descriptor.proto";
+
+option go_package = "github.com/jhump/protoreflect/internal/testprotos";
 
 message Simple {
 	optional string name = 1;

--- a/desc/protoprint/testfiles/desc_test_complex_source_info-no-trailing-comments.proto
+++ b/desc/protoprint/testfiles/desc_test_complex_source_info-no-trailing-comments.proto
@@ -1,10 +1,10 @@
 syntax = "proto2";
 
-option go_package = "github.com/jhump/protoreflect/internal/testprotos";
-
 package foo.bar;
 
 import "google/protobuf/descriptor.proto";
+
+option go_package = "github.com/jhump/protoreflect/internal/testprotos";
 
 message Simple {
   optional string name = 1;

--- a/desc/protoprint/testfiles/desc_test_complex_source_info-only-doc-comments.proto
+++ b/desc/protoprint/testfiles/desc_test_complex_source_info-only-doc-comments.proto
@@ -1,10 +1,10 @@
 syntax = "proto2";
 
-option go_package = "github.com/jhump/protoreflect/internal/testprotos";
-
 package foo.bar;
 
 import "google/protobuf/descriptor.proto";
+
+option go_package = "github.com/jhump/protoreflect/internal/testprotos";
 
 message Simple {
   optional string name = 1;

--- a/desc/protoprint/testfiles/desc_test_complex_source_info-trailing-on-next-line.proto
+++ b/desc/protoprint/testfiles/desc_test_complex_source_info-trailing-on-next-line.proto
@@ -1,10 +1,10 @@
 syntax = "proto2";
 
-option go_package = "github.com/jhump/protoreflect/internal/testprotos";
-
 package foo.bar;
 
 import "google/protobuf/descriptor.proto";
+
+option go_package = "github.com/jhump/protoreflect/internal/testprotos";
 
 message Simple {
   optional string name = 1;

--- a/desc/protoprint/testfiles/descriptor-compact.proto
+++ b/desc/protoprint/testfiles/descriptor-compact.proto
@@ -35,6 +35,7 @@
 // A valid .proto file can be translated directly to a FileDescriptorProto
 // without any other information (e.g. without reading its imports).
 syntax = "proto2";
+package google.protobuf;
 option cc_enable_arenas = true;
 option csharp_namespace = "Google.Protobuf.Reflection";
 option go_package = "github.com/golang/protobuf/protoc-gen-go/descriptor;descriptor";
@@ -42,7 +43,6 @@ option java_outer_classname = "DescriptorProtos";
 option java_package = "com.google.protobuf";
 option objc_class_prefix = "GPB";
 option optimize_for = SPEED;
-package google.protobuf;
 // The protocol compiler can output a FileDescriptorSet containing the .proto
 // files it parses.
 message FileDescriptorSet {

--- a/desc/protoprint/testfiles/descriptor-default.proto
+++ b/desc/protoprint/testfiles/descriptor-default.proto
@@ -38,6 +38,8 @@
 
 syntax = "proto2";
 
+package google.protobuf;
+
 option cc_enable_arenas = true;
 
 option csharp_namespace = "Google.Protobuf.Reflection";
@@ -51,8 +53,6 @@ option java_package = "com.google.protobuf";
 option objc_class_prefix = "GPB";
 
 option optimize_for = SPEED;
-
-package google.protobuf;
 
 // The protocol compiler can output a FileDescriptorSet containing the .proto
 // files it parses.

--- a/desc/protoprint/testfiles/descriptor-multiline-style-comments.proto
+++ b/desc/protoprint/testfiles/descriptor-multiline-style-comments.proto
@@ -42,6 +42,8 @@
 
 syntax = "proto2";
 
+package google.protobuf;
+
 option cc_enable_arenas = true;
 
 option csharp_namespace = "Google.Protobuf.Reflection";
@@ -55,8 +57,6 @@ option java_package = "com.google.protobuf";
 option objc_class_prefix = "GPB";
 
 option optimize_for = SPEED;
-
-package google.protobuf;
 
 /*
  * The protocol compiler can output a FileDescriptorSet containing the .proto

--- a/desc/protoprint/testfiles/descriptor-no-trailing-comments.proto
+++ b/desc/protoprint/testfiles/descriptor-no-trailing-comments.proto
@@ -38,6 +38,8 @@
 
 syntax = "proto2";
 
+package google.protobuf;
+
 option cc_enable_arenas = true;
 
 option csharp_namespace = "Google.Protobuf.Reflection";
@@ -51,8 +53,6 @@ option java_package = "com.google.protobuf";
 option objc_class_prefix = "GPB";
 
 option optimize_for = SPEED;
-
-package google.protobuf;
 
 // The protocol compiler can output a FileDescriptorSet containing the .proto
 // files it parses.

--- a/desc/protoprint/testfiles/descriptor-only-doc-comments.proto
+++ b/desc/protoprint/testfiles/descriptor-only-doc-comments.proto
@@ -1,5 +1,7 @@
 syntax = "proto2";
 
+package google.protobuf;
+
 option cc_enable_arenas = true;
 
 option csharp_namespace = "Google.Protobuf.Reflection";
@@ -13,8 +15,6 @@ option java_package = "com.google.protobuf";
 option objc_class_prefix = "GPB";
 
 option optimize_for = SPEED;
-
-package google.protobuf;
 
 // The protocol compiler can output a FileDescriptorSet containing the .proto
 // files it parses.

--- a/desc/protoprint/testfiles/descriptor-trailing-on-next-line.proto
+++ b/desc/protoprint/testfiles/descriptor-trailing-on-next-line.proto
@@ -38,6 +38,8 @@
 
 syntax = "proto2";
 
+package google.protobuf;
+
 option cc_enable_arenas = true;
 
 option csharp_namespace = "Google.Protobuf.Reflection";
@@ -51,8 +53,6 @@ option java_package = "com.google.protobuf";
 option objc_class_prefix = "GPB";
 
 option optimize_for = SPEED;
-
-package google.protobuf;
 
 // The protocol compiler can output a FileDescriptorSet containing the .proto
 // files it parses.


### PR DESCRIPTION
Fixes #227 

Still needs new test cases. But all existing tests pass with minor changes. This also adds API to the `FileBuilder` to allow defining explicit imports. This changes the behavior slightly: before it would strip unused imports when round-tripping a `*desc.FileDescriptor` (more as a side effect than intentionally), but now they are preserved.