### PR TITLE
Add option to set proto2 syntax in resulting FileDescriptorProtos if specified

### DIFF
--- a/desc/protoparse/parser_test.go
+++ b/desc/protoparse/parser_test.go
@@ -162,7 +162,7 @@ func parseFileForTest(filename string) (*parseResult, error) {
 		_ = f.Close()
 	}()
 	errs := newErrorHandler(nil, nil)
-	res := parseProto(filename, f, errs, true, true)
+	res := parseProto(filename, f, errs, true, true, true)
 	return res, errs.getError()
 }
 

--- a/desc/protoparse/reporting_test.go
+++ b/desc/protoparse/reporting_test.go
@@ -58,7 +58,7 @@ func TestErrorReporting(t *testing.T) {
 				"test.proto:5:41: syntax error: unexpected \"enum\", expecting ';'",
 				"test.proto:5:69: syntax error: unexpected ';', expecting '='",
 				"test.proto:7:53: syntax error: unexpected '='",
-				`test.proto:2:50: syntax value must be "proto2" or "proto3"`,
+				`test.proto:2:50: syntax value must be "proto2" or "proto3" but was "proto"`,
 			},
 		},
 		{

--- a/desc/protoparse/validate_test.go
+++ b/desc/protoparse/validate_test.go
@@ -44,7 +44,7 @@ func TestBasicValidation(t *testing.T) {
 		},
 		{
 			contents: `syntax = "proto1";`,
-			errMsg:   `test.proto:1:10: syntax value must be "proto2" or "proto3"`,
+			errMsg:   `test.proto:1:10: syntax value must be "proto2" or "proto3" but was "proto1"`,
 		},
 		{
 			contents: `message Foo { optional string s = 5000000000; }`,
@@ -358,7 +358,7 @@ func TestBasicValidation(t *testing.T) {
 
 	for i, tc := range testCases {
 		errs := newErrorHandler(nil, nil)
-		_ = parseProto("test.proto", strings.NewReader(tc.contents), errs, true, true)
+		_ = parseProto("test.proto", strings.NewReader(tc.contents), errs, true, true, true)
 		err := errs.getError()
 		if tc.succeeds {
 			testutil.Ok(t, err, "case #%d should succeed", i)


### PR DESCRIPTION
I'm not actually sure if we want this in protoreflect, but I thought I'd at least put it up for discussion. Being able to differentiate would be useful for us, but also see notes on `protoc`.