### PR TITLE
protoparse: ResolveFilenames fixes up path separators so it works correctly on Windows

### DIFF
--- a/desc/protoparse/resolve_files.go
+++ b/desc/protoparse/resolve_files.go
@@ -49,6 +49,11 @@ func ResolveFilenames(importPaths []string, fileNames ...string) ([]string, erro
 		if err != nil {
 			return nil, err
 		}
+		// On Windows, the resolved paths will use "\", but proto imports
+		// require the use of "/". So fix up here.
+		if filepath.Separator != '/' {
+			resolvedFileName = strings.Replace(resolvedFileName, string(filepath.Separator), "/", -1)
+		}
 		resolvedFileNames = append(resolvedFileNames, resolvedFileName)
 	}
 	return resolvedFileNames, nil


### PR DESCRIPTION
fixes #254 