### PR TITLE
protoparse: use nil instead of empty slice for uninterpreted options

### DIFF
--- a/desc/protoparse/parser.go
+++ b/desc/protoparse/parser.go
@@ -626,6 +626,9 @@ func (r *parseResult) createFileDescriptor(filename string, file *fileNode) erro
 }
 
 func (r *parseResult) asUninterpretedOptions(nodes []*optionNode) []*dpb.UninterpretedOption {
+	if len(nodes) == 0 {
+		return nil
+	}
 	opts := make([]*dpb.UninterpretedOption, len(nodes))
 	for i, n := range nodes {
 		opts[i] = r.asUninterpretedOption(n)


### PR DESCRIPTION
Fixes #252 