### PR TITLE
Fixed Index iterator for tags assignments

### DIFF
--- a/desc/builder/builder_test.go
+++ b/desc/builder/builder_test.go
@@ -1392,19 +1392,19 @@ func TestInterleavedFieldNumbers(t *testing.T) {
 	testutil.Ok(t, err)
 
 	testutil.Require(t, md.FindFieldByName("one") != nil)
-	testutil.Require(t, md.FindFieldByName("one").GetNumber() == 1)
+	testutil.Eq(t, int32(1), md.FindFieldByName("one").GetNumber())
 
 	testutil.Require(t, md.FindFieldByName("two") != nil)
-	testutil.Require(t, md.FindFieldByName("two").GetNumber() == 2)
+	testutil.Eq(t, int32(2), md.FindFieldByName("two").GetNumber())
 
 	testutil.Require(t, md.FindFieldByName("three") != nil)
-	testutil.Require(t, md.FindFieldByName("three").GetNumber() == 3)
+	testutil.Eq(t, int32(3), md.FindFieldByName("three").GetNumber())
 
 	testutil.Require(t, md.FindFieldByName("four") != nil)
-	testutil.Require(t, md.FindFieldByName("four").GetNumber() == 4)
+	testutil.Eq(t, int32(4), md.FindFieldByName("four").GetNumber())
 
 	testutil.Require(t, md.FindFieldByName("five") != nil)
-	testutil.Require(t, md.FindFieldByName("five").GetNumber() == 5)
+	testutil.Eq(t, int32(5), md.FindFieldByName("five").GetNumber())
 }
 
 func clone(t *testing.T, fb *FileBuilder) *FileBuilder {

--- a/desc/builder/builder_test.go
+++ b/desc/builder/builder_test.go
@@ -1380,6 +1380,33 @@ func TestRemoveField(t *testing.T) {
 	testutil.Eq(t, "three", children[1].GetName())
 }
 
+func TestInterleavedFieldNumbers(t *testing.T) {
+	msg := NewMessage("MessageWithInterleavedFieldNumbers").
+		AddField(NewField("one", FieldTypeInt64()).SetNumber(1)).
+		AddField(NewField("two", FieldTypeInt64())).
+		AddField(NewField("three", FieldTypeString()).SetNumber(3)).
+		AddField(NewField("four", FieldTypeInt64())).
+		AddField(NewField("five", FieldTypeString()).SetNumber(5))
+
+	md, err := msg.Build()
+	testutil.Ok(t, err)
+
+	testutil.Require(t, md.FindFieldByName("one") != nil)
+	testutil.Require(t, md.FindFieldByName("one").GetNumber() == 1)
+
+	testutil.Require(t, md.FindFieldByName("two") != nil)
+	testutil.Require(t, md.FindFieldByName("two").GetNumber() == 2)
+
+	testutil.Require(t, md.FindFieldByName("three") != nil)
+	testutil.Require(t, md.FindFieldByName("three").GetNumber() == 3)
+
+	testutil.Require(t, md.FindFieldByName("four") != nil)
+	testutil.Require(t, md.FindFieldByName("four").GetNumber() == 4)
+
+	testutil.Require(t, md.FindFieldByName("five") != nil)
+	testutil.Require(t, md.FindFieldByName("five").GetNumber() == 5)
+}
+
 func clone(t *testing.T, fb *FileBuilder) *FileBuilder {
 	fd, err := fb.Build()
 	testutil.Ok(t, err)

--- a/desc/builder/message.go
+++ b/desc/builder/message.go
@@ -755,10 +755,12 @@ func (mb *MessageBuilder) buildProto(path []int32, sourceInfo *dpb.SourceCodeInf
 
 	if len(needTagsAssigned) > 0 {
 		tags := make([]int, len(fields)-len(needTagsAssigned))
-		for i, fld := range fields {
+		tagsIndex := 0
+		for _, fld := range fields {
 			tag := fld.GetNumber()
 			if tag != 0 {
-				tags[i] = int(tag)
+				tags[tagsIndex] = int(tag)
+				tagsIndex++
 			}
 		}
 		sort.Ints(tags)


### PR DESCRIPTION
Current code was using wrong index during assignment in tags array. 
`tags ` array length will always be smaller than or equal to `fields` array length. Since we are accessing `tags` array with `fields` index  we encounter `indexOutOfBound`.

- Added new indexCounter for maintaining currIndex for tags array.