### PR TITLE
Fix go.mod for Go 1.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,10 @@
 module github.com/jhump/protoreflect
 
 require (
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
 	github.com/golang/protobuf v1.3.1
 	golang.org/x/net v0.0.0-20180530234432-1e491301e022
 	golang.org/x/text v0.3.0 // indirect
-	google.golang.org/genproto v0.0.0-20170818100345-ee236bd376b0
+	google.golang.org/genproto v0.0.0-20170818010345-ee236bd376b0
 	google.golang.org/grpc v1.8.0
 )

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/jhump/protoreflect
 
 require (
-	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
 	github.com/golang/protobuf v1.3.1
 	golang.org/x/net v0.0.0-20180530234432-1e491301e022
 	golang.org/x/text v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
-github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 golang.org/x/net v0.0.0-20180530234432-1e491301e022 h1:MVYFTUmVD3/+ERcvRRI+P/C2+WOUimXh+Pd8LVsklZ4=

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,12 @@
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 golang.org/x/net v0.0.0-20180530234432-1e491301e022 h1:MVYFTUmVD3/+ERcvRRI+P/C2+WOUimXh+Pd8LVsklZ4=
 golang.org/x/net v0.0.0-20180530234432-1e491301e022/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-google.golang.org/genproto v0.0.0-20170818100345-ee236bd376b0 h1:jgaHBfsPDMBDKsth1hPtI1HcOyecWndWOFSGW21VgaM=
-google.golang.org/genproto v0.0.0-20170818100345-ee236bd376b0/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
+google.golang.org/genproto v0.0.0-20170818010345-ee236bd376b0 h1:ZvI3lsq5AIkr7axxmT3tfwFlJVRFLqe6Fp0W03+MJ38=
+google.golang.org/genproto v0.0.0-20170818010345-ee236bd376b0/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/grpc v1.8.0 h1:HN69LlNA/SpyBIRxTfuU0QOntYfdeEeBWlVhRHRCOyw=
 google.golang.org/grpc v1.8.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=


### PR DESCRIPTION
This PR fixes the timestamp in dependency version.

I’ve also pinned `github.com/golang/glog` module version (that’s what `go mod tidy` does anyway).

---

The `go.mod` in this project does not work with `go1.13` (checked out at https://github.com/golang/go/commit/2d6ee6e89a). The project depends on `google.golang.org/genproto@v0.0.0-20170818`**`10`**`0345-ee236bd376b0`, but the timestamp is invalid. It should be `20170818`**`01`**`0345` instead. See https://github.com/googleapis/go-genproto/commit/ee236bd376b077c7a89f260c026c4735b195e459

Steps to reproduce:

```
# Check our Go version.
% go version
go version go1.13-2d6ee6e89a darwin/amd64

# Clean local module cache.
% go clean -modcache

# Don’t use the modules proxy.
% go env -w GOPROXY=direct

% go mod tidy
go: google.golang.org/genproto@v0.0.0-20170818100345-ee236bd376b0: invalid pseudo-version: does not match version-control timestamp (2017-08-18T01:03:45Z)
```

Note that the those steps won’t cause an error with go1.12. Running `go1.13 mod tidy` after `go1.12 mod tidy` succeeds, so we have to clean the mod cache. Moreover, the [broken] module version is cached in the default `GOPROXY=https://proxy.golang.org` so we have to disable that too.