### PR TITLE
protoparse: nil decls could also mean empty message body

### DIFF
--- a/desc/protoparse/source_code_info.go
+++ b/desc/protoparse/source_code_info.go
@@ -112,8 +112,7 @@ func (r *parseResult) generateSourceCodeInfoForMessage(sci *sourceCodeInfo, n ms
 		decls = n.decls
 	case *groupNode:
 		decls = n.decls
-	}
-	if decls == nil {
+	case *mapFieldNode:
 		// map entry so nothing else to do
 		return
 	}


### PR DESCRIPTION
Fixes #245 

The message name was absent from source code info if the message had an empty body. Oops.