### PR TITLE
dynamic/msgregistry: Add typed errors for lookups

### DIFF
--- a/dynamic/msgregistry/message_registry_test.go
+++ b/dynamic/msgregistry/message_registry_test.go
@@ -1,6 +1,7 @@
 package msgregistry
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -59,9 +60,10 @@ func TestMessageRegistry_LookupTypes(t *testing.T) {
 
 	// wrong type
 	_, err = mr.FindMessageTypeByUrl("foo.bar/google.protobuf.FieldDescriptorProto.Type")
-	testutil.Require(t, err != nil && strings.Contains(err.Error(), "wanted message, got enum"))
+	unexpectedType := (*ErrUnexpectedType)(nil)
+	testutil.Require(t, errors.As(err, &unexpectedType))
 	_, err = mr.FindEnumTypeByUrl("foo.bar/google.protobuf.DescriptorProto")
-	testutil.Require(t, err != nil && strings.Contains(err.Error(), "wanted enum, got message"))
+	testutil.Require(t, errors.As(err, &unexpectedType))
 
 	// unmarshal any successfully finds the registered type
 	b, err := proto.Marshal(md.AsProto())

--- a/dynamic/msgregistry/message_registry_test.go
+++ b/dynamic/msgregistry/message_registry_test.go
@@ -1,7 +1,6 @@
 package msgregistry
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -60,10 +59,11 @@ func TestMessageRegistry_LookupTypes(t *testing.T) {
 
 	// wrong type
 	_, err = mr.FindMessageTypeByUrl("foo.bar/google.protobuf.FieldDescriptorProto.Type")
-	unexpectedType := (*ErrUnexpectedType)(nil)
-	testutil.Require(t, errors.As(err, &unexpectedType))
+	_, ok := err.(*ErrUnexpectedType)
+	testutil.Require(t, ok)
 	_, err = mr.FindEnumTypeByUrl("foo.bar/google.protobuf.DescriptorProto")
-	testutil.Require(t, errors.As(err, &unexpectedType))
+	_, ok = err.(*ErrUnexpectedType)
+	testutil.Require(t, ok)
 
 	// unmarshal any successfully finds the registered type
 	b, err := proto.Marshal(md.AsProto())


### PR DESCRIPTION
Adds typed errors used when looking up a message and finding an enum or vice versa.