### PR TITLE
fix panics in protoparse identified by oss-fuzz

### DIFF
--- a/desc/protoparse/lexer.go
+++ b/desc/protoparse/lexer.go
@@ -61,11 +61,6 @@ func (rr *runeReader) endMark() string {
 	return m
 }
 
-func lexError(l protoLexer, pos *SourcePos, err string) {
-	pl := l.(*protoLex)
-	_ = pl.errs.handleErrorWithPos(pos, err)
-}
-
 type protoLex struct {
 	filename string
 	input    *runeReader
@@ -382,6 +377,10 @@ func (l *protoLex) Lex(lval *protoSymType) int {
 			l.input.unreadRune(cn)
 		}
 
+		if c > 255 {
+			l.setError(lval, errors.New("invalid character"))
+			return _ERROR
+		}
 		l.setRune(lval, c)
 		return int(c)
 	}

--- a/desc/protoparse/parser_test.go
+++ b/desc/protoparse/parser_test.go
@@ -3,6 +3,7 @@ package protoparse
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -33,6 +34,24 @@ func TestEmptyParse(t *testing.T) {
 	testutil.Eq(t, 0, len(fd[0].GetEnumTypes()))
 	testutil.Eq(t, 0, len(fd[0].GetExtensions()))
 	testutil.Eq(t, 0, len(fd[0].GetServices()))
+}
+
+func TestJunkParse(t *testing.T) {
+	// inputs that have been found in the past to cause panics by oss-fuzz
+	inputs := map[string]string{
+		"case-34232": `'';`,
+		"case-34238": `.`,
+	}
+	for name, input := range inputs {
+		protoName := fmt.Sprintf("%s.proto", name)
+		p := Parser{
+			Accessor: FileContentsFromMap(map[string]string{protoName: input}),
+		}
+		_, err := p.ParseFiles(protoName)
+		// we expect this to error... but we don't want it to panic
+		testutil.Nok(t, err, "junk input should have returned error")
+		t.Logf("error from parse: %v", err)
+	}
 }
 
 func TestSimpleParse(t *testing.T) {


### PR DESCRIPTION
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=34232
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=34238

Both bugs had the same root cause: unicode chars with very high code points that collided with the various constants for known token types.

So now the lexer is small enough to limit the symbol type value for such runes to less than 256. The smallest constant is 57346, so _plenty_ of headroom in between to avoid collisions. If it sees a symbol with a greater code point, it will now report an error "invalid character".

This should be fine since this handling is only for stand-alone runes/punctuation. Protobuf does not allow such symbols as part of identifiers nor as any allowed punctuation or operator. Unicode points like this are only valid in a proto source file inside of a string literal. So if we come across a lone rune with such a value (not in a string literal), then it is definitely a syntax error.