### PR TITLE
return error if FindMessageTypeByUrl returns nil message type

### DIFF
--- a/dynamic/msgregistry/message_registry.go
+++ b/dynamic/msgregistry/message_registry.go
@@ -716,6 +716,9 @@ func (r *MessageRegistry) Resolve(typeUrl string) (proto.Message, error) {
 	if err != nil {
 		return nil, err
 	}
+	if md == nil {
+		return nil, fmt.Errorf("unknown message type: %s", typeUrl)
+	}
 	return r.mf.NewMessage(md), nil
 }
 


### PR DESCRIPTION
Thanks for the great project!
I found a tiny bug in `Resolve` method of `*MessageRegistry`.
[`FindMessageTypeByUrl`](https://pkg.go.dev/github.com/jhump/protoreflect@v1.7.0/dynamic/msgregistry?tab=doc#MessageRegistry.FindMessageTypeByUrl) may returns nil message type, so we must check it.