### PR TITLE
Return an ErrorWithSourcePos if the FileAccessor cannot resolve a path

### DIFF
--- a/desc/protoparse/linker_test.go
+++ b/desc/protoparse/linker_test.go
@@ -72,7 +72,7 @@ func TestLinkerValidation(t *testing.T) {
 			map[string]string{
 				"foo.proto": "import \"foo2.proto\"; message fubar{}",
 			},
-			"failed to load imports for \"foo.proto\": file not found: foo2.proto",
+			"foo.proto: failed to load imports: file not found: foo2.proto",
 		},
 		{
 			map[string]string{

--- a/desc/protoparse/parser.go
+++ b/desc/protoparse/parser.go
@@ -400,7 +400,10 @@ func parseProtoFiles(acc FileAccessor, filenames []string, recursive, validate b
 				case ErrorWithSourcePos:
 					return err
 				default:
-					return fmt.Errorf("failed to load imports for %q: %s", name, err)
+					return ErrorWithSourcePos{
+						Pos:        unknownPos(name),
+						Underlying: fmt.Errorf("failed to load imports: %v", err),
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This allows one to deduce what file the error happened in. Optimally this could have the import location attached to the `SourcePos`, however `SourceCodeInfos` are not computed at this point.