### PR TITLE
codec: fix code to work without XXX_Marshal

### DIFF
--- a/codec/encode.go
+++ b/codec/encode.go
@@ -103,7 +103,7 @@ func (cb *Buffer) EncodeDelimitedMessage(pm proto.Message) error {
 func marshalMessage(b []byte, pm proto.Message, deterministic bool) ([]byte, error) {
 	// we try to use the most efficient way to marshal to existing slice
 	nm, ok := pm.(interface {
-		// this interface is implemented by generated messages
+		// this interface is implemented by generated messages before api-v2
 		XXX_Size() int
 		XXX_Marshal(b []byte, deterministic bool) ([]byte, error)
 	})
@@ -141,6 +141,17 @@ func marshalMessage(b []byte, pm proto.Message, deterministic bool) ([]byte, err
 			}
 			return append(b, bytes...), nil
 		}
+
+		var buf proto.Buffer
+		buf.SetDeterministic(true)
+		if err := buf.Marshal(pm); err != nil {
+			return nil, err
+		}
+		bytes := buf.Bytes()
+		if len(b) == 0 {
+			return bytes, nil
+		}
+		return append(b, bytes...), nil
 	}
 
 	mam, ok := pm.(interface {

--- a/codec/encode_test.go
+++ b/codec/encode_test.go
@@ -1,11 +1,11 @@
 package codec_test
 
 import (
-	"github.com/jhump/protoreflect/codec"
 	"testing"
 
 	"github.com/golang/protobuf/proto"
 
+	"github.com/jhump/protoreflect/codec"
 	"github.com/jhump/protoreflect/desc"
 	"github.com/jhump/protoreflect/dynamic"
 	"github.com/jhump/protoreflect/internal/testprotos"

--- a/dynamic/binary_test.go
+++ b/dynamic/binary_test.go
@@ -176,6 +176,13 @@ func binaryTranslationParty(t *testing.T, msg proto.Message, includesNaN bool) {
 				bb := make([]byte, 0, mm.XXX_Size())
 				return mm.XXX_Marshal(bb, true)
 			}
+
+			var buf proto.Buffer
+			buf.SetDeterministic(true)
+			if err := buf.Marshal(m); err != nil {
+				return nil, err
+			}
+			return buf.Bytes(), nil
 		}
 		return proto.Marshal(m)
 	}


### PR DESCRIPTION
The existing fallback code path didn’t use deterministic marshaling.

This is required with the protobuf api-v2 branch:
https://github.com/golang/protobuf/tree/api-v2

cc @dsnet