### PR TITLE
clone standard imports to avoid sharing

### DIFF
--- a/desc/protoparse/parser.go
+++ b/desc/protoparse/parser.go
@@ -385,7 +385,10 @@ func parseProtoFiles(acc FileAccessor, filenames []string, recursive, validate b
 			}
 		} else if d, ok := standardImports[name]; ok {
 			// it's a well-known import
-			parsed[name] = &parseResult{fd: d}
+			// (we clone it to make sure we're not sharing state with other
+			//  parsers, which could result in unsafe races if multiple
+			//  parsers are trying to access it concurrently)
+			parsed[name] = &parseResult{fd: proto.Clone(d).(*dpb.FileDescriptorProto)}
 		} else {
 			return err
 		}

--- a/desc/protoparse/std_imports_test.go
+++ b/desc/protoparse/std_imports_test.go
@@ -3,16 +3,18 @@ package protoparse
 import (
 	"testing"
 
+	"github.com/golang/protobuf/proto"
+
 	"github.com/jhump/protoreflect/internal/testutil"
 )
 
 func TestStdImports(t *testing.T) {
 	// make sure we can successfully parse all standard imports
 	var p Parser
-	for name, proto := range standardImports {
+	for name, fileProto := range standardImports {
 		fds, err := p.ParseFiles(name)
 		testutil.Ok(t, err)
 		testutil.Eq(t, 1, len(fds))
-		testutil.Eq(t, proto, fds[0].AsFileDescriptorProto())
+		testutil.Require(t, proto.Equal(fileProto, fds[0].AsFileDescriptorProto()))
 	}
 }


### PR DESCRIPTION
Fixes #236 

This approach is an alternative to #237. This approach is much safer -- by cloning the object, we can't be sharing state, so no future data races can pop up. The down-side is that it is less efficient since it must make copies of data structures for every parser.