### PR TITLE
don't touch shared 'standard import' descriptors in parser

### DIFF
--- a/desc/protoparse/linker.go
+++ b/desc/protoparse/linker.go
@@ -54,6 +54,10 @@ func (l *linker) linkFiles() (map[string]*desc.FileDescriptor, error) {
 	// Now that we have linked descriptors, we can interpret any uninterpreted
 	// options that remain.
 	for _, r := range l.files {
+		if r.isShared {
+			// shared descriptors are already linked
+			continue
+		}
 		fd := linked[r.fd.GetName()]
 		if err := interpretFileOptions(r, richFileDescriptorish{FileDescriptor: fd}); err != nil {
 			return nil, err
@@ -224,6 +228,10 @@ func descriptorType(m proto.Message) string {
 func (l *linker) resolveReferences() error {
 	l.extensions = map[string]map[int32]string{}
 	for _, r := range l.files {
+		if r.isShared {
+			// shared descriptors are already resolved
+			continue
+		}
 		fd := r.fd
 		prefix := fd.GetPackage()
 		scopes := []scope{fileScope(fd, l)}


### PR DESCRIPTION
Fixes #236 

The `protoparse` package maintains a map of "standard imports" (so that user does not need to supply proto source for `google/protobuf/*.proto` files, same ones that ship with `protoc`).

But there are steps after parsing that try to modify the descriptor protos. These end up causing data races if multiple goroutines are parsing at the same time and making use of these standard imports, since they are not protected by any mutex.

This solution just avoids all mutations to shared protos -- they don't _need_ to be modified since they have already been fully linked/resolved. (A possibly safer approach is to just clone them for every parse, but that is much less efficient. So we'll see if we can nip all the races in the bud w/ this change instead.)