### PR TITLE
Propagate errors within linkFiles

### DIFF
--- a/desc/protoparse/linker.go
+++ b/desc/protoparse/linker.go
@@ -73,6 +73,12 @@ func (l *linker) linkFiles() (map[string]*desc.FileDescriptor, error) {
 		}
 	}
 
+	// When Parser calls linkFiles, it does not check errs again, and it expects that linkFiles
+	// will return all errors it should process. If the ErrorReporter handles all errors itself
+	// and always returns nil, we should get ErrInvalidSource here, and need to propagate this
+	if err := l.errs.getError(); err != nil {
+		return nil, err
+	}
 	return linked, nil
 }
 


### PR DESCRIPTION
This issue came up in buf. Buf has it's own `ErrorReporter` scheme, where `nil` is always returned. After debugging, we found out that `handleErrorWithPos` was being called after the last call to `getError`, which meant an error was being reported that was not being propagated to the return value of `ParseFiles`. This meant that the `ErrorReporter` had been called, but `ParseFiles` returned no error, when it should have returned `ErrInvalidSource`.

This fixes the issue by doing another call to `getError` at the end of `linkFiles`, so that `linkFiles` returns all errors, as `ParseFiles` expects (`ParseFiles` does not call `getError` again). This also adds a specific test for this that reproduces the issue we saw - without the fix, this test fails, but with this fix, it passes.