### PR TITLE
Handle if Pos is nil on ErrorWithSourcePos

### DIFF
--- a/desc/protoparse/errors.go
+++ b/desc/protoparse/errors.go
@@ -92,15 +92,26 @@ type ErrorWithSourcePos struct {
 
 // Error implements the error interface
 func (e ErrorWithSourcePos) Error() string {
-	if e.Pos.Line <= 0 || e.Pos.Col <= 0 {
-		return fmt.Sprintf("%s: %v", e.Pos.Filename, e.Underlying)
+	filename := "<input>"
+	line := 0
+	col := 0
+	if e.Pos != nil {
+		filename = e.Pos.Filename
+		line = e.Pos.Line
+		col = e.Pos.Col
 	}
-	return fmt.Sprintf("%s:%d:%d: %v", e.Pos.Filename, e.Pos.Line, e.Pos.Col, e.Underlying)
+	if line <= 0 || col <= 0 {
+		return fmt.Sprintf("%s: %v", filename, e.Underlying)
+	}
+	return fmt.Sprintf("%s:%d:%d: %v", filename, line, col, e.Underlying)
 }
 
 // GetPosition implements the ErrorWithPos interface, supplying a location in
 // proto source that caused the error.
 func (e ErrorWithSourcePos) GetPosition() SourcePos {
+	if e.Pos == nil {
+		return SourcePos{}
+	}
 	return *e.Pos
 }
 

--- a/desc/protoparse/errors.go
+++ b/desc/protoparse/errors.go
@@ -92,25 +92,21 @@ type ErrorWithSourcePos struct {
 
 // Error implements the error interface
 func (e ErrorWithSourcePos) Error() string {
-	filename := "<input>"
-	line := 0
-	col := 0
-	if e.Pos != nil {
-		filename = e.Pos.Filename
-		line = e.Pos.Line
-		col = e.Pos.Col
+	sourcePos := e.GetPosition()
+	if sourcePos.Line <= 0 || sourcePos.Col <= 0 {
+		return fmt.Sprintf("%s: %v", sourcePos.Filename, e.Underlying)
 	}
-	if line <= 0 || col <= 0 {
-		return fmt.Sprintf("%s: %v", filename, e.Underlying)
-	}
-	return fmt.Sprintf("%s:%d:%d: %v", filename, line, col, e.Underlying)
+	return fmt.Sprintf("%s:%d:%d: %v", sourcePos.Filename, sourcePos.Line, sourcePos.Col, e.Underlying)
 }
 
 // GetPosition implements the ErrorWithPos interface, supplying a location in
 // proto source that caused the error.
+//
+// If there is no underlying SourcePos, a new SourcePost with "<input>" as the
+// filename will be returned.
 func (e ErrorWithSourcePos) GetPosition() SourcePos {
 	if e.Pos == nil {
-		return SourcePos{}
+		return SourcePos{Filename: "<input>"}
 	}
 	return *e.Pos
 }

--- a/desc/protoparse/errors.go
+++ b/desc/protoparse/errors.go
@@ -85,6 +85,8 @@ type ErrorWithPos interface {
 // should instead look for instances of the ErrorWithPos interface, which
 // will find other kinds of errors. This type is only exported for backwards
 // compatibility.
+//
+// SourcePos should always be set and never nil.
 type ErrorWithSourcePos struct {
 	Underlying error
 	Pos        *SourcePos
@@ -101,9 +103,6 @@ func (e ErrorWithSourcePos) Error() string {
 
 // GetPosition implements the ErrorWithPos interface, supplying a location in
 // proto source that caused the error.
-//
-// If there is no underlying SourcePos, a new SourcePost with "<input>" as the
-// filename will be returned.
 func (e ErrorWithSourcePos) GetPosition() SourcePos {
 	if e.Pos == nil {
 		return SourcePos{Filename: "<input>"}


### PR DESCRIPTION
I know you're not going to like this, but I'd really recommend we do this. This returns sensible defaults for `SourcePos` if it is nil.

There's still a further issue where we expect non-nil `SourcePos` values that should be investigated, but an interface function shouldn't panic if an underlying value is nil, just on general principle (and most Golang codebases go by this).

I **really** don't think that `error` should ever panic, for example - I'd expect `Error()` to not panic under any conditions, as that defeats the purpose. We're gonna have to get around this in Buf by manually doing the below logic otherwise, not that that will convince you :-) We can't have panics due to bugs like #324 if that makes sense