### PR TITLE
Change ErrorWithPos.GetUnderlying to ErrorWithPos.Unwrap

### DIFF
--- a/desc/protoparse/error_reporting_test.go
+++ b/desc/protoparse/error_reporting_test.go
@@ -193,7 +193,7 @@ func TestErrorReporting(t *testing.T) {
 			testutil.Eq(t, tc.expectedErrs[j], reported[j].Error(), "case #%d: parse error[%d] have %q; instead got %q", i+1, j, tc.expectedErrs[j], reported[j].Error())
 			split := strings.SplitN(tc.expectedErrs[j], ":", 4)
 			testutil.Eq(t, 4, len(split), "case #%d: expected %q [%d] to contain at least 4 elements split by :", i+1, tc.expectedErrs[j], j)
-			testutil.Eq(t, split[3], " "+reported[j].GetUnderlying().Error(), "case #%d: parse error underlying[%d] have %q; instead got %q", i+1, j, split[3], reported[j].GetUnderlying().Error())
+			testutil.Eq(t, split[3], " "+reported[j].Unwrap().Error(), "case #%d: parse error underlying[%d] have %q; instead got %q", i+1, j, split[3], reported[j].Unwrap().Error())
 		}
 
 		count = 0

--- a/desc/protoparse/errors.go
+++ b/desc/protoparse/errors.go
@@ -60,10 +60,11 @@ func (h *errorHandler) getError() error {
 // about the location in the file that caused the error.
 //
 // The value of Error() will contain both the SourcePos and Underlying error.
+// The value of Unwrap() will only be the Underlying error.
 type ErrorWithPos interface {
 	error
 	GetPosition() SourcePos
-	GetUnderlying() error
+	Unwrap() error
 }
 
 // ErrorWithSourcePos is an error about a proto source file that includes
@@ -93,9 +94,9 @@ func (e ErrorWithSourcePos) GetPosition() SourcePos {
 	return *e.Pos
 }
 
-// GetUnderlying implements the ErrorWithPos interface, supplying the
-// underlying error. This error will not include location information.
-func (e ErrorWithSourcePos) GetUnderlying() error {
+// Unwrap implements the ErrorWithPos interface, supplying the underlying
+// error. This error will not include location information.
+func (e ErrorWithSourcePos) Unwrap() error {
 	return e.Underlying
 }
 


### PR DESCRIPTION
Re: https://github.com/jhump/protoreflect/pull/260