### PR TITLE
fix panic in binary decoding when skipping over data that has invalid length prefix

### DIFF
--- a/dynamic/binary.go
+++ b/dynamic/binary.go
@@ -690,11 +690,18 @@ func skipGroup(b *codedBuffer) (int, int, error) {
 				}
 				i++
 			}
-			b.index = i + 1
+			// TODO: This would only overflow if buffer length was MaxInt and we
+			// read the last byte. This is not a real/feasible concern on 64-bit
+			// systems. Something to worry about for 32-bit systems? Do we care?
+			b.index++
 		case proto.WireBytes:
 			l, err := b.decodeVarint()
 			if err != nil {
 				return 0, 0, err
+			}
+			lInt := int(l)
+			if lInt < 0 {
+				return 0, 0, fmt.Errorf("proto: bad byte length %d", lInt)
 			}
 			if !b.skip(int(l)) {
 				return 0, 0, io.ErrUnexpectedEOF

--- a/dynamic/codec.go
+++ b/dynamic/codec.go
@@ -36,7 +36,7 @@ func (cb *codedBuffer) eof() bool {
 
 func (cb *codedBuffer) skip(count int) bool {
 	newIndex := cb.index + count
-	if newIndex > len(cb.buf) {
+	if newIndex < cb.index || newIndex > len(cb.buf) {
 		return false
 	}
 	cb.index = newIndex
@@ -258,13 +258,13 @@ func (cb *codedBuffer) decodeRawBytes(alloc bool) (buf []byte, err error) {
 
 	if !alloc {
 		buf = cb.buf[cb.index:end]
-		cb.index += nb
+		cb.index = end
 		return
 	}
 
 	buf = make([]byte, nb)
 	copy(buf, cb.buf[cb.index:])
-	cb.index += nb
+	cb.index = end
 	return
 }
 


### PR DESCRIPTION
Fixes #233