### PR TITLE
double options in protoprint

### DIFF
--- a/desc/protoprint/testfiles/test-unrecognized-options.proto
+++ b/desc/protoprint/testfiles/test-unrecognized-options.proto
@@ -1,0 +1,34 @@
+syntax = "proto3";
+
+import "google/protobuf/descriptor.proto";
+
+message Test {
+}
+
+message Foo {
+  repeated Bar bar = 1;
+
+  message Bar {
+    Baz baz = 1;
+
+    string name = 2;
+  }
+
+  enum Baz {
+    ZERO = 0;
+
+    FROB = 1;
+
+    NITZ = 2;
+  }
+}
+
+service TestService {
+  rpc Get ( Test ) returns ( Test ) {
+    option (foo) = { bar:<baz:FROB name:"abc"> bar:<baz:NITZ name:"xyz"> bar:<baz:FROB name:"abc"> bar:<baz:NITZ name:"xyz"> };
+  }
+}
+
+extend google.protobuf.MethodOptions {
+  Foo foo = 54321;
+}

--- a/desc/protoprint/testfiles/test-unrecognized-options.proto
+++ b/desc/protoprint/testfiles/test-unrecognized-options.proto
@@ -25,7 +25,7 @@ message Foo {
 
 service TestService {
   rpc Get ( Test ) returns ( Test ) {
-    option (foo) = { bar:<baz:FROB name:"abc"> bar:<baz:NITZ name:"xyz"> bar:<baz:FROB name:"abc"> bar:<baz:NITZ name:"xyz"> };
+    option (foo) = { bar:<baz:FROB name:"abc"> bar:<baz:NITZ name:"xyz"> };
   }
 }
 


### PR DESCRIPTION
This will fix in #363 in master (and in future releases).

Another fix was also applied to [another branch](https://github.com/jhump/protoreflect/compare/jh/double-options-v1.7-patch), for a [patch release of v1.7](https://github.com/jhump/protoreflect/releases/tag/v1.7.1).