### PR TITLE
protoparse: fix option source locations

### DIFF
--- a/desc/descriptor_no_unsafe.go
+++ b/desc/descriptor_no_unsafe.go
@@ -1,5 +1,6 @@
-//+build appengine
-// TODO: other build tags for environments where unsafe package is inappropriate
+//+build appengine gopherjs purego
+// NB: other environments where unsafe is unappropriate should use "purego" build tag
+// https://github.com/golang/go/issues/23172
 
 package desc
 

--- a/desc/descriptor_unsafe.go
+++ b/desc/descriptor_unsafe.go
@@ -1,5 +1,6 @@
-//+build !appengine
-// TODO: exclude other build tags for environments where unsafe package is inappropriate
+//+build !appengine,!gopherjs,!purego
+// NB: other environments where unsafe is unappropriate should use "purego" build tag
+// https://github.com/golang/go/issues/23172
 
 package desc
 

--- a/desc/internal/source_info.go
+++ b/desc/internal/source_info.go
@@ -40,12 +40,13 @@ func asMapKey(slice []int32) string {
 	//return array.Interface()
 
 	b := make([]byte, len(slice)*4)
-	for i, s := range slice {
-		j := i * 4
+	j := 0
+	for _, s := range slice {
 		b[j] = byte(s)
 		b[j+1] = byte(s >> 8)
 		b[j+2] = byte(s >> 16)
 		b[j+3] = byte(s >> 24)
+		j += 4
 	}
 	return string(b)
 }

--- a/desc/protoparse/ast.go
+++ b/desc/protoparse/ast.go
@@ -166,12 +166,6 @@ type basicCompositeNode struct {
 	last  node
 }
 
-func (n *basicCompositeNode) toBasicNode() basicNode {
-	// only works on terminals: composite nodes where first
-	// and last are *basicNode (and also equal)
-	return *n.first.(*basicNode)
-}
-
 func (n *basicCompositeNode) start() *SourcePos {
 	return n.first.start()
 }
@@ -426,7 +420,7 @@ func (n *floatLiteralNode) pushTrailingComment(c *comment) {
 }
 
 type boolLiteralNode struct {
-	basicNode
+	*identNode
 	val bool
 }
 
@@ -521,7 +515,7 @@ func (n *fieldNode) getGroupKeyword() node {
 }
 
 type labelNode struct {
-	basicNode
+	*identNode
 	repeated bool
 	required bool
 }

--- a/desc/protoparse/options.go
+++ b/desc/protoparse/options.go
@@ -1004,7 +1004,7 @@ func interpretOptions(res *parseResult, element descriptorish, opts proto.Messag
 
 	} else {
 		// not lenient: try to convert into the passed in message
-		// and fail is not successful
+		// and fail if not successful
 		if err := dm.ConvertTo(opts); err != nil {
 			node := res.nodes[element.AsProto()]
 			return nil, ErrorWithSourcePos{Pos: node.start(), Underlying: err}

--- a/desc/protoparse/proto.y
+++ b/desc/protoparse/proto.y
@@ -251,9 +251,9 @@ scalarConstant : stringLit {
 	}
 	| name {
 		if $1.val == "true" {
-			$$ = &boolLiteralNode{basicNode: $1.toBasicNode(), val: true}
+			$$ = &boolLiteralNode{identNode: $1, val: true}
 		} else if $1.val == "false" {
-			$$ = &boolLiteralNode{basicNode: $1.toBasicNode(), val: false}
+			$$ = &boolLiteralNode{identNode: $1, val: false}
 		} else if $1.val == "inf" {
 			f := &floatLiteralNode{val: math.Inf(1)}
 			f.setRange($1, $1)
@@ -413,19 +413,19 @@ typeIdent : ident
 
 field : _REQUIRED typeIdent name '=' _INT_LIT ';' {
 		checkTag(protolex, $5.start(), $5.val)
-		lbl := &labelNode{basicNode: $1.toBasicNode(), required: true}
+		lbl := &labelNode{identNode: $1, required: true}
 		$$ = &fieldNode{label: lbl, fldType: $2, name: $3, tag: $5}
 		$$.setRange($1, $6)
 	}
 	| _OPTIONAL typeIdent name '=' _INT_LIT ';' {
 		checkTag(protolex, $5.start(), $5.val)
-		lbl := &labelNode{basicNode: $1.toBasicNode()}
+		lbl := &labelNode{identNode: $1}
 		$$ = &fieldNode{label: lbl, fldType: $2, name: $3, tag: $5}
 		$$.setRange($1, $6)
 	}
 	| _REPEATED typeIdent name '=' _INT_LIT ';' {
 		checkTag(protolex, $5.start(), $5.val)
-		lbl := &labelNode{basicNode: $1.toBasicNode(), repeated: true}
+		lbl := &labelNode{identNode: $1, repeated: true}
 		$$ = &fieldNode{label: lbl, fldType: $2, name: $3, tag: $5}
 		$$.setRange($1, $6)
 	}
@@ -436,19 +436,19 @@ field : _REQUIRED typeIdent name '=' _INT_LIT ';' {
 	}
 	| _REQUIRED typeIdent name '=' _INT_LIT '[' fieldOptions ']' ';' {
 		checkTag(protolex, $5.start(), $5.val)
-		lbl := &labelNode{basicNode: $1.toBasicNode(), required: true}
+		lbl := &labelNode{identNode: $1, required: true}
 		$$ = &fieldNode{label: lbl, fldType: $2, name: $3, tag: $5, options: $7}
 		$$.setRange($1, $9)
 	}
 	| _OPTIONAL typeIdent name '=' _INT_LIT '[' fieldOptions ']' ';' {
 		checkTag(protolex, $5.start(), $5.val)
-		lbl := &labelNode{basicNode: $1.toBasicNode()}
+		lbl := &labelNode{identNode: $1}
 		$$ = &fieldNode{label: lbl, fldType: $2, name: $3, tag: $5, options: $7}
 		$$.setRange($1, $9)
 	}
 	| _REPEATED typeIdent name '=' _INT_LIT '[' fieldOptions ']' ';' {
 		checkTag(protolex, $5.start(), $5.val)
-		lbl := &labelNode{basicNode: $1.toBasicNode(), repeated: true}
+		lbl := &labelNode{identNode: $1, repeated: true}
 		$$ = &fieldNode{label: lbl, fldType: $2, name: $3, tag: $5, options: $7}
 		$$.setRange($1, $9)
 	}
@@ -476,7 +476,7 @@ group : _REQUIRED _GROUP name '=' _INT_LIT '{' messageBody '}' {
 		if !unicode.IsUpper(rune($3.val[0])) {
 			lexError(protolex, $3.start(), fmt.Sprintf("group %s should have a name that starts with a capital letter", $3.val))
 		}
-		lbl := &labelNode{basicNode: $1.toBasicNode(), required: true}
+		lbl := &labelNode{identNode: $1, required: true}
 		$$ = &groupNode{groupKeyword: $2, label: lbl, name: $3, tag: $5, decls: $7}
 		$$.setRange($1, $8)
 	}
@@ -485,7 +485,7 @@ group : _REQUIRED _GROUP name '=' _INT_LIT '{' messageBody '}' {
 		if !unicode.IsUpper(rune($3.val[0])) {
 			lexError(protolex, $3.start(), fmt.Sprintf("group %s should have a name that starts with a capital letter", $3.val))
 		}
-		lbl := &labelNode{basicNode: $1.toBasicNode()}
+		lbl := &labelNode{identNode: $1}
 		$$ = &groupNode{groupKeyword: $2, label: lbl, name: $3, tag: $5, decls: $7}
 		$$.setRange($1, $8)
 	}
@@ -494,7 +494,7 @@ group : _REQUIRED _GROUP name '=' _INT_LIT '{' messageBody '}' {
 		if !unicode.IsUpper(rune($3.val[0])) {
 			lexError(protolex, $3.start(), fmt.Sprintf("group %s should have a name that starts with a capital letter", $3.val))
 		}
-		lbl := &labelNode{basicNode: $1.toBasicNode(), repeated: true}
+		lbl := &labelNode{identNode: $1, repeated: true}
 		$$ = &groupNode{groupKeyword: $2, label: lbl, name: $3, tag: $5, decls: $7}
 		$$.setRange($1, $8)
 	}

--- a/desc/protoparse/proto.y.go
+++ b/desc/protoparse/proto.y.go
@@ -1193,9 +1193,9 @@ protodefault:
 //line proto.y:252
 		{
 			if protoDollar[1].id.val == "true" {
-				protoVAL.v = &boolLiteralNode{basicNode: protoDollar[1].id.toBasicNode(), val: true}
+				protoVAL.v = &boolLiteralNode{identNode: protoDollar[1].id, val: true}
 			} else if protoDollar[1].id.val == "false" {
-				protoVAL.v = &boolLiteralNode{basicNode: protoDollar[1].id.toBasicNode(), val: false}
+				protoVAL.v = &boolLiteralNode{identNode: protoDollar[1].id, val: false}
 			} else if protoDollar[1].id.val == "inf" {
 				f := &floatLiteralNode{val: math.Inf(1)}
 				f.setRange(protoDollar[1].id, protoDollar[1].id)
@@ -1423,7 +1423,7 @@ protodefault:
 //line proto.y:414
 		{
 			checkTag(protolex, protoDollar[5].ui.start(), protoDollar[5].ui.val)
-			lbl := &labelNode{basicNode: protoDollar[1].id.toBasicNode(), required: true}
+			lbl := &labelNode{identNode: protoDollar[1].id, required: true}
 			protoVAL.fld = &fieldNode{label: lbl, fldType: protoDollar[2].id, name: protoDollar[3].id, tag: protoDollar[5].ui}
 			protoVAL.fld.setRange(protoDollar[1].id, protoDollar[6].b)
 		}
@@ -1432,7 +1432,7 @@ protodefault:
 //line proto.y:420
 		{
 			checkTag(protolex, protoDollar[5].ui.start(), protoDollar[5].ui.val)
-			lbl := &labelNode{basicNode: protoDollar[1].id.toBasicNode()}
+			lbl := &labelNode{identNode: protoDollar[1].id}
 			protoVAL.fld = &fieldNode{label: lbl, fldType: protoDollar[2].id, name: protoDollar[3].id, tag: protoDollar[5].ui}
 			protoVAL.fld.setRange(protoDollar[1].id, protoDollar[6].b)
 		}
@@ -1441,7 +1441,7 @@ protodefault:
 //line proto.y:426
 		{
 			checkTag(protolex, protoDollar[5].ui.start(), protoDollar[5].ui.val)
-			lbl := &labelNode{basicNode: protoDollar[1].id.toBasicNode(), repeated: true}
+			lbl := &labelNode{identNode: protoDollar[1].id, repeated: true}
 			protoVAL.fld = &fieldNode{label: lbl, fldType: protoDollar[2].id, name: protoDollar[3].id, tag: protoDollar[5].ui}
 			protoVAL.fld.setRange(protoDollar[1].id, protoDollar[6].b)
 		}
@@ -1458,7 +1458,7 @@ protodefault:
 //line proto.y:437
 		{
 			checkTag(protolex, protoDollar[5].ui.start(), protoDollar[5].ui.val)
-			lbl := &labelNode{basicNode: protoDollar[1].id.toBasicNode(), required: true}
+			lbl := &labelNode{identNode: protoDollar[1].id, required: true}
 			protoVAL.fld = &fieldNode{label: lbl, fldType: protoDollar[2].id, name: protoDollar[3].id, tag: protoDollar[5].ui, options: protoDollar[7].opts}
 			protoVAL.fld.setRange(protoDollar[1].id, protoDollar[9].b)
 		}
@@ -1467,7 +1467,7 @@ protodefault:
 //line proto.y:443
 		{
 			checkTag(protolex, protoDollar[5].ui.start(), protoDollar[5].ui.val)
-			lbl := &labelNode{basicNode: protoDollar[1].id.toBasicNode()}
+			lbl := &labelNode{identNode: protoDollar[1].id}
 			protoVAL.fld = &fieldNode{label: lbl, fldType: protoDollar[2].id, name: protoDollar[3].id, tag: protoDollar[5].ui, options: protoDollar[7].opts}
 			protoVAL.fld.setRange(protoDollar[1].id, protoDollar[9].b)
 		}
@@ -1476,7 +1476,7 @@ protodefault:
 //line proto.y:449
 		{
 			checkTag(protolex, protoDollar[5].ui.start(), protoDollar[5].ui.val)
-			lbl := &labelNode{basicNode: protoDollar[1].id.toBasicNode(), repeated: true}
+			lbl := &labelNode{identNode: protoDollar[1].id, repeated: true}
 			protoVAL.fld = &fieldNode{label: lbl, fldType: protoDollar[2].id, name: protoDollar[3].id, tag: protoDollar[5].ui, options: protoDollar[7].opts}
 			protoVAL.fld.setRange(protoDollar[1].id, protoDollar[9].b)
 		}
@@ -1512,7 +1512,7 @@ protodefault:
 			if !unicode.IsUpper(rune(protoDollar[3].id.val[0])) {
 				lexError(protolex, protoDollar[3].id.start(), fmt.Sprintf("group %s should have a name that starts with a capital letter", protoDollar[3].id.val))
 			}
-			lbl := &labelNode{basicNode: protoDollar[1].id.toBasicNode(), required: true}
+			lbl := &labelNode{identNode: protoDollar[1].id, required: true}
 			protoVAL.grp = &groupNode{groupKeyword: protoDollar[2].id, label: lbl, name: protoDollar[3].id, tag: protoDollar[5].ui, decls: protoDollar[7].msgDecls}
 			protoVAL.grp.setRange(protoDollar[1].id, protoDollar[8].b)
 		}
@@ -1524,7 +1524,7 @@ protodefault:
 			if !unicode.IsUpper(rune(protoDollar[3].id.val[0])) {
 				lexError(protolex, protoDollar[3].id.start(), fmt.Sprintf("group %s should have a name that starts with a capital letter", protoDollar[3].id.val))
 			}
-			lbl := &labelNode{basicNode: protoDollar[1].id.toBasicNode()}
+			lbl := &labelNode{identNode: protoDollar[1].id}
 			protoVAL.grp = &groupNode{groupKeyword: protoDollar[2].id, label: lbl, name: protoDollar[3].id, tag: protoDollar[5].ui, decls: protoDollar[7].msgDecls}
 			protoVAL.grp.setRange(protoDollar[1].id, protoDollar[8].b)
 		}
@@ -1536,7 +1536,7 @@ protodefault:
 			if !unicode.IsUpper(rune(protoDollar[3].id.val[0])) {
 				lexError(protolex, protoDollar[3].id.start(), fmt.Sprintf("group %s should have a name that starts with a capital letter", protoDollar[3].id.val))
 			}
-			lbl := &labelNode{basicNode: protoDollar[1].id.toBasicNode(), repeated: true}
+			lbl := &labelNode{identNode: protoDollar[1].id, repeated: true}
 			protoVAL.grp = &groupNode{groupKeyword: protoDollar[2].id, label: lbl, name: protoDollar[3].id, tag: protoDollar[5].ui, decls: protoDollar[7].msgDecls}
 			protoVAL.grp.setRange(protoDollar[1].id, protoDollar[8].b)
 		}

--- a/desc/protoparse/test-source-info.txt
+++ b/desc/protoparse/test-source-info.txt
@@ -488,6 +488,18 @@ desc_test_comments.proto:69:22
  "super"!
 
 
+ > message_type[0] > enum_type[0] > options:
+desc_test_comments.proto:72:3
+desc_test_comments.proto:89:36
+
+
+ > message_type[0] > enum_type[0] > options > allow_alias:
+desc_test_comments.proto:72:3
+desc_test_comments.proto:72:29
+    Leading comments:
+ allow_alias comments!
+
+
  > message_type[0] > enum_type[0] > value:
 desc_test_comments.proto:74:3
 desc_test_comments.proto:87:17
@@ -581,11 +593,6 @@ desc_test_comments.proto:77:9
  > message_type[0] > enum_type[0] > value[3] > number:
 desc_test_comments.proto:77:12
 desc_test_comments.proto:77:13
-
-
- > message_type[0] > enum_type[0] > options:
-desc_test_comments.proto:79:3
-desc_test_comments.proto:89:36
 
 
  > message_type[0] > enum_type[0] > options > efubars:

--- a/desc/protoparse/test-source-info.txt
+++ b/desc/protoparse/test-source-info.txt
@@ -3,7 +3,7 @@
 
 :
 desc_test_comments.proto:8:1
-desc_test_comments.proto:119:2
+desc_test_comments.proto:123:2
 
 
  > syntax:
@@ -59,12 +59,12 @@ desc_test_comments.proto:18:34
 
  > message_type:
 desc_test_comments.proto:25:1
-desc_test_comments.proto:89:2
+desc_test_comments.proto:91:2
 
 
  > message_type[0]:
 desc_test_comments.proto:25:1
-desc_test_comments.proto:89:2
+desc_test_comments.proto:91:2
     Leading detached comment [0]:
  Multiple white space lines (like above) cannot
  be preserved...
@@ -93,16 +93,18 @@ desc_test_comments.proto:35:54
  > message_type[0] > options > deprecated:
 desc_test_comments.proto:26:3
 desc_test_comments.proto:26:28
+    Trailing comments:
+ deprecated!
 
 
  > message_type[0] > field:
 desc_test_comments.proto:29:2
-desc_test_comments.proto:66:3
+desc_test_comments.proto:67:3
 
 
  > message_type[0] > field[0]:
 desc_test_comments.proto:29:2
-desc_test_comments.proto:32:92
+desc_test_comments.proto:32:125
     Leading comments:
  A field comment
     Trailing comments:
@@ -139,7 +141,7 @@ desc_test_comments.proto:29:64
 
  > message_type[0] > field[0] > options:
 desc_test_comments.proto:32:5
-desc_test_comments.proto:32:90
+desc_test_comments.proto:32:123
 
 
  > message_type[0] > field[0] > options > packed:
@@ -148,23 +150,25 @@ desc_test_comments.proto:32:16
 
 
  > message_type[0] > field[0] > json_name:
-desc_test_comments.proto:32:18
-desc_test_comments.proto:32:35
+desc_test_comments.proto:32:32
+desc_test_comments.proto:32:49
+    Trailing comments:
+ custom JSON! 
 
 
  > message_type[0] > field[0] > options > ffubar:
-desc_test_comments.proto:32:37
-desc_test_comments.proto:32:62
+desc_test_comments.proto:32:70
+desc_test_comments.proto:32:95
 
 
  > message_type[0] > field[0] > options > ffubar[0]:
-desc_test_comments.proto:32:37
-desc_test_comments.proto:32:62
+desc_test_comments.proto:32:70
+desc_test_comments.proto:32:95
 
 
  > message_type[0] > field[0] > options > ffubarb:
-desc_test_comments.proto:32:64
-desc_test_comments.proto:32:90
+desc_test_comments.proto:32:97
+desc_test_comments.proto:32:123
 
 
  > message_type[0] > options > mfubar:
@@ -334,19 +338,19 @@ desc_test_comments.proto:52:30
 
  > message_type[0] > field[2]:
 desc_test_comments.proto:55:2
-desc_test_comments.proto:66:3
+desc_test_comments.proto:67:3
     Leading comments:
  Group comment
 
 
  > message_type[0] > nested_type:
 desc_test_comments.proto:55:2
-desc_test_comments.proto:66:3
+desc_test_comments.proto:67:3
 
 
  > message_type[0] > nested_type[0]:
 desc_test_comments.proto:55:2
-desc_test_comments.proto:66:3
+desc_test_comments.proto:67:3
 
 
  > message_type[0] > field[2] > label:
@@ -367,78 +371,80 @@ desc_test_comments.proto:55:44
 
 
  > message_type[0] > nested_type[0] > options:
-desc_test_comments.proto:56:3
-desc_test_comments.proto:61:50
+desc_test_comments.proto:57:3
+desc_test_comments.proto:62:50
 
 
  > message_type[0] > nested_type[0] > options > mfubar:
-desc_test_comments.proto:56:3
-desc_test_comments.proto:56:38
+desc_test_comments.proto:57:3
+desc_test_comments.proto:57:38
+    Leading comments:
+ this is a custom option
 
 
  > message_type[0] > nested_type[0] > field:
-desc_test_comments.proto:58:3
-desc_test_comments.proto:64:27
+desc_test_comments.proto:59:3
+desc_test_comments.proto:65:27
 
 
  > message_type[0] > nested_type[0] > field[0]:
-desc_test_comments.proto:58:3
-desc_test_comments.proto:58:27
+desc_test_comments.proto:59:3
+desc_test_comments.proto:59:27
 
 
  > message_type[0] > nested_type[0] > field[0] > label:
-desc_test_comments.proto:58:3
-desc_test_comments.proto:58:11
-
-
- > message_type[0] > nested_type[0] > field[0] > type:
-desc_test_comments.proto:58:12
-desc_test_comments.proto:58:18
-
-
- > message_type[0] > nested_type[0] > field[0] > name:
-desc_test_comments.proto:58:19
-desc_test_comments.proto:58:22
-
-
- > message_type[0] > nested_type[0] > field[0] > number:
-desc_test_comments.proto:58:25
-desc_test_comments.proto:58:26
-
-
- > message_type[0] > nested_type[0] > field[1]:
-desc_test_comments.proto:59:3
-desc_test_comments.proto:59:26
-
-
- > message_type[0] > nested_type[0] > field[1] > label:
 desc_test_comments.proto:59:3
 desc_test_comments.proto:59:11
 
 
- > message_type[0] > nested_type[0] > field[1] > type:
+ > message_type[0] > nested_type[0] > field[0] > type:
 desc_test_comments.proto:59:12
-desc_test_comments.proto:59:17
+desc_test_comments.proto:59:18
+
+
+ > message_type[0] > nested_type[0] > field[0] > name:
+desc_test_comments.proto:59:19
+desc_test_comments.proto:59:22
+
+
+ > message_type[0] > nested_type[0] > field[0] > number:
+desc_test_comments.proto:59:25
+desc_test_comments.proto:59:26
+
+
+ > message_type[0] > nested_type[0] > field[1]:
+desc_test_comments.proto:60:3
+desc_test_comments.proto:60:26
+
+
+ > message_type[0] > nested_type[0] > field[1] > label:
+desc_test_comments.proto:60:3
+desc_test_comments.proto:60:11
+
+
+ > message_type[0] > nested_type[0] > field[1] > type:
+desc_test_comments.proto:60:12
+desc_test_comments.proto:60:17
 
 
  > message_type[0] > nested_type[0] > field[1] > name:
-desc_test_comments.proto:59:18
-desc_test_comments.proto:59:21
+desc_test_comments.proto:60:18
+desc_test_comments.proto:60:21
 
 
  > message_type[0] > nested_type[0] > field[1] > number:
-desc_test_comments.proto:59:24
-desc_test_comments.proto:59:25
+desc_test_comments.proto:60:24
+desc_test_comments.proto:60:25
 
 
  > message_type[0] > nested_type[0] > options > no_standard_descriptor_accessor:
-desc_test_comments.proto:61:3
-desc_test_comments.proto:61:50
+desc_test_comments.proto:62:3
+desc_test_comments.proto:62:50
 
 
  > message_type[0] > nested_type[0] > field[2]:
-desc_test_comments.proto:64:3
-desc_test_comments.proto:64:27
+desc_test_comments.proto:65:3
+desc_test_comments.proto:65:27
     Leading comments:
  Leading comment...
     Trailing comments:
@@ -446,346 +452,346 @@ desc_test_comments.proto:64:27
 
 
  > message_type[0] > nested_type[0] > field[2] > label:
-desc_test_comments.proto:64:3
-desc_test_comments.proto:64:11
+desc_test_comments.proto:65:3
+desc_test_comments.proto:65:11
 
 
  > message_type[0] > nested_type[0] > field[2] > type:
-desc_test_comments.proto:64:12
-desc_test_comments.proto:64:18
+desc_test_comments.proto:65:12
+desc_test_comments.proto:65:18
 
 
  > message_type[0] > nested_type[0] > field[2] > name:
-desc_test_comments.proto:64:19
-desc_test_comments.proto:64:22
+desc_test_comments.proto:65:19
+desc_test_comments.proto:65:22
 
 
  > message_type[0] > nested_type[0] > field[2] > number:
-desc_test_comments.proto:64:25
-desc_test_comments.proto:64:26
+desc_test_comments.proto:65:25
+desc_test_comments.proto:65:26
 
 
  > message_type[0] > enum_type:
-desc_test_comments.proto:68:2
-desc_test_comments.proto:88:3
+desc_test_comments.proto:69:2
+desc_test_comments.proto:90:3
 
 
  > message_type[0] > enum_type[0]:
-desc_test_comments.proto:68:2
-desc_test_comments.proto:88:3
+desc_test_comments.proto:69:2
+desc_test_comments.proto:90:3
 
 
  > message_type[0] > enum_type[0] > name:
-desc_test_comments.proto:68:7
-desc_test_comments.proto:68:22
+desc_test_comments.proto:69:7
+desc_test_comments.proto:69:22
     Trailing comments:
  "super"!
 
 
  > message_type[0] > enum_type[0] > value:
-desc_test_comments.proto:72:3
-desc_test_comments.proto:85:17
+desc_test_comments.proto:74:3
+desc_test_comments.proto:87:17
 
 
  > message_type[0] > enum_type[0] > value[0]:
-desc_test_comments.proto:72:3
-desc_test_comments.proto:72:72
+desc_test_comments.proto:74:3
+desc_test_comments.proto:74:72
 
 
  > message_type[0] > enum_type[0] > value[0] > name:
-desc_test_comments.proto:72:3
-desc_test_comments.proto:72:8
-
-
- > message_type[0] > enum_type[0] > value[0] > number:
-desc_test_comments.proto:72:11
-desc_test_comments.proto:72:12
-
-
- > message_type[0] > enum_type[0] > value[0] > options:
-desc_test_comments.proto:72:14
-desc_test_comments.proto:72:70
-
-
- > message_type[0] > enum_type[0] > value[0] > options > evfubars:
-desc_test_comments.proto:72:14
-desc_test_comments.proto:72:42
-
-
- > message_type[0] > enum_type[0] > value[0] > options > evfubar:
-desc_test_comments.proto:72:44
-desc_test_comments.proto:72:70
-
-
- > message_type[0] > enum_type[0] > value[1]:
-desc_test_comments.proto:73:3
-desc_test_comments.proto:73:86
-
-
- > message_type[0] > enum_type[0] > value[1] > name:
-desc_test_comments.proto:73:3
-desc_test_comments.proto:73:8
-
-
- > message_type[0] > enum_type[0] > value[1] > number:
-desc_test_comments.proto:73:11
-desc_test_comments.proto:73:12
-
-
- > message_type[0] > enum_type[0] > value[1] > options:
-desc_test_comments.proto:73:15
-desc_test_comments.proto:73:84
-
-
- > message_type[0] > enum_type[0] > value[1] > options > evfubaruf:
-desc_test_comments.proto:73:15
-desc_test_comments.proto:73:43
-
-
- > message_type[0] > enum_type[0] > value[1] > options > evfubaru:
-desc_test_comments.proto:73:59
-desc_test_comments.proto:73:84
-
-
- > message_type[0] > enum_type[0] > value[2]:
-desc_test_comments.proto:74:3
-desc_test_comments.proto:74:13
-
-
- > message_type[0] > enum_type[0] > value[2] > name:
 desc_test_comments.proto:74:3
 desc_test_comments.proto:74:8
 
 
- > message_type[0] > enum_type[0] > value[2] > number:
+ > message_type[0] > enum_type[0] > value[0] > number:
 desc_test_comments.proto:74:11
 desc_test_comments.proto:74:12
 
 
- > message_type[0] > enum_type[0] > value[3]:
+ > message_type[0] > enum_type[0] > value[0] > options:
+desc_test_comments.proto:74:14
+desc_test_comments.proto:74:70
+
+
+ > message_type[0] > enum_type[0] > value[0] > options > evfubars:
+desc_test_comments.proto:74:14
+desc_test_comments.proto:74:42
+
+
+ > message_type[0] > enum_type[0] > value[0] > options > evfubar:
+desc_test_comments.proto:74:44
+desc_test_comments.proto:74:70
+
+
+ > message_type[0] > enum_type[0] > value[1]:
 desc_test_comments.proto:75:3
-desc_test_comments.proto:75:14
+desc_test_comments.proto:75:86
+
+
+ > message_type[0] > enum_type[0] > value[1] > name:
+desc_test_comments.proto:75:3
+desc_test_comments.proto:75:8
+
+
+ > message_type[0] > enum_type[0] > value[1] > number:
+desc_test_comments.proto:75:11
+desc_test_comments.proto:75:12
+
+
+ > message_type[0] > enum_type[0] > value[1] > options:
+desc_test_comments.proto:75:15
+desc_test_comments.proto:75:84
+
+
+ > message_type[0] > enum_type[0] > value[1] > options > evfubaruf:
+desc_test_comments.proto:75:15
+desc_test_comments.proto:75:43
+
+
+ > message_type[0] > enum_type[0] > value[1] > options > evfubaru:
+desc_test_comments.proto:75:59
+desc_test_comments.proto:75:84
+
+
+ > message_type[0] > enum_type[0] > value[2]:
+desc_test_comments.proto:76:3
+desc_test_comments.proto:76:13
+
+
+ > message_type[0] > enum_type[0] > value[2] > name:
+desc_test_comments.proto:76:3
+desc_test_comments.proto:76:8
+
+
+ > message_type[0] > enum_type[0] > value[2] > number:
+desc_test_comments.proto:76:11
+desc_test_comments.proto:76:12
+
+
+ > message_type[0] > enum_type[0] > value[3]:
+desc_test_comments.proto:77:3
+desc_test_comments.proto:77:14
 
 
  > message_type[0] > enum_type[0] > value[3] > name:
-desc_test_comments.proto:75:3
-desc_test_comments.proto:75:9
+desc_test_comments.proto:77:3
+desc_test_comments.proto:77:9
 
 
  > message_type[0] > enum_type[0] > value[3] > number:
-desc_test_comments.proto:75:12
-desc_test_comments.proto:75:13
+desc_test_comments.proto:77:12
+desc_test_comments.proto:77:13
 
 
  > message_type[0] > enum_type[0] > options:
-desc_test_comments.proto:77:3
-desc_test_comments.proto:87:36
+desc_test_comments.proto:79:3
+desc_test_comments.proto:89:36
 
 
  > message_type[0] > enum_type[0] > options > efubars:
-desc_test_comments.proto:77:3
-desc_test_comments.proto:77:38
+desc_test_comments.proto:79:3
+desc_test_comments.proto:79:38
 
 
  > message_type[0] > enum_type[0] > value[4]:
-desc_test_comments.proto:79:3
-desc_test_comments.proto:79:13
+desc_test_comments.proto:81:3
+desc_test_comments.proto:81:13
 
 
  > message_type[0] > enum_type[0] > value[4] > name:
-desc_test_comments.proto:79:3
-desc_test_comments.proto:79:8
+desc_test_comments.proto:81:3
+desc_test_comments.proto:81:8
 
 
  > message_type[0] > enum_type[0] > value[4] > number:
-desc_test_comments.proto:79:11
-desc_test_comments.proto:79:12
+desc_test_comments.proto:81:11
+desc_test_comments.proto:81:12
 
 
  > message_type[0] > enum_type[0] > value[5]:
-desc_test_comments.proto:80:3
-desc_test_comments.proto:80:15
+desc_test_comments.proto:82:3
+desc_test_comments.proto:82:15
 
 
  > message_type[0] > enum_type[0] > value[5] > name:
-desc_test_comments.proto:80:3
-desc_test_comments.proto:80:10
+desc_test_comments.proto:82:3
+desc_test_comments.proto:82:10
 
 
  > message_type[0] > enum_type[0] > value[5] > number:
-desc_test_comments.proto:80:13
-desc_test_comments.proto:80:14
-
-
- > message_type[0] > enum_type[0] > value[6]:
-desc_test_comments.proto:81:3
-desc_test_comments.proto:81:46
-
-
- > message_type[0] > enum_type[0] > value[6] > name:
-desc_test_comments.proto:81:3
-desc_test_comments.proto:81:10
-
-
- > message_type[0] > enum_type[0] > value[6] > number:
-desc_test_comments.proto:81:13
-desc_test_comments.proto:81:14
-
-
- > message_type[0] > enum_type[0] > value[6] > options:
-desc_test_comments.proto:81:16
-desc_test_comments.proto:81:44
-
-
- > message_type[0] > enum_type[0] > value[6] > options > evfubarsf:
-desc_test_comments.proto:81:16
-desc_test_comments.proto:81:44
-
-
- > message_type[0] > enum_type[0] > value[7]:
-desc_test_comments.proto:82:3
+desc_test_comments.proto:82:13
 desc_test_comments.proto:82:14
 
 
+ > message_type[0] > enum_type[0] > value[6]:
+desc_test_comments.proto:83:3
+desc_test_comments.proto:83:46
+
+
+ > message_type[0] > enum_type[0] > value[6] > name:
+desc_test_comments.proto:83:3
+desc_test_comments.proto:83:10
+
+
+ > message_type[0] > enum_type[0] > value[6] > number:
+desc_test_comments.proto:83:13
+desc_test_comments.proto:83:14
+
+
+ > message_type[0] > enum_type[0] > value[6] > options:
+desc_test_comments.proto:83:16
+desc_test_comments.proto:83:44
+
+
+ > message_type[0] > enum_type[0] > value[6] > options > evfubarsf:
+desc_test_comments.proto:83:16
+desc_test_comments.proto:83:44
+
+
+ > message_type[0] > enum_type[0] > value[7]:
+desc_test_comments.proto:84:3
+desc_test_comments.proto:84:14
+
+
  > message_type[0] > enum_type[0] > value[7] > name:
-desc_test_comments.proto:82:3
-desc_test_comments.proto:82:9
+desc_test_comments.proto:84:3
+desc_test_comments.proto:84:9
 
 
  > message_type[0] > enum_type[0] > value[7] > number:
-desc_test_comments.proto:82:12
-desc_test_comments.proto:82:13
-
-
- > message_type[0] > enum_type[0] > value[8]:
-desc_test_comments.proto:83:3
-desc_test_comments.proto:83:17
-
-
- > message_type[0] > enum_type[0] > value[8] > name:
-desc_test_comments.proto:83:3
-desc_test_comments.proto:83:12
-
-
- > message_type[0] > enum_type[0] > value[8] > number:
-desc_test_comments.proto:83:15
-desc_test_comments.proto:83:16
-
-
- > message_type[0] > enum_type[0] > value[9]:
-desc_test_comments.proto:84:3
+desc_test_comments.proto:84:12
 desc_test_comments.proto:84:13
 
 
- > message_type[0] > enum_type[0] > value[9] > name:
-desc_test_comments.proto:84:3
-desc_test_comments.proto:84:8
-
-
- > message_type[0] > enum_type[0] > value[9] > number:
-desc_test_comments.proto:84:11
-desc_test_comments.proto:84:12
-
-
- > message_type[0] > enum_type[0] > value[10]:
+ > message_type[0] > enum_type[0] > value[8]:
 desc_test_comments.proto:85:3
 desc_test_comments.proto:85:17
 
 
- > message_type[0] > enum_type[0] > value[10] > name:
+ > message_type[0] > enum_type[0] > value[8] > name:
 desc_test_comments.proto:85:3
-desc_test_comments.proto:85:9
-
-
- > message_type[0] > enum_type[0] > value[10] > number:
 desc_test_comments.proto:85:12
+
+
+ > message_type[0] > enum_type[0] > value[8] > number:
+desc_test_comments.proto:85:15
 desc_test_comments.proto:85:16
 
 
- > message_type[0] > enum_type[0] > options > efubar:
+ > message_type[0] > enum_type[0] > value[9]:
+desc_test_comments.proto:86:3
+desc_test_comments.proto:86:13
+
+
+ > message_type[0] > enum_type[0] > value[9] > name:
+desc_test_comments.proto:86:3
+desc_test_comments.proto:86:8
+
+
+ > message_type[0] > enum_type[0] > value[9] > number:
+desc_test_comments.proto:86:11
+desc_test_comments.proto:86:12
+
+
+ > message_type[0] > enum_type[0] > value[10]:
 desc_test_comments.proto:87:3
-desc_test_comments.proto:87:36
+desc_test_comments.proto:87:17
+
+
+ > message_type[0] > enum_type[0] > value[10] > name:
+desc_test_comments.proto:87:3
+desc_test_comments.proto:87:9
+
+
+ > message_type[0] > enum_type[0] > value[10] > number:
+desc_test_comments.proto:87:12
+desc_test_comments.proto:87:16
+
+
+ > message_type[0] > enum_type[0] > options > efubar:
+desc_test_comments.proto:89:3
+desc_test_comments.proto:89:36
 
 
  > extension[0] > extendee:
-desc_test_comments.proto:94:1
-desc_test_comments.proto:94:8
+desc_test_comments.proto:96:1
+desc_test_comments.proto:96:8
     Leading comments:
  extendee comment
 
 
  > extension[1] > extendee:
-desc_test_comments.proto:94:1
-desc_test_comments.proto:94:8
+desc_test_comments.proto:96:1
+desc_test_comments.proto:96:8
 
 
  > extension:
-desc_test_comments.proto:96:2
-desc_test_comments.proto:98:30
+desc_test_comments.proto:98:2
+desc_test_comments.proto:100:30
 
 
  > extension[0]:
-desc_test_comments.proto:96:2
-desc_test_comments.proto:96:30
+desc_test_comments.proto:98:2
+desc_test_comments.proto:98:30
     Leading comments:
  comment for guid1
 
 
  > extension[0] > label:
-desc_test_comments.proto:96:2
-desc_test_comments.proto:96:10
+desc_test_comments.proto:98:2
+desc_test_comments.proto:98:10
 
 
  > extension[0] > type:
-desc_test_comments.proto:96:11
-desc_test_comments.proto:96:17
+desc_test_comments.proto:98:11
+desc_test_comments.proto:98:17
 
 
  > extension[0] > name:
-desc_test_comments.proto:96:18
-desc_test_comments.proto:96:23
+desc_test_comments.proto:98:18
+desc_test_comments.proto:98:23
 
 
  > extension[0] > number:
-desc_test_comments.proto:96:26
-desc_test_comments.proto:96:29
+desc_test_comments.proto:98:26
+desc_test_comments.proto:98:29
 
 
  > extension[1]:
-desc_test_comments.proto:98:2
-desc_test_comments.proto:98:30
+desc_test_comments.proto:100:2
+desc_test_comments.proto:100:30
     Leading comments:
  ... and a comment for guid2
 
 
  > extension[1] > label:
-desc_test_comments.proto:98:2
-desc_test_comments.proto:98:10
+desc_test_comments.proto:100:2
+desc_test_comments.proto:100:10
 
 
  > extension[1] > type:
-desc_test_comments.proto:98:11
-desc_test_comments.proto:98:17
+desc_test_comments.proto:100:11
+desc_test_comments.proto:100:17
 
 
  > extension[1] > name:
-desc_test_comments.proto:98:18
-desc_test_comments.proto:98:23
+desc_test_comments.proto:100:18
+desc_test_comments.proto:100:23
 
 
  > extension[1] > number:
-desc_test_comments.proto:98:26
-desc_test_comments.proto:98:29
+desc_test_comments.proto:100:26
+desc_test_comments.proto:100:29
 
 
  > service:
-desc_test_comments.proto:103:1
-desc_test_comments.proto:119:2
+desc_test_comments.proto:105:1
+desc_test_comments.proto:123:2
 
 
  > service[0]:
-desc_test_comments.proto:103:1
-desc_test_comments.proto:119:2
+desc_test_comments.proto:105:1
+desc_test_comments.proto:123:2
     Leading comments:
  Service comment
     Trailing comments:
@@ -793,57 +799,63 @@ desc_test_comments.proto:119:2
 
 
  > service[0] > name:
-desc_test_comments.proto:103:28
-desc_test_comments.proto:103:38
+desc_test_comments.proto:105:28
+desc_test_comments.proto:105:38
     Leading comments:
  service name 
 
 
  > service[0] > options:
-desc_test_comments.proto:104:2
-desc_test_comments.proto:108:38
+desc_test_comments.proto:107:2
+desc_test_comments.proto:112:38
 
 
  > service[0] > options > sfubar:
-desc_test_comments.proto:104:2
-desc_test_comments.proto:105:40
+desc_test_comments.proto:107:2
+desc_test_comments.proto:109:40
 
 
  > service[0] > options > sfubar > id:
-desc_test_comments.proto:104:2
-desc_test_comments.proto:104:36
+desc_test_comments.proto:107:2
+desc_test_comments.proto:107:36
+    Leading comments:
+ option that sets field
 
 
  > service[0] > options > sfubar > name:
-desc_test_comments.proto:105:2
-desc_test_comments.proto:105:40
+desc_test_comments.proto:109:2
+desc_test_comments.proto:109:40
+    Leading comments:
+ another option that sets field
 
 
  > service[0] > options > deprecated:
-desc_test_comments.proto:106:2
-desc_test_comments.proto:106:28
+desc_test_comments.proto:110:2
+desc_test_comments.proto:110:28
+    Trailing comments:
+ DEPRECATED!
 
 
  > service[0] > options > sfubare:
-desc_test_comments.proto:108:2
-desc_test_comments.proto:108:38
+desc_test_comments.proto:112:2
+desc_test_comments.proto:112:38
 
 
  > service[0] > method:
-desc_test_comments.proto:111:2
-desc_test_comments.proto:118:3
+desc_test_comments.proto:115:2
+desc_test_comments.proto:122:3
 
 
  > service[0] > method[0]:
-desc_test_comments.proto:111:2
-desc_test_comments.proto:112:70
+desc_test_comments.proto:115:2
+desc_test_comments.proto:116:70
     Leading comments:
  Method comment
 
 
  > service[0] > method[0] > name:
-desc_test_comments.proto:111:21
-desc_test_comments.proto:111:33
+desc_test_comments.proto:115:21
+desc_test_comments.proto:115:33
     Leading comments:
  rpc name 
     Trailing comments:
@@ -851,69 +863,69 @@ desc_test_comments.proto:111:33
 
 
  > service[0] > method[0] > client_streaming:
-desc_test_comments.proto:111:66
-desc_test_comments.proto:111:72
+desc_test_comments.proto:115:66
+desc_test_comments.proto:115:72
     Leading comments:
  comment B 
 
 
  > service[0] > method[0] > input_type:
-desc_test_comments.proto:111:89
-desc_test_comments.proto:111:96
+desc_test_comments.proto:115:89
+desc_test_comments.proto:115:96
     Leading comments:
  comment C 
 
 
  > service[0] > method[0] > output_type:
-desc_test_comments.proto:112:43
-desc_test_comments.proto:112:50
+desc_test_comments.proto:116:43
+desc_test_comments.proto:116:50
     Leading comments:
 comment E 
 
 
  > service[0] > method[1]:
-desc_test_comments.proto:114:2
-desc_test_comments.proto:118:3
+desc_test_comments.proto:118:2
+desc_test_comments.proto:122:3
 
 
  > service[0] > method[1] > name:
-desc_test_comments.proto:114:6
-desc_test_comments.proto:114:14
+desc_test_comments.proto:118:6
+desc_test_comments.proto:118:14
 
 
  > service[0] > method[1] > input_type:
-desc_test_comments.proto:114:16
-desc_test_comments.proto:114:23
+desc_test_comments.proto:118:16
+desc_test_comments.proto:118:23
 
 
  > service[0] > method[1] > output_type:
-desc_test_comments.proto:114:34
-desc_test_comments.proto:114:55
+desc_test_comments.proto:118:34
+desc_test_comments.proto:118:55
 
 
  > service[0] > method[1] > options:
-desc_test_comments.proto:115:3
-desc_test_comments.proto:117:42
+desc_test_comments.proto:119:3
+desc_test_comments.proto:121:42
 
 
  > service[0] > method[1] > options > deprecated:
-desc_test_comments.proto:115:3
-desc_test_comments.proto:115:28
+desc_test_comments.proto:119:3
+desc_test_comments.proto:119:28
 
 
  > service[0] > method[1] > options > mtfubar:
-desc_test_comments.proto:116:3
-desc_test_comments.proto:116:39
+desc_test_comments.proto:120:3
+desc_test_comments.proto:120:39
 
 
  > service[0] > method[1] > options > mtfubar[0]:
-desc_test_comments.proto:116:3
-desc_test_comments.proto:116:39
+desc_test_comments.proto:120:3
+desc_test_comments.proto:120:39
 
 
  > service[0] > method[1] > options > mtfubard:
-desc_test_comments.proto:117:3
-desc_test_comments.proto:117:42
+desc_test_comments.proto:121:3
+desc_test_comments.proto:121:42
 ---- desc_test_options.proto ----
 
 

--- a/desc/protoparse/test-source-info.txt
+++ b/desc/protoparse/test-source-info.txt
@@ -147,6 +147,8 @@ desc_test_comments.proto:32:123
  > message_type[0] > field[0] > options > packed:
 desc_test_comments.proto:32:5
 desc_test_comments.proto:32:16
+    Trailing comments:
+ packed! 
 
 
  > message_type[0] > field[0] > json_name:

--- a/desc/protoprint/print.go
+++ b/desc/protoprint/print.go
@@ -266,7 +266,7 @@ func (p *Printer) printProto(dsc desc.Descriptor, out io.Writer) error {
 	mf := dynamic.NewMessageFactoryWithExtensionRegistry(&er)
 	fdp := dsc.GetFile().AsFileDescriptorProto()
 	sourceInfo := internal.CreateSourceInfoMap(fdp)
-	extendOptionLocations(sourceInfo)
+	extendOptionLocations(sourceInfo, fdp.GetSourceCodeInfo().Location)
 
 	path := findElement(dsc)
 	switch d := dsc.(type) {
@@ -1523,8 +1523,11 @@ var edges = map[edgeKind]map[int32]edgeKind{
 	},
 }
 
-func extendOptionLocations(sc internal.SourceInfoMap) {
-	for _, loc := range sc {
+func extendOptionLocations(sc internal.SourceInfoMap, locs []*descriptor.SourceCodeInfo_Location) {
+	// we iterate in the order that locations appear in descriptor
+	// for determinism (if we ranged over the map, order and thus
+	// potentially results are non-deterministic)
+	for _, loc := range locs {
 		allowed := edges[edgeKindFile]
 		for i := 0; i+1 < len(loc.Path); i += 2 {
 			nextKind, ok := allowed[loc.Path[i]]

--- a/desc/protoprint/testfiles/test-non-files-full.txt
+++ b/desc/protoprint/testfiles/test-non-files-full.txt
@@ -23,14 +23,14 @@ import "desc_test_options.proto";
 
 // We need a request for our RPC service below.
 message /* detached message name */ /* request with a capital R */ Request /* trailer */ {
-  option deprecated = true;
+  option deprecated = true; // deprecated!
 
   // A field comment
   repeated int32 ids = /* detached tag */ /* tag numero uno */ 1 /*
        * tag trailer
        * that spans multiple lines...
        * more than two.
-       */ [packed = true, json_name = "|foo|", (testprotos.ffubar) = "abc", (testprotos.ffubarb) = "xyz"]; // field trailer #1...
+       */ [packed = true /* packed! */, json_name = "|foo|" /* custom JSON! */, (testprotos.ffubar) = "abc", (testprotos.ffubarb) = "xyz"]; // field trailer #1...
 
   // lead mfubar
   option (testprotos.mfubar) = true; // trailing mfubar
@@ -53,6 +53,7 @@ message /* detached message name */ /* request with a capital R */ Request /* tr
   reserved "foo", "bar", "baz";
 
   optional group Extras = 3 {
+    // this is a custom option
     option (testprotos.mfubar) = false;
 
     optional double dbl = 1;
@@ -66,6 +67,7 @@ message /* detached message name */ /* request with a capital R */ Request /* tr
   }
 
   enum MarioCharacters /* "super"! */ {
+    // allow_alias comments!
     option allow_alias = true;
 
     MARIO = 1 [(testprotos.evfubars) = -314, (testprotos.evfubar) = 278];
@@ -109,7 +111,7 @@ extend /* extendee comment */ Request {
 service /* service name */ RpcService {
   option (testprotos.sfubar) = { id:100 name:"bob" };
 
-  option deprecated = false;
+  option deprecated = false; // DEPRECATED!
 
   option (testprotos.sfubare) = VALUE;
 
@@ -131,14 +133,14 @@ service /* service name */ RpcService {
 
 // We need a request for our RPC service below.
 message /* detached message name */ /* request with a capital R */ Request /* trailer */ {
-  option deprecated = true;
+  option deprecated = true; // deprecated!
 
   // A field comment
   repeated int32 ids = /* detached tag */ /* tag numero uno */ 1 /*
        * tag trailer
        * that spans multiple lines...
        * more than two.
-       */ [packed = true, json_name = "|foo|", (testprotos.ffubar) = "abc", (testprotos.ffubarb) = "xyz"]; // field trailer #1...
+       */ [packed = true /* packed! */, json_name = "|foo|" /* custom JSON! */, (testprotos.ffubar) = "abc", (testprotos.ffubarb) = "xyz"]; // field trailer #1...
 
   // lead mfubar
   option (testprotos.mfubar) = true; // trailing mfubar
@@ -161,6 +163,7 @@ message /* detached message name */ /* request with a capital R */ Request /* tr
   reserved "foo", "bar", "baz";
 
   optional group Extras = 3 {
+    // this is a custom option
     option (testprotos.mfubar) = false;
 
     optional double dbl = 1;
@@ -174,6 +177,7 @@ message /* detached message name */ /* request with a capital R */ Request /* tr
   }
 
   enum MarioCharacters /* "super"! */ {
+    // allow_alias comments!
     option allow_alias = true;
 
     MARIO = 1 [(testprotos.evfubars) = -314, (testprotos.evfubar) = 278];
@@ -210,7 +214,7 @@ repeated int32 ids = /* detached tag */ /* tag numero uno */ 1 /*
      * tag trailer
      * that spans multiple lines...
      * more than two.
-     */ [packed = true, json_name = "|foo|", (testprotos.ffubar) = "abc", (testprotos.ffubarb) = "xyz"]; // field trailer #1...
+     */ [packed = true /* packed! */, json_name = "|foo|" /* custom JSON! */, (testprotos.ffubar) = "abc", (testprotos.ffubarb) = "xyz"]; // field trailer #1...
 -------- foo.bar.Request.name (*desc.FieldDescriptor) --------
 // some detached comments
 
@@ -222,6 +226,7 @@ repeated int32 ids = /* detached tag */ /* tag numero uno */ 1 /*
 optional /* type comment */ string /* name comment */ name = 2 [/* default lead */ default = "fubar" /* default trail */];
 -------- foo.bar.Request.extras (*desc.FieldDescriptor) --------
 optional group Extras = 3 {
+  // this is a custom option
   option (testprotos.mfubar) = false;
 
   optional double dbl = 1;
@@ -235,6 +240,7 @@ optional group Extras = 3 {
 }
 -------- foo.bar.Request.Extras (*desc.MessageDescriptor) --------
 message /* group name */ Extras {
+  // this is a custom option
   option (testprotos.mfubar) = false;
 
   optional double dbl = 1;
@@ -255,6 +261,7 @@ optional float flt = 2;
 optional string str = 3; // Trailing comment...
 -------- foo.bar.Request.MarioCharacters (*desc.EnumDescriptor) --------
 enum MarioCharacters /* "super"! */ {
+  // allow_alias comments!
   option allow_alias = true;
 
   MARIO = 1 [(testprotos.evfubars) = -314, (testprotos.evfubar) = 278];
@@ -320,7 +327,7 @@ extend Request {
 service /* service name */ RpcService {
   option (testprotos.sfubar) = { id:100 name:"bob" };
 
-  option deprecated = false;
+  option deprecated = false; // DEPRECATED!
 
   option (testprotos.sfubare) = VALUE;
 

--- a/desc/protoprint/testfiles/test-preserve-comments.proto
+++ b/desc/protoprint/testfiles/test-preserve-comments.proto
@@ -22,14 +22,14 @@ import "desc_test_options.proto";
 
 // We need a request for our RPC service below.
 message /* detached message name */ /* request with a capital R */ Request /* trailer */ {
-  option deprecated = true;
+  option deprecated = true; // deprecated!
 
   // A field comment
   repeated int32 ids = /* detached tag */ /* tag numero uno */ 1 /*
        * tag trailer
        * that spans multiple lines...
        * more than two.
-       */ [packed = true, json_name = "|foo|", (testprotos.ffubar) = "abc", (testprotos.ffubarb) = "xyz"]; // field trailer #1...
+       */ [packed = true /* packed! */, json_name = "|foo|" /* custom JSON! */, (testprotos.ffubar) = "abc", (testprotos.ffubarb) = "xyz"]; // field trailer #1...
 
   // lead mfubar
   option (testprotos.mfubar) = true; // trailing mfubar
@@ -52,6 +52,7 @@ message /* detached message name */ /* request with a capital R */ Request /* tr
   reserved "foo", "bar", "baz";
 
   optional group Extras = 3 {
+    // this is a custom option
     option (testprotos.mfubar) = false;
 
     optional double dbl = 1;
@@ -65,6 +66,7 @@ message /* detached message name */ /* request with a capital R */ Request /* tr
   }
 
   enum MarioCharacters /* "super"! */ {
+    // allow_alias comments!
     option allow_alias = true;
 
     MARIO = 1 [(testprotos.evfubars) = -314, (testprotos.evfubar) = 278];
@@ -108,7 +110,7 @@ extend /* extendee comment */ Request {
 service /* service name */ RpcService {
   option (testprotos.sfubar) = { id:100 name:"bob" };
 
-  option deprecated = false;
+  option deprecated = false; // DEPRECATED!
 
   option (testprotos.sfubare) = VALUE;
 

--- a/internal/testprotos/desc_test_comments.proto
+++ b/internal/testprotos/desc_test_comments.proto
@@ -23,13 +23,13 @@ import "desc_test_options.proto";
 
 // We need a request for our RPC service below.
 message /* detached message name */ /* request with a capital R */ Request // trailer
-{	option deprecated = true;
+{	option deprecated = true; // deprecated!
 
 	// A field comment
 	repeated int32 ids = /* detached tag */ /* tag numero uno */ 1 /* tag trailer
 		that spans multiple lines...
 		more than two. */
-	  [packed=true, json_name="|foo|", (testprotos.ffubar)="abc", (testprotos.ffubarb)="xyz"];
+	  [packed=true /* packed! */, json_name="|foo|" /* custom JSON! */, (testprotos.ffubar)="abc", (testprotos.ffubarb)="xyz"];
 	// field trailer #1...
 
 	/* lead mfubar */ option (testprotos.mfubar) = true; // trailing mfubar
@@ -53,6 +53,7 @@ message /* detached message name */ /* request with a capital R */ Request // tr
 
 	// Group comment
 	optional group /* group name */ Extras = 3 {
+		// this is a custom option
 		option (testprotos.mfubar) = false;
 
 		optional double dbl = 1;
@@ -67,6 +68,7 @@ message /* detached message name */ /* request with a capital R */ Request // tr
 
 	enum MarioCharacters // "super"!
 	{
+		// allow_alias comments!
 		option allow_alias = true;
 
 		MARIO = 1 [(testprotos.evfubars) = -314, (testprotos.evfubar) = 278];
@@ -101,9 +103,11 @@ Request {
 
 // Service comment
 service /* service name */ RpcService {
+	// option that sets field
 	option(testprotos.sfubar).id= 100;
+	// another option that sets field
 	option(testprotos.sfubar).name= "bob";
-	option deprecated = false;
+	option deprecated = false; // DEPRECATED!
 
 	option (testprotos.sfubare) = VALUE;
 


### PR DESCRIPTION
Fixes #230 

When validating enums, the code was _removing_ `allow_alias` from the set of uninterpreted options, even though we still need it there for subsequent link step.

The repro case also demonstrated another issue: short options (like for fields and enum values) that had a boolean value would lose trailing comments. This was just a bug in how the AST was assembled -- it was not correctly preserving comment info from the original `true` token returned by the lexer.

After fixing that, some extra option comments I added to the test file then exposed another issue in the `protoprint` package: non-deterministic output if there were multiple applicable source locations for a printed option.