### PR TITLE
protoparse: c++ scoping rules for enum values

### DIFF
--- a/desc/protoparse/linker_test.go
+++ b/desc/protoparse/linker_test.go
@@ -113,6 +113,12 @@ func TestLinkerValidation(t *testing.T) {
 		},
 		{
 			map[string]string{
+				"foo.proto": "enum foo { bar = 1; baz = 2; } enum fu { bar = 1; baz = 2; }",
+			},
+			`foo.proto:1:42: duplicate symbol bar: already defined as enum value; protobuf uses C++ scoping rules for enum values, so they exist in the scope enclosing the enum`,
+		},
+		{
+			map[string]string{
 				"foo.proto": "message foo {} enum foo { V = 0; }",
 			},
 			"foo.proto:1:16: duplicate symbol foo: already defined as message",

--- a/desc/protoparse/reporting_test.go
+++ b/desc/protoparse/reporting_test.go
@@ -104,7 +104,7 @@ func TestErrorReporting(t *testing.T) {
 					`,
 			},
 			expectedErrs: []string{
-				"test.proto:8:49: duplicate symbol Bar.BAZ: already defined as enum value",
+				"test.proto:8:49: duplicate symbol BAZ: already defined as enum value; protobuf uses C++ scoping rules for enum values, so they exist in the scope enclosing the enum",
 				"test.proto:10:41: duplicate symbol Bar: already defined as enum",
 				"test.proto:12:49: duplicate symbol Bar.Foo: already defined as method",
 				"test.proto:12:58: method Bar.Foo: unknown request type Frob",


### PR DESCRIPTION
Fixes #400.