### PR TITLE
if no json_name attribute present, compute it the same way that protoc does

### DIFF
--- a/desc/descriptor_no_unsafe.go
+++ b/desc/descriptor_no_unsafe.go
@@ -13,12 +13,9 @@ type memoizedDefault struct{}
 func (md *MessageDescriptor) FindFieldByJSONName(jsonName string) *FieldDescriptor {
 	// NB: With allowed use of unsafe, we use it to atomically define an index
 	// via atomic.LoadPointer/atomic.StorePointer. Without it, we skip the index
-	// and do an linear scan of fields each time.
+	// and must do a linear scan of fields each time.
 	for _, f := range md.fields {
-		jn := f.proto.GetJsonName()
-		if jn == "" {
-			jn = f.proto.GetName()
-		}
+		jn := f.GetJSONName()
 		if jn == jsonName {
 			return f
 		}

--- a/desc/descriptor_test.go
+++ b/desc/descriptor_test.go
@@ -1201,3 +1201,22 @@ func TestToFileDescriptorSet(t *testing.T) {
 		testutil.Eq(t, expectedFile.AsFileDescriptorProto(), f)
 	}
 }
+
+func TestJsonCamelCase(t *testing.T) {
+	testCases := map[string]string{
+		// NB: these example keys were all run through protoc and the
+		// values below are the json_name values computed by protoc
+		// (to make sure we correctly mirror protoc behavior)
+		"abc":       "abc",
+		"__def":     "Def",
+		"a_b_":      "aB",
+		"d_e":       "dE",
+		"abc_def":   "abcDef",
+		"c_d_e":     "cDE",
+		"_a_b_c_d":  "ABCD",
+		"a_b_c_d_e": "aBCDE",
+	}
+	for k, v := range testCases {
+		testutil.Eq(t, v, jsonCamelCase(k))
+	}
+}

--- a/desc/descriptor_unsafe.go
+++ b/desc/descriptor_unsafe.go
@@ -34,10 +34,7 @@ func (md *MessageDescriptor) FindFieldByJSONName(jsonName string) *FieldDescript
 		// slow path: compute the index
 		index = map[string]*FieldDescriptor{}
 		for _, f := range md.fields {
-			jn := f.proto.GetJsonName()
-			if jn == "" {
-				jn = f.proto.GetName()
-			}
+			jn := f.GetJSONName()
 			index[jn] = f
 		}
 		atomic.StorePointer(addrOfJsonNames, *(*unsafe.Pointer)(unsafe.Pointer(&index)))


### PR DESCRIPTION
This should resolve https://github.com/fullstorydev/grpcurl/issues/132.

Interestingly, I think the root issue here is the same as/related to https://github.com/protocolbuffers/protobuf/issues/5587.

When `protoc` generates code (vs. a plugin generating code), it _does_ know whether a `json_name` option was explicitly provided. I think this is because the `json_name` field is _not_ populated in the descriptors used for that code-gen step. But when a plugin, on the other hand, is generating the code, the `json_name` option gets filled in on the descriptor that is passed to the plugin.

So I believe that means that the embedded descriptors in the core runtimes (such as C++ and Java) do _not_ have the `json_name` option populated for fields that did not explicitly set the option. When this library (or related libraries/tools, like `grpcurl`) downloads descriptors via the reflection service from a C++ or Java server, it thus can get descriptors with no `json_name` value set.

To make sure things are sane and consistent, instead of defaulting to the proto name in this case (which this code was previously doing), we actually do the same camel-case computation as `protoc` to compute the correct value.

This also fixes an issue where using `[json_name=""]` would not be respected by this library and it would instead use the original proto field name as the JSON name.