### PR TITLE
Add GetUnderlying function to ErrorWithPos

### DIFF
--- a/desc/protoparse/error_reporting_test.go
+++ b/desc/protoparse/error_reporting_test.go
@@ -190,7 +190,10 @@ func TestErrorReporting(t *testing.T) {
 		testutil.Eq(t, len(tc.expectedErrs), count, "case #%d: parse should have called reporter %d times", i+1, len(tc.expectedErrs))
 		testutil.Eq(t, len(tc.expectedErrs), len(reported), "case #%d: wrong number of errors reported", i+1)
 		for j := range tc.expectedErrs {
-			testutil.Require(t, strings.Contains(reported[j].Error(), tc.expectedErrs[j]), "case #%d: parse error[%d] have %q; instead got %q", i+1, j, tc.expectedErrs[j], reported[j].Error())
+			testutil.Eq(t, tc.expectedErrs[j], reported[j].Error(), "case #%d: parse error[%d] have %q; instead got %q", i+1, j, tc.expectedErrs[j], reported[j].Error())
+			split := strings.SplitN(tc.expectedErrs[j], ":", 4)
+			testutil.Eq(t, 4, len(split), "case #%d: expected %q [%d] to contain at least 4 elements split by :", i+1, tc.expectedErrs[j], j)
+			testutil.Eq(t, split[3], " "+reported[j].GetUnderlying().Error(), "case #%d: parse error underlying[%d] have %q; instead got %q", i+1, j, split[3], reported[j].GetUnderlying().Error())
 		}
 
 		count = 0

--- a/desc/protoparse/errors.go
+++ b/desc/protoparse/errors.go
@@ -58,9 +58,12 @@ func (h *errorHandler) getError() error {
 
 // ErrorWithPos is an error about a proto source file that includes information
 // about the location in the file that caused the error.
+//
+// The value of Error() will contain both the SourcePos and Underlying error.
 type ErrorWithPos interface {
 	error
 	GetPosition() SourcePos
+	GetUnderlying() error
 }
 
 // ErrorWithSourcePos is an error about a proto source file that includes
@@ -88,6 +91,12 @@ func (e ErrorWithSourcePos) Error() string {
 // proto source that caused the error.
 func (e ErrorWithSourcePos) GetPosition() SourcePos {
 	return *e.Pos
+}
+
+// GetUnderlying implements the ErrorWithPos interface, supplying the
+// underlying error. This error will not include location information.
+func (e ErrorWithSourcePos) GetUnderlying() error {
+	return e.Underlying
 }
 
 var _ ErrorWithPos = ErrorWithSourcePos{}


### PR DESCRIPTION
I need access to the underlying error without any source information, this exposes it. Everything works if you just add the function, I added specific tests cases as well though.

This effectively makes ErrorWithPos equal to the old ErrorWithSourcePos in terms of what it exposes, but as an interface.