### PR TITLE
protoparse should produce deterministic results

### DIFF
--- a/desc/protoparse/options.go
+++ b/desc/protoparse/options.go
@@ -991,7 +991,7 @@ func interpretOptions(res *parseResult, element descriptorish, opts proto.Messag
 		// If we're lenient, then we don't want to clobber the passed in message
 		// and leave it partially populated. So we convert into a copy first
 		optsClone := proto.Clone(opts)
-		if err := dm.ConvertTo(optsClone); err != nil {
+		if err := dm.ConvertToDeterministic(optsClone); err != nil {
 			// TODO: do this in a more granular way, so we can convert individual
 			// fields and leave bad ones uninterpreted instead of skipping all of
 			// the work we've done so far.
@@ -1005,7 +1005,7 @@ func interpretOptions(res *parseResult, element descriptorish, opts proto.Messag
 	} else {
 		// not lenient: try to convert into the passed in message
 		// and fail if not successful
-		if err := dm.ConvertTo(opts); err != nil {
+		if err := dm.ConvertToDeterministic(opts); err != nil {
 			node := res.nodes[element.AsProto()]
 			return nil, ErrorWithSourcePos{Pos: node.start(), Underlying: err}
 		}

--- a/dynamic/maps_1.11.go
+++ b/dynamic/maps_1.11.go
@@ -76,7 +76,7 @@ func canConvertMap(src reflect.Value, target reflect.Type) bool {
 	return true
 }
 
-func mergeMapVal(src, target reflect.Value, targetType reflect.Type) error {
+func mergeMapVal(src, target reflect.Value, targetType reflect.Type, deterministic bool) error {
 	tkt := targetType.Key()
 	tvt := targetType.Elem()
 	for _, k := range src.MapKeys() {
@@ -90,7 +90,7 @@ func mergeMapVal(src, target reflect.Value, targetType reflect.Type) error {
 			nk = k.Addr()
 		} else {
 			nk = reflect.New(tkt).Elem()
-			if err := mergeVal(k, nk); err != nil {
+			if err := mergeVal(k, nk, deterministic); err != nil {
 				return err
 			}
 		}
@@ -100,7 +100,7 @@ func mergeMapVal(src, target reflect.Value, targetType reflect.Type) error {
 			nv = v.Addr()
 		} else {
 			nv = reflect.New(tvt).Elem()
-			if err := mergeVal(v, nv); err != nil {
+			if err := mergeVal(v, nv, deterministic); err != nil {
 				return err
 			}
 		}

--- a/dynamic/maps_1.12.go
+++ b/dynamic/maps_1.12.go
@@ -80,7 +80,7 @@ func canConvertMap(src reflect.Value, target reflect.Type) bool {
 	return true
 }
 
-func mergeMapVal(src, target reflect.Value, targetType reflect.Type) error {
+func mergeMapVal(src, target reflect.Value, targetType reflect.Type, deterministic bool) error {
 	tkt := targetType.Key()
 	tvt := targetType.Elem()
 	iter := src.MapRange()
@@ -96,7 +96,7 @@ func mergeMapVal(src, target reflect.Value, targetType reflect.Type) error {
 			nk = k.Addr()
 		} else {
 			nk = reflect.New(tkt).Elem()
-			if err := mergeVal(k, nk); err != nil {
+			if err := mergeVal(k, nk, deterministic); err != nil {
 				return err
 			}
 		}
@@ -106,7 +106,7 @@ func mergeMapVal(src, target reflect.Value, targetType reflect.Type) error {
 			nv = v.Addr()
 		} else {
 			nv = reflect.New(tvt).Elem()
-			if err := mergeVal(v, nv); err != nil {
+			if err := mergeVal(v, nv, deterministic); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
I _think_ this will resolve #304. Though the caller of `protoparse` will still also need to use deterministic serialization when writing the descriptors to bytes, in case there are recognized extensions or known fields with map types.

@bufdev, is it easy for you to try out this branch?