### PR TITLE
Replace Accessor, LookupImport, LookupImportProto with FileProviders

### DIFF
--- a/desc/protoparse/errors.go
+++ b/desc/protoparse/errors.go
@@ -19,6 +19,15 @@ var ErrNoSyntax = errors.New("no syntax specified; defaulting to proto2 syntax")
 // ErrLookupImportAndProtoSet is the error returned if both LookupImport and LookupImportProto are set.
 var ErrLookupImportAndProtoSet = errors.New("both LookupImport and LookupImportProto set")
 
+// ErrFileProvidersAndAccessorSet is the error returned if both FileProviders and Accessor is set.
+var ErrFileProvidersAndAccessorSet = errors.New("both FileProviders and Accessor set")
+
+// ErrFileProvidersAndLookupImportSet is the error returned if both FileProviders and LookupImport is set.
+var ErrFileProvidersAndLookupImportSet = errors.New("both FileProviders and LookupImport set")
+
+// ErrFileProvidersAndLookupImportProtoSet is the error returned if both FileProviders and LookupImportProto is set.
+var ErrFileProvidersAndLookupImportProtoSet = errors.New("both FileProviders and LookupImportProto set")
+
 // ErrorReporter is responsible for reporting the given error. If the reporter
 // returns a non-nil error, parsing/linking will abort with that error. If the
 // reporter returns nil, parsing will continue, allowing the parser to try to

--- a/desc/protoparse/file_provider.go
+++ b/desc/protoparse/file_provider.go
@@ -1,0 +1,54 @@
+package protoparse
+
+import (
+	"io"
+
+	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/jhump/protoreflect/desc"
+)
+
+type FileProvider interface {
+	isFileProvider()
+}
+
+func ReadCloserFileProvider(f func(string) (io.ReadCloser, error)) FileProvider {
+	return readCloserFileProvider{
+		f: f,
+	}
+}
+
+func FileDescriptorFileProvider(f func(string) (*desc.FileDescriptor, error)) FileProvider {
+	return fileDescriptorProtoFileProvider{
+		f: fileDescriptorFuncToFileDescriptorProtoFunc(f),
+	}
+}
+
+func FileDescriptorProtoFileProvider(f func(string) (*dpb.FileDescriptorProto, error)) FileProvider {
+	return fileDescriptorProtoFileProvider{
+		f: f,
+	}
+}
+
+type readCloserFileProvider struct {
+	f func(string) (io.ReadCloser, error)
+}
+
+func (readCloserFileProvider) isFileProvider() {}
+
+type fileDescriptorProtoFileProvider struct {
+	f func(string) (*dpb.FileDescriptorProto, error)
+}
+
+func (fileDescriptorProtoFileProvider) isFileProvider() {}
+
+func fileDescriptorFuncToFileDescriptorProtoFunc(
+	f func(string) (*desc.FileDescriptor, error),
+) func(string) (*dpb.FileDescriptorProto, error) {
+	return func(path string) (*dpb.FileDescriptorProto, error) {
+		fileDescriptor, err := f(path)
+		if fileDescriptor != nil {
+			return fileDescriptor.AsFileDescriptorProto(), err
+		}
+		return nil, err
+	}
+}


### PR DESCRIPTION
Before I go any further with this and do the Godoc, I thought I'd put this up so we could discuss.

Here's basically the problem: Right now, you can use `Accessor` and `LookupImport/LookupImportProto` to set how you access source files and compiled `FileDescriptorSets`. The ordering of access is:

- `Accessor`
- `LookupImport/LookupImportProto`
- protoreflect builtin WKTs

We're trying to implement `buf protoc --descriptor_set_in`, which obviously requires `LookupImportProto`. However, we have our own versions of the WKTs (see https://github.com/bufbuild/buf/pull/43 for why), which we expose via our `Accessor`, which itself cascades from source files to these builtin WKTs. So for us, the order is:

- `Accessor` with source files
- `Accessor` with our builtin WKTs
- `LookupImport/LookupImportProto`
- protoreflect builtin WKTs (which are never hit, since the `Accessor` takes care of this)

However, if we want to use `LookupImportProto, what we need is:

- `Accessor` with source files
- `LookupImport/LookupImportProto`
- `Accessor` with our builtin WKTs

Which isn't possible right now since you can't have multiple Accessors or specify any ordering outside of setting/not setting `Accessor` and `LookupImport/LookupImportProto`.

This is an attempt to replace all of `Accessor, LookupImport, LookupImportProto` with a new `FileProvider` interface that only has one private function, and has constructors `ReadCloserFileProvider, FileDescriptorFileProvider, FileDescriptorProtoFileProvider` that give you instances of `FileProvider` based on what amounts to values you would otherwise pass to `Accessor, LookupImport, LookupImportProto`. So as an example:

```go
p := protoparse.Parser{
  FileProviders: []protoparse.FileProvider{
    protoparse.ReadCloserFileProvider(fileAccessorForSourceFiles),
    protoparse.FileDescriptorProtoFileProvider(lookupImportProto),
    protoparse.ReadCloserFileProvider(fileAccessorForOurBuiltinWKTs),
  },
}
```

The new logic will cascade down the slice to use the first `FileProvider` that doesn't return an error.

The tests aren't passing, and the Godoc isn't complete, but I wanted to get your thoughts.