### PR TITLE
protoparse: add WarningReporter; add warnings for missing syntax

### DIFF
--- a/desc/protoparse/ast.go
+++ b/desc/protoparse/ast.go
@@ -1,5 +1,7 @@
 package protoparse
 
+import "fmt"
+
 // This file defines all of the nodes in the proto AST.
 
 // SourcePos identifies a location in a proto source file.
@@ -7,6 +9,13 @@ type SourcePos struct {
 	Filename  string
 	Line, Col int
 	Offset    int
+}
+
+func (pos SourcePos) String() string {
+	if pos.Line <= 0 || pos.Col <= 0 {
+		return pos.Filename
+	}
+	return fmt.Sprintf("%s:%d:%d", pos.Filename, pos.Line, pos.Col)
 }
 
 func unknownPos(filename string) *SourcePos {

--- a/desc/protoparse/descriptor_protos.go
+++ b/desc/protoparse/descriptor_protos.go
@@ -31,6 +31,8 @@ func (r *parseResult) createFileDescriptor(filename string, file *fileNode) {
 		if isProto3 {
 			fd.Syntax = proto.String(file.syntax.syntax.val)
 		}
+	} else {
+		r.errs.warn(file.start(), "No syntax specified. Defaulting to proto2 syntax.")
 	}
 
 	for _, decl := range file.decls {

--- a/desc/protoparse/descriptor_protos.go
+++ b/desc/protoparse/descriptor_protos.go
@@ -32,7 +32,7 @@ func (r *parseResult) createFileDescriptor(filename string, file *fileNode) {
 			fd.Syntax = proto.String(file.syntax.syntax.val)
 		}
 	} else {
-		r.errs.warn(file.start(), "No syntax specified. Defaulting to proto2 syntax.")
+		r.errs.warn(file.start(), WarnNoSyntax)
 	}
 
 	for _, decl := range file.decls {

--- a/desc/protoparse/descriptor_protos.go
+++ b/desc/protoparse/descriptor_protos.go
@@ -32,7 +32,7 @@ func (r *parseResult) createFileDescriptor(filename string, file *fileNode) {
 			fd.Syntax = proto.String(file.syntax.syntax.val)
 		}
 	} else {
-		r.errs.warn(file.start(), WarnNoSyntax)
+		r.errs.warn(file.start(), ErrNoSyntax)
 	}
 
 	for _, decl := range file.decls {

--- a/desc/protoparse/errors.go
+++ b/desc/protoparse/errors.go
@@ -11,10 +11,10 @@ import (
 // always returns nil.
 var ErrInvalidSource = errors.New("parse failed: invalid proto source")
 
-// WarnNoSyntax is a sentinel error that may be passed to a warning reporter.
+// ErrNoSyntax is a sentinel error that may be passed to a warning reporter.
 // The error the reporter receives will be wrapped with source position that
 // indicates the file that had no syntax statement.
-var WarnNoSyntax = errors.New("no syntax specified; defaulting to proto2 syntax")
+var ErrNoSyntax = errors.New("no syntax specified; defaulting to proto2 syntax")
 
 // ErrorReporter is responsible for reporting the given error. If the reporter
 // returns a non-nil error, parsing/linking will abort with that error. If the

--- a/desc/protoparse/lexer.go
+++ b/desc/protoparse/lexer.go
@@ -60,10 +60,6 @@ type protoLex struct {
 	comments   []comment
 }
 
-func newTestLexer(in io.Reader) *protoLex {
-	return newLexer(in, "test.proto", newErrorHandler(nil))
-}
-
 func newLexer(in io.Reader, filename string, errs *errorHandler) *protoLex {
 	return &protoLex{
 		input:    &runeReader{rr: bufio.NewReader(in)},

--- a/desc/protoparse/lexer_test.go
+++ b/desc/protoparse/lexer_test.go
@@ -1,6 +1,7 @@
 package protoparse
 
 import (
+	"io"
 	"strings"
 	"testing"
 
@@ -222,4 +223,8 @@ func TestLexerErrors(t *testing.T) {
 		testutil.Require(t, sym.err != nil)
 		testutil.Require(t, strings.Contains(sym.err.Error(), tc.errMsg), "case %d: expected message to contain %q but does not: %q", i, tc.errMsg, sym.err.Error())
 	}
+}
+
+func newTestLexer(in io.Reader) *protoLex {
+	return newLexer(in, "test.proto", newErrorHandler(nil, nil))
 }

--- a/desc/protoparse/parser_test.go
+++ b/desc/protoparse/parser_test.go
@@ -161,7 +161,7 @@ func parseFileForTest(filename string) (*parseResult, error) {
 	defer func() {
 		_ = f.Close()
 	}()
-	errs := newErrorHandler(nil)
+	errs := newErrorHandler(nil, nil)
 	res := parseProto(filename, f, errs, true)
 	return res, errs.getError()
 }

--- a/desc/protoparse/reporting_test.go
+++ b/desc/protoparse/reporting_test.go
@@ -228,9 +228,9 @@ func TestWarningReporting(t *testing.T) {
 		text string
 	}
 	var msgs []msg
-	rep := func(pos SourcePos, message string) {
+	rep := func(warn ErrorWithPos) {
 		msgs = append(msgs, msg{
-			pos: pos, text: message,
+			pos: warn.GetPosition(), text: warn.Unwrap().Error(),
 		})
 	}
 
@@ -247,7 +247,7 @@ func TestWarningReporting(t *testing.T) {
 		{
 			source: `message Foo {}`,
 			expectedNotices: []string{
-				"test.proto:1:1: No syntax specified. Defaulting to proto2 syntax.",
+				"test.proto:1:1: no syntax specified; defaulting to proto2 syntax",
 			},
 		},
 	}

--- a/desc/protoparse/validate_test.go
+++ b/desc/protoparse/validate_test.go
@@ -243,7 +243,7 @@ func TestBasicValidation(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		errs := newErrorHandler(nil)
+		errs := newErrorHandler(nil, nil)
 		_ = parseProto("test.proto", strings.NewReader(tc.contents), errs, true)
 		err := errs.getError()
 		if tc.succeeds {


### PR DESCRIPTION
Add `WarningReporter` optional field to `Parser`, for collecting warnings that occur during parse operation.

Adds one actual warning message, for when a file does not have a `syntax` declaration.

TODO: use this mechanism to warn about unused imports.