### PR TITLE
Always indicate SourcePos for ErrorWithSourcePos in parseProtoFile

### DIFF
--- a/desc/protoparse/errors.go
+++ b/desc/protoparse/errors.go
@@ -121,3 +121,16 @@ var _ ErrorWithPos = ErrorWithSourcePos{}
 func errorWithPos(pos *SourcePos, format string, args ...interface{}) ErrorWithPos {
 	return ErrorWithSourcePos{Pos: pos, Underlying: fmt.Errorf(format, args...)}
 }
+
+type errorWithFilename struct {
+	underlying error
+	filename   string
+}
+
+func (e errorWithFilename) Error() string {
+	return fmt.Sprintf("%s: %v", e.filename, e.underlying)
+}
+
+func (e errorWithFilename) Unwrap() error {
+	return e.underlying
+}

--- a/desc/protoparse/parser.go
+++ b/desc/protoparse/parser.go
@@ -449,7 +449,8 @@ func parseProtoFile(acc FileAccessor, filename string, importLoc *SourcePos, err
 	} else {
 		if !strings.Contains(err.Error(), filename) {
 			// an error message that doesn't indicate the file is awful!
-			err = fmt.Errorf("%s: %w", filename, err)
+			// this cannot be %w as this is not compatible with go <= 1.13
+			err = fmt.Errorf("%s: %v", filename, err)
 		}
 		// The top-level loop in parseProtoFiles calls this with nil for the top-level files
 		// importLoc is only for imports, otherwise we do not want to return a ErrorWithSourcePos

--- a/desc/protoparse/parser.go
+++ b/desc/protoparse/parser.go
@@ -450,7 +450,10 @@ func parseProtoFile(acc FileAccessor, filename string, importLoc *SourcePos, err
 		if !strings.Contains(err.Error(), filename) {
 			// an error message that doesn't indicate the file is awful!
 			// this cannot be %w as this is not compatible with go <= 1.13
-			err = fmt.Errorf("%s: %v", filename, err)
+			err = errorWithFilename{
+				underlying: err,
+				filename:   filename,
+			}
 		}
 		// The top-level loop in parseProtoFiles calls this with nil for the top-level files
 		// importLoc is only for imports, otherwise we do not want to return a ErrorWithSourcePos


### PR DESCRIPTION
This fixes #324 

This also removes the auto-add of the filename to the error, because it should be derived from the `SourcePos`. Actually now, since `Pos` will not be nil, if the `strings.Contains` logic were to remain, you'd get i.e. `path/to/foo.proto: path/to/foo.proto: error message`.