### PR TITLE
Use packed encoding if there are any values, not just more than 1

### DIFF
--- a/codec/encode_fields.go
+++ b/codec/encode_fields.go
@@ -65,7 +65,7 @@ func (cb *Buffer) EncodeFieldValue(fd *desc.FieldDescriptor, val interface{}) er
 		if err != nil {
 			return err
 		}
-		if isPacked(fd) && len(sl) > 1 &&
+		if isPacked(fd) && len(sl) > 0 &&
 			(wt == proto.WireVarint || wt == proto.WireFixed32 || wt == proto.WireFixed64) {
 			// packed repeated field
 			var packedBuffer Buffer


### PR DESCRIPTION
I found this via a problem with the JS protoc generated code which doesn't properly decode unpacked enums when the proto definition says the field is packed.

Here's what the protobuf documentation at https://developers.google.com/protocol-buffers/docs/encoding#packed says:

> A packed repeated field containing zero elements does not appear in the encoded message. Otherwise, all of the elements of the field are packed into a single key-value pair with wire type 2 (length-delimited).

Here's an example of the JS error stack when this happened:
```
Error [AssertionError]: Assertion failed
    at new goog.asserts.AssertionError (node_modules/google-protobuf/google-protobuf.js:79:876)
    at Object.goog.asserts.doAssertFailure_ (node_modules/google-protobuf/google-protobuf.js:80:257)
    at Object.goog.asserts.assert [as assert] (node_modules/google-protobuf/google-protobuf.js:81:83)
    at jspb.BinaryReader.readPackedField_ (node_modules/google-protobuf/google-protobuf.js:261:71)
    at jspb.BinaryReader.readPackedEnum (node_modules/google-protobuf/google-protobuf.js:266:287)
```