### PR TITLE
Disable GOPROXY for gotip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ matrix:
     - go: "1.12"
       env: GO111MODULE=on
     - go: tip
+      env:
+      - GOPROXY=direct
+      - GOSUMDB=off
 
 # accomodate forks
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ matrix:
     - go: tip
       env:
       - GOPROXY=direct
-      - GOSUMDB=off
 
 # accomodate forks
 before_install:


### PR DESCRIPTION
This PR ensures that issue like #258 would fail at CI stage by disabling GOPROXY for gotip (Go 1.13).