### PR TITLE
protoparse: take 2 on fixing symbol resolution to properly match protoc's C++-like namespace handling

### DIFF
--- a/desc/protoparse/linker_test.go
+++ b/desc/protoparse/linker_test.go
@@ -91,6 +91,13 @@ func TestLinkerValidation(t *testing.T) {
 	}{
 		{
 			map[string]string{
+				"foo.proto":  `syntax = "proto3"; package namespace.a; import "foo2.proto"; message Foo{ b.Bar b = 1; }`,
+				"foo2.proto": `syntax = "proto3"; package namespace.b; message Bar{}`,
+			},
+			"", // should succeed
+		},
+		{
+			map[string]string{
 				"foo.proto": "import \"foo2.proto\"; message fubar{}",
 			},
 			`foo.proto:1:8: file not found: foo2.proto`,


### PR DESCRIPTION
Previous fix (#393) was not correct! The new test case in here was borrowed from #396. And with this fixed code, it now passes.

The change requires the linker to track all package namespaces explicitly, so they can be checked when finding symbols. The previous approach was trying to be clever and avoid that extra state, but it did not work correctly.