### PR TITLE
serializes sub map field in a deterministic way

### DIFF
--- a/codec/encode_fields.go
+++ b/codec/encode_fields.go
@@ -34,6 +34,7 @@ func (cb *Buffer) EncodeFieldValue(fd *desc.FieldDescriptor, val interface{}) er
 		valType := entryType.FindFieldByNumber(2)
 		var entryBuffer Buffer
 		if cb.IsDeterministic() {
+			entryBuffer.SetDeterministic(true)
 			keys := make([]interface{}, 0, len(mp))
 			for k := range mp {
 				keys = append(keys, k)


### PR DESCRIPTION
you could test this bug with  the following proto schema:
```
message TestSub{
  map<int32,int32> UpgradeConditions = 6;
}

message TestSubConf{
  map<string, TestSub> TestSubMap = 1;
}
```
With `MarshalDeterministic`, the field `UpgradeConditions`  serializes to bytes not in a deterministic way.

