### PR TITLE
protoparse: report unused imports to configured WarningReporter

### DIFF
--- a/desc/protoparse/errors.go
+++ b/desc/protoparse/errors.go
@@ -167,7 +167,7 @@ type ErrorUnusedImport interface {
 type errUnusedImport string
 
 func (e errUnusedImport) Error() string {
-	return fmt.Sprintf("import %q not used", e)
+	return fmt.Sprintf("import %q not used", string(e))
 }
 
 func (e errUnusedImport) UnusedImport() string {

--- a/desc/protoparse/errors.go
+++ b/desc/protoparse/errors.go
@@ -154,3 +154,22 @@ func (e errorWithFilename) Error() string {
 func (e errorWithFilename) Unwrap() error {
 	return e.underlying
 }
+
+// ErrorUnusedImport may be passed to a warning reporter when an unused
+// import is detected. The error the reporter receives will be wrapped
+// with source position that indicates the file and line where the import
+// statement appeared.
+type ErrorUnusedImport interface {
+	error
+	UnusedImport() string
+}
+
+type errUnusedImport string
+
+func (e errUnusedImport) Error() string {
+	return fmt.Sprintf("import %q not used", e)
+}
+
+func (e errUnusedImport) UnusedImport() string {
+	return string(e)
+}

--- a/desc/protoparse/parser.go
+++ b/desc/protoparse/parser.go
@@ -251,6 +251,10 @@ func (p Parser) parseAndLink(filenames []string) (*linker, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Now we're done linking, so we can check to see if any imports were unused
+	for _, file := range filenames {
+		l.checkForUnusedImports(file)
+	}
 	if p.IncludeSourceCodeInfo {
 		for _, pr := range results.resultsByFilename {
 			pr.fd.SourceCodeInfo = pr.generateSourceCodeInfo()

--- a/desc/protoparse/reporting_test.go
+++ b/desc/protoparse/reporting_test.go
@@ -338,6 +338,14 @@ func TestWarningReporting(t *testing.T) {
 				"test.proto": `syntax = "proto3"; import "google/protobuf/descriptor.proto"; message Foo { option deprecated = true; }`,
 			},
 		},
+		{
+			// makes sure we can use a given descriptor.proto to override non-custom options
+			name: "implicitly used descriptor.proto import with new option",
+			sources: map[string]string{
+				"test.proto": `syntax = "proto3"; import "google/protobuf/descriptor.proto"; message Foo { option foobar = 123; }`,
+				"google/protobuf/descriptor.proto": `syntax = "proto2"; package google.protobuf; message MessageOptions { optional fixed32 foobar = 99; }`,
+			},
+		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {


### PR DESCRIPTION
This is currently built on top of the monster change in PR #354.

I may try to backport this one since that change is big, and it may be some time longer before I can reasonably get it in merge-able shape...

Resolves #281