### PR TITLE
work around the fact that v2 messages don't have an XXX_unrecognized field

### DIFF
--- a/dynamic/dynamic_message.go
+++ b/dynamic/dynamic_message.go
@@ -2328,21 +2328,7 @@ func (m *Message) mergeInto(pm proto.Message, deterministic bool) error {
 			}
 		}
 
-		u := target.FieldByName("XXX_unrecognized")
-		if u.IsValid() && u.Type() == typeOfBytes {
-			// Just store the bytes in the unrecognized field
-			ub := u.Interface().([]byte)
-			ub = append(ub, b.Bytes()...)
-			u.Set(reflect.ValueOf(ub))
-		} else {
-			// This message does not have an XXX_unrecognized in which to store
-			// this data. It could be an API v2 message, which stores unrecognized
-			// fields differently. So, in case that is what this is, let's try to
-			// unmarshal the data into it
-			if err := proto.UnmarshalMerge(b.Bytes(), pm); err != nil {
-				return err
-			}
-		}
+		setUnrecognized(target, b.Bytes())
 	}
 
 	// finally, convey unknown fields into the given message by letting it unmarshal them
@@ -2355,6 +2341,63 @@ func (m *Message) mergeInto(pm proto.Message, deterministic bool) error {
 	}
 
 	return nil
+}
+
+func setUnrecognized(val reflect.Value, data []byte) {
+	u := val.FieldByName("XXX_unrecognized")
+	if u.IsValid() && u.Type() == typeOfBytes {
+		// Just store the bytes in the unrecognized field
+		ub := u.Interface().([]byte)
+		ub = append(ub, data...)
+		u.Set(reflect.ValueOf(ub))
+		return
+	}
+
+	get, set, argType, ok := unrecognizedGetSetMethods(val)
+	if !ok {
+		return
+	}
+
+	existing := get.Call([]reflect.Value(nil))[0].Convert(typeOfBytes).Interface().([]byte)
+	if len(existing) > 0 {
+		data = append(existing, data...)
+	}
+	set.Call([]reflect.Value{reflect.ValueOf(data).Convert(argType)})
+}
+
+func unrecognizedGetSetMethods(val reflect.Value) (get reflect.Value, set reflect.Value, argType reflect.Type, ok bool) {
+	// val could be an APIv2 message. We use reflection to interact with
+	// this message so that we don't have a hard dependency on the new
+	// version of the protobuf package.
+	refMethod := val.MethodByName("ProtoReflect")
+	if !refMethod.IsValid() {
+		if val.CanAddr() {
+			refMethod = val.Addr().MethodByName("ProtoReflect")
+		}
+		if !refMethod.IsValid() {
+			return
+		}
+	}
+	refType := refMethod.Type()
+	if refType.NumIn() != 0 || refType.NumOut() != 1 {
+		return
+	}
+	ref := refMethod.Call([]reflect.Value(nil))
+	getMethod, setMethod := ref[0].MethodByName("GetUnknown"), ref[0].MethodByName("SetUnknown")
+	if !getMethod.IsValid() || !setMethod.IsValid() {
+		return
+	}
+	getType := getMethod.Type()
+	setType := setMethod.Type()
+	if getType.NumIn() != 0 || getType.NumOut() != 1 || setType.NumIn() != 1 || setType.NumOut() != 0 {
+		return
+	}
+	arg := setType.In(0)
+	if !arg.ConvertibleTo(typeOfBytes) || getType.Out(0) != arg {
+		return
+	}
+
+	return getMethod, setMethod, arg, true
 }
 
 func canConvert(src reflect.Value, target reflect.Type) bool {
@@ -2571,13 +2614,15 @@ func (m *Message) mergeFrom(pm proto.Message) error {
 
 	// now actually perform the merge
 	for fd, v := range values {
-		mergeField(m, fd, v)
+		if err := mergeField(m, fd, v); err != nil {
+			return err
+		}
 	}
 
-	u := src.FieldByName("XXX_unrecognized")
-	if u.IsValid() && u.Type() == typeOfBytes {
+	data := getUnrecognized(src)
+	if len(data) > 0 {
 		// ignore any error returned: pulling in unknown fields is best-effort
-		_ = m.UnmarshalMerge(u.Interface().([]byte))
+		_ = m.UnmarshalMerge(data)
 	}
 
 	// lastly, also extract any unknown extensions the message may have (unknown extensions
@@ -2588,6 +2633,20 @@ func (m *Message) mergeFrom(pm proto.Message) error {
 		_ = m.UnmarshalMerge(unknownExtensions)
 	}
 	return nil
+}
+
+func getUnrecognized(val reflect.Value) []byte {
+	u := val.FieldByName("XXX_unrecognized")
+	if u.IsValid() && u.Type() == typeOfBytes {
+		return u.Interface().([]byte)
+	}
+
+	get, _, _, ok := unrecognizedGetSetMethods(val)
+	if !ok {
+		return nil
+	}
+
+	return get.Call([]reflect.Value(nil))[0].Convert(typeOfBytes).Interface().([]byte)
 }
 
 // Validate checks that all required fields are present. It returns an error if any are absent.

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/jhump/protobuf v2.6.1+incompatible h1:45MMYOwWuoSQB+pFVwZuoKix+13fjYaGOJnM4gNdIH4=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/internal/unrecognized.go
+++ b/internal/unrecognized.go
@@ -1,0 +1,86 @@
+package internal
+
+import (
+	"reflect"
+
+	"github.com/golang/protobuf/proto"
+)
+
+var typeOfBytes = reflect.TypeOf([]byte(nil))
+
+// GetUnrecognized fetches the bytes of unrecognized fields for the given message.
+func GetUnrecognized(msg proto.Message) []byte {
+	val := reflect.Indirect(reflect.ValueOf(msg))
+	u := val.FieldByName("XXX_unrecognized")
+	if u.IsValid() && u.Type() == typeOfBytes {
+		return u.Interface().([]byte)
+	}
+
+	// Fallback to reflection for API v2 messages
+	get, _, _, ok := unrecognizedGetSetMethods(val)
+	if !ok {
+		return nil
+	}
+
+	return get.Call([]reflect.Value(nil))[0].Convert(typeOfBytes).Interface().([]byte)
+}
+
+// SetUnrecognized adds the given bytes to the unrecognized fields for the given message.
+func SetUnrecognized(msg proto.Message, data []byte) {
+	val := reflect.Indirect(reflect.ValueOf(msg))
+	u := val.FieldByName("XXX_unrecognized")
+	if u.IsValid() && u.Type() == typeOfBytes {
+		// Just store the bytes in the unrecognized field
+		ub := u.Interface().([]byte)
+		ub = append(ub, data...)
+		u.Set(reflect.ValueOf(ub))
+		return
+	}
+
+	// Fallback to reflection for API v2 messages
+	get, set, argType, ok := unrecognizedGetSetMethods(val)
+	if !ok {
+		return
+	}
+
+	existing := get.Call([]reflect.Value(nil))[0].Convert(typeOfBytes).Interface().([]byte)
+	if len(existing) > 0 {
+		data = append(existing, data...)
+	}
+	set.Call([]reflect.Value{reflect.ValueOf(data).Convert(argType)})
+}
+
+func unrecognizedGetSetMethods(val reflect.Value) (get reflect.Value, set reflect.Value, argType reflect.Type, ok bool) {
+	// val could be an APIv2 message. We use reflection to interact with
+	// this message so that we don't have a hard dependency on the new
+	// version of the protobuf package.
+	refMethod := val.MethodByName("ProtoReflect")
+	if !refMethod.IsValid() {
+		if val.CanAddr() {
+			refMethod = val.Addr().MethodByName("ProtoReflect")
+		}
+		if !refMethod.IsValid() {
+			return
+		}
+	}
+	refType := refMethod.Type()
+	if refType.NumIn() != 0 || refType.NumOut() != 1 {
+		return
+	}
+	ref := refMethod.Call([]reflect.Value(nil))
+	getMethod, setMethod := ref[0].MethodByName("GetUnknown"), ref[0].MethodByName("SetUnknown")
+	if !getMethod.IsValid() || !setMethod.IsValid() {
+		return
+	}
+	getType := getMethod.Type()
+	setType := setMethod.Type()
+	if getType.NumIn() != 0 || getType.NumOut() != 1 || setType.NumIn() != 1 || setType.NumOut() != 0 {
+		return
+	}
+	arg := setType.In(0)
+	if !arg.ConvertibleTo(typeOfBytes) || getType.Out(0) != arg {
+		return
+	}
+
+	return getMethod, setMethod, arg, true
+}


### PR DESCRIPTION
When converting a `*dynamic.Message` into a generated message, we could drop some fields if the generated message does not have an `XXX_unrecognized` field.

This fixes that so, if the target message has no such field, it will use reflection to try get/set unrecognized bytes using the new APIv2 mechanism.