### PR TITLE
protoparse: do not allow allow_alias enum option if the enum does not actually have aliases

### DIFF
--- a/desc/protoparse/options_test.go
+++ b/desc/protoparse/options_test.go
@@ -85,7 +85,7 @@ func TestOptionsInUnlinkedFiles(t *testing.T) {
 		},
 		{
 			// enum options
-			contents: `enum Test { option allow_alias = true; option deprecated = true; option (must.link) = 123.456; ZERO = 0; }`,
+			contents: `enum Test { option allow_alias = true; option deprecated = true; option (must.link) = 123.456; ZERO = 0; ZILCH = 0; }`,
 			uninterpreted: map[string]interface{}{
 				"Test:(must.link)": 123.456,
 			},

--- a/desc/protoparse/validate.go
+++ b/desc/protoparse/validate.go
@@ -200,21 +200,22 @@ func validateEnum(res *parseResult, isProto3 bool, prefix string, ed *dpb.EnumDe
 	}
 
 	allowAlias := false
+	var allowAliasOpt *dpb.UninterpretedOption
 	if index, err := findOption(res, scope, ed.Options.GetUninterpretedOption(), "allow_alias"); err != nil {
 		return err
 	} else if index >= 0 {
-		opt := ed.Options.UninterpretedOption[index]
+		allowAliasOpt = ed.Options.UninterpretedOption[index]
 		valid := false
-		if opt.IdentifierValue != nil {
-			if opt.GetIdentifierValue() == "true" {
+		if allowAliasOpt.IdentifierValue != nil {
+			if allowAliasOpt.GetIdentifierValue() == "true" {
 				allowAlias = true
 				valid = true
-			} else if opt.GetIdentifierValue() == "false" {
+			} else if allowAliasOpt.GetIdentifierValue() == "false" {
 				valid = true
 			}
 		}
 		if !valid {
-			optNode := res.getOptionNode(opt)
+			optNode := res.getOptionNode(allowAliasOpt)
 			if err := res.errs.handleErrorWithPos(optNode.GetValue().Start(), "%s: expecting bool value for allow_alias option", scope); err != nil {
 				return err
 			}
@@ -228,17 +229,27 @@ func validateEnum(res *parseResult, isProto3 bool, prefix string, ed *dpb.EnumDe
 		}
 	}
 
-	if !allowAlias {
-		// make sure all value numbers are distinct
-		vals := map[int32]string{}
-		for _, evd := range ed.Value {
-			if existing := vals[evd.GetNumber()]; existing != "" {
+	// check for aliases
+	vals := map[int32]string{}
+	hasAlias := false
+	for _, evd := range ed.Value {
+		existing := vals[evd.GetNumber()]
+		if existing != "" {
+			if allowAlias {
+				hasAlias = true
+			} else {
 				evNode := res.getEnumValueNode(evd)
 				if err := res.errs.handleErrorWithPos(evNode.GetNumber().Start(), "%s: values %s and %s both have the same numeric value %d; use allow_alias option if intentional", scope, existing, evd.GetName(), evd.GetNumber()); err != nil {
 					return err
 				}
 			}
-			vals[evd.GetNumber()] = evd.GetName()
+		}
+		vals[evd.GetNumber()] = evd.GetName()
+	}
+	if allowAlias && !hasAlias {
+		optNode := res.getOptionNode(allowAliasOpt)
+		if err := res.errs.handleErrorWithPos(optNode.GetValue().Start(), "%s: allow_alias is true but no values are aliases", scope); err != nil {
+			return err
 		}
 	}
 

--- a/desc/protoparse/validate_test.go
+++ b/desc/protoparse/validate_test.go
@@ -151,6 +151,14 @@ func TestBasicValidation(t *testing.T) {
 			succeeds: true,
 		},
 		{
+			contents: `enum Foo { option allow_alias = false; V1 = 1; V2 = 2; }`,
+			succeeds: true,
+		},
+		{
+			contents: `enum Foo { option allow_alias = true; V1 = 1; V2 = 2; }`,
+			errMsg:   `test.proto:1:33: enum Foo: allow_alias is true but no values are aliases`,
+		},
+		{
 			contents: `syntax = "proto3"; enum Foo { V1 = 0; reserved 1 to 20; reserved "V2"; }`,
 			succeeds: true,
 		},


### PR DESCRIPTION
This resolves #357.