### PR TITLE
protparse: fix recently introduced issue with trailing comment on last element in file

### DIFF
--- a/desc/protoparse/lexer.go
+++ b/desc/protoparse/lexer.go
@@ -209,8 +209,8 @@ func (l *protoLex) Lex(lval *protoSymType) int {
 			// we're not actually returning a rune, but this will associate
 			// accumulated comments as a trailing comment on last symbol
 			// (if appropriate)
-			l.setIdent(lval, "")
-			l.eof = lval.id
+			l.setRune(lval, 0)
+			l.eof = lval.b
 			return 0
 		} else if err != nil {
 			// we don't call setError because we don't want it wrapped

--- a/desc/protoparse/test-source-info.txt
+++ b/desc/protoparse/test-source-info.txt
@@ -5261,6 +5261,8 @@ desc_test_complex.proto:268:48
  > message_type[9]:
 desc_test_complex.proto:271:1
 desc_test_complex.proto:296:2
+    Trailing comments:
+ comment for last element in file, KeywordCollisionOptions
 
 
  > message_type[9] > name:

--- a/internal/testprotos/desc_test_complex.proto
+++ b/internal/testprotos/desc_test_complex.proto
@@ -294,3 +294,4 @@ message KeywordCollisionOptions {
 		}
 	];
 }
+// comment for last element in file, KeywordCollisionOptions


### PR DESCRIPTION
If the last element in a file contained a trailing comment, but no extra whitespace/newlines after, between trailing comment and EOF, that comment could incorrectly be left off and _not_ attributed as a trailing comment.

Fixes #371 

This is admittedly a very subtle (and thus obnoxious) bug fix. The logic for when to attribute a comment as trailing comment to prior symbol is gross, and the change that introduced this tickled an obscure subtlety in it :(