### PR TITLE
protoparse enforces add'l requirements for message sets

### DIFF
--- a/desc/protoparse/linker.go
+++ b/desc/protoparse/linker.go
@@ -69,7 +69,7 @@ func (l *linker) linkFiles() (map[string]*desc.FileDescriptor, error) {
 		}
 		// we should now have any message_set_wire_format options parsed
 		// and can do further validation on tag ranges
-		if err := checkExtensionTagsInFile(fd, r); err != nil {
+		if err := checkExtensionsInFile(fd, r); err != nil {
 			return nil, err
 		}
 	}

--- a/desc/protoparse/parser.go
+++ b/desc/protoparse/parser.go
@@ -798,46 +798,55 @@ func checkTag(pos *SourcePos, v uint64, maxTag int32) error {
 	return nil
 }
 
-func checkExtensionTagsInFile(fd *desc.FileDescriptor, res *parseResult) error {
+func checkExtensionsInFile(fd *desc.FileDescriptor, res *parseResult) error {
 	for _, fld := range fd.GetExtensions() {
-		if err := checkExtensionTag(fld, res); err != nil {
+		if err := checkExtension(fld, res); err != nil {
 			return err
 		}
 	}
 	for _, md := range fd.GetMessageTypes() {
-		if err := checkExtensionTagsInMessage(md, res); err != nil {
+		if err := checkExtensionsInMessage(md, res); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func checkExtensionTagsInMessage(md *desc.MessageDescriptor, res *parseResult) error {
+func checkExtensionsInMessage(md *desc.MessageDescriptor, res *parseResult) error {
 	for _, fld := range md.GetNestedExtensions() {
-		if err := checkExtensionTag(fld, res); err != nil {
+		if err := checkExtension(fld, res); err != nil {
 			return err
 		}
 	}
 	for _, nmd := range md.GetNestedMessageTypes() {
-		if err := checkExtensionTagsInMessage(nmd, res); err != nil {
+		if err := checkExtensionsInMessage(nmd, res); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func checkExtensionTag(fld *desc.FieldDescriptor, res *parseResult) error {
-	// NB: This is kind of gross that we don't enforce this in validateBasic(). But it would
-	// require doing some minimal linking there (to identify the extendee and locate its
-	// descriptor). To keep the code simpler, we just wait until things are fully linked.
-
-	// In validateBasic() we just made sure these were within bounds for any message. But
-	// now that things are linked, we can check if the extendee is messageset wire format
-	// and, if not, enforce tighter limit.
-	if !fld.GetOwner().GetMessageOptions().GetMessageSetWireFormat() && fld.GetNumber() > internal.MaxNormalTag {
-		pos := res.getFieldNode(fld.AsFieldDescriptorProto()).FieldTag().Start()
-		return errorWithPos(pos, "tag number %d is higher than max allowed tag number (%d)", fld.GetNumber(), internal.MaxNormalTag)
+func checkExtension(fld *desc.FieldDescriptor, res *parseResult) error {
+	// NB: It's a little gross that we don't enforce these in validateBasic().
+	// But requires some minimal linking to resolve the extendee, so we can
+	// interrogate its descriptor.
+	if fld.GetOwner().GetMessageOptions().GetMessageSetWireFormat() {
+		// Message set wire format requires that all extensions be messages
+		// themselves (no scalar extensions)
+		if fld.GetType() != dpb.FieldDescriptorProto_TYPE_MESSAGE {
+			pos := res.getFieldNode(fld.AsFieldDescriptorProto()).FieldType().Start()
+			return errorWithPos(pos, "messages with message-set wire format cannot contain scalar extensions, only messages")
+		}
+	} else {
+		// In validateBasic() we just made sure these were within bounds for any message. But
+		// now that things are linked, we can check if the extendee is messageset wire format
+		// and, if not, enforce tighter limit.
+		if fld.GetNumber() > internal.MaxNormalTag {
+			pos := res.getFieldNode(fld.AsFieldDescriptorProto()).FieldTag().Start()
+			return errorWithPos(pos, "tag number %d is higher than max allowed tag number (%d)", fld.GetNumber(), internal.MaxNormalTag)
+		}
 	}
+
 	return nil
 }
 

--- a/desc/protoparse/validate_test.go
+++ b/desc/protoparse/validate_test.go
@@ -27,12 +27,20 @@ func TestBasicValidation(t *testing.T) {
 			succeeds: true,
 		},
 		{
-			contents: `message Foo { optional double bar = 536870912; option message_set_wire_format = true; }`,
+			contents: `message Foo { oneof bar { group Baz = 1 [deprecated=true] { optional int abc = 1; } } }`,
 			succeeds: true,
 		},
 		{
-			contents: `message Foo { oneof bar { group Baz = 1 [deprecated=true] { optional int abc = 1; } } }`,
+			contents: `message Foo { option message_set_wire_format = true; extensions 1 to 100; }`,
 			succeeds: true,
+		},
+		{
+			contents: `message Foo { optional double bar = 536870912; option message_set_wire_format = true; }`,
+			errMsg:   "test.proto:1:15: messages with message-set wire format cannot contain non-extension fields",
+		},
+		{
+			contents: `message Foo { option message_set_wire_format = true; }`,
+			errMsg:   "test.proto:1:15: messages with message-set wire format must contain at least one extension range",
 		},
 		{
 			contents: `syntax = "proto1";`,


### PR DESCRIPTION
There are several requirements for messages that have message-set wire format that protoc enforces, but that protoparse was failing to enforce.

Resolves #359