### PR TITLE
add CreateFileDescriptorsFromSet

### DIFF
--- a/desc/imports.go
+++ b/desc/imports.go
@@ -292,6 +292,13 @@ func (r *ImportResolver) CreateFileDescriptorFromSet(fds *dpb.FileDescriptorSet)
 	return createFileDescriptorFromSet(fds, r)
 }
 
+// CreateFileDescriptorsFromSet is the same as the package function of the same
+// name, but any alternate paths configured in this resolver are used when
+// linking the descriptor protos in the given set.
+func (r *ImportResolver) CreateFileDescriptorsFromSet(fds *dpb.FileDescriptorSet) (map[string]*FileDescriptor, error) {
+	return createFileDescriptorsFromSet(fds, r)
+}
+
 const dotPrefix = "." + string(filepath.Separator)
 
 func clean(path string) string {


### PR DESCRIPTION
This was a strange omission in the API. The one that was present, that just returns a single descriptor, is a special case, when the descriptor set only contains one file plus its transitive closure. But descriptor sets often contain multiple files.

Admittedly this is just short-hand for using `CreateFileDescriptors` and passing `fileSet.GetFile()` to it. But, for someone perusing the API, this entry point is more obvious/intuitive _how_ to convert a file descriptor set into descriptors.