### PR TITLE
fix more inconsistencies between protoparse and protoc

### DIFF
--- a/desc/protoparse/lexer.go
+++ b/desc/protoparse/lexer.go
@@ -236,11 +236,10 @@ func (l *protoLex) Lex(lval *protoSymType) int {
 			}
 			if cn >= '0' && cn <= '9' {
 				l.adjustPos(cn)
-				token := []rune{c, cn}
-				token = l.readNumber(token, false, true)
-				f, err := strconv.ParseFloat(string(token), 64)
+				token := l.readNumber(c, cn)
+				f, err := strconv.ParseFloat(token, 64)
 				if err != nil {
-					l.setError(lval, err)
+					l.setError(lval, numError(err, "float", token))
 					return _ERROR
 				}
 				l.setFloat(lval, f)
@@ -266,66 +265,42 @@ func (l *protoLex) Lex(lval *protoSymType) int {
 
 		if c >= '0' && c <= '9' {
 			// integer or float literal
-			if c == '0' {
-				cn, _, err := l.input.readRune()
+			token := l.readNumber(c)
+			if strings.HasPrefix(token, "0x") || strings.HasPrefix(token, "0X") {
+				// hexadecimal
+				ui, err := strconv.ParseUint(token[2:], 16, 64)
 				if err != nil {
-					l.setInt(lval, 0)
-					return _INT_LIT
+					l.setError(lval, numError(err, "hexadecimal integer", token[2:]))
+					return _ERROR
 				}
-				if cn == 'x' || cn == 'X' {
-					cnn, _, err := l.input.readRune()
-					if err != nil {
-						l.input.unreadRune(cn)
-						l.setInt(lval, 0)
-						return _INT_LIT
-					}
-					if (cnn >= '0' && cnn <= '9') || (cnn >= 'a' && cnn <= 'f') || (cnn >= 'A' && cnn <= 'F') {
-						// hexadecimal!
-						l.adjustPos(cn, cnn)
-						token := []rune{cnn}
-						token = l.readHexNumber(token)
-						ui, err := strconv.ParseUint(string(token), 16, 64)
-						if err != nil {
-							l.setError(lval, err)
-							return _ERROR
-						}
-						l.setInt(lval, ui)
-						return _INT_LIT
-					}
-					l.input.unreadRune(cnn)
-					l.input.unreadRune(cn)
-					l.setInt(lval, 0)
-					return _INT_LIT
-				} else {
-					l.input.unreadRune(cn)
-				}
+				l.setInt(lval, ui)
+				return _INT_LIT
 			}
-			token := []rune{c}
-			token = l.readNumber(token, true, true)
-			numstr := string(token)
-			if strings.Contains(numstr, ".") || strings.Contains(numstr, "e") || strings.Contains(numstr, "E") {
+			if strings.Contains(token, ".") || strings.Contains(token, "e") || strings.Contains(token, "E") {
 				// floating point!
-				f, err := strconv.ParseFloat(numstr, 64)
+				f, err := strconv.ParseFloat(token, 64)
 				if err != nil {
-					l.setError(lval, err)
+					l.setError(lval, numError(err, "float", token))
 					return _ERROR
 				}
 				l.setFloat(lval, f)
 				return _FLOAT_LIT
 			}
 			// integer! (decimal or octal)
-			ui, err := strconv.ParseUint(numstr, 0, 64)
+			ui, err := strconv.ParseUint(token, 0, 64)
 			if err != nil {
+				kind := "integer"
 				if numErr, ok := err.(*strconv.NumError); ok && numErr.Err == strconv.ErrRange {
 					// if it's too big to be an int, parse it as a float
 					var f float64
-					f, err = strconv.ParseFloat(numstr, 64)
+					kind = "float"
+					f, err = strconv.ParseFloat(token, 64)
 					if err == nil {
 						l.setFloat(lval, f)
 						return _FLOAT_LIT
 					}
 				}
-				l.setError(lval, err)
+				l.setError(lval, numError(err, kind, token))
 				return _ERROR
 			}
 			l.setInt(lval, ui)
@@ -525,79 +500,47 @@ func (l *protoLex) setError(lval *protoSymType, err error) {
 	lval.err = l.addSourceError(err)
 }
 
-func (l *protoLex) readNumber(sofar []rune, allowDot bool, allowExp bool) []rune {
+func (l *protoLex) readNumber(sofar ...rune) string {
 	token := sofar
+	allowExpSign := false
 	for {
 		c, _, err := l.input.readRune()
 		if err != nil {
 			break
 		}
-		if c == '.' {
-			if !allowDot {
-				l.input.unreadRune(c)
-				break
-			}
-			allowDot = false
-		} else if c == 'e' || c == 'E' {
-			if !allowExp {
-				l.input.unreadRune(c)
-				break
-			}
-			allowExp = false
-			cn, _, err := l.input.readRune()
-			if err != nil {
-				l.input.unreadRune(c)
-				break
-			}
-			if cn == '-' || cn == '+' {
-				cnn, _, err := l.input.readRune()
-				if err != nil {
-					l.input.unreadRune(cn)
-					l.input.unreadRune(c)
-					break
-				}
-				if cnn < '0' || cnn > '9' {
-					l.input.unreadRune(cnn)
-					l.input.unreadRune(cn)
-					l.input.unreadRune(c)
-					break
-				}
-				l.adjustPos(c)
-				token = append(token, c)
-				c, cn = cn, cnn
-			} else if cn < '0' || cn > '9' {
-				l.input.unreadRune(cn)
-				l.input.unreadRune(c)
-				break
-			}
-			l.adjustPos(c)
-			token = append(token, c)
-			c = cn
-		} else if c < '0' || c > '9' {
+		if (c == '-' || c == '+') && !allowExpSign {
 			l.input.unreadRune(c)
 			break
+		}
+		allowExpSign = false
+		if c != '.' && c != '_' && (c < '0' || c > '9') &&
+			(c < 'a' || c > 'z') && (c < 'A' || c > 'Z') &&
+			c != '-' && c != '+' {
+			// no more chars in the number token
+			l.input.unreadRune(c)
+			break
+		}
+		if c == 'e' || c == 'E' {
+			// scientific notation char can be followed by
+			// an exponent sign
+			allowExpSign = true
 		}
 		l.adjustPos(c)
 		token = append(token, c)
 	}
-	return token
+	return string(token)
 }
 
-func (l *protoLex) readHexNumber(sofar []rune) []rune {
-	token := sofar
-	for {
-		c, _, err := l.input.readRune()
-		if err != nil {
-			break
-		}
-		if (c < 'a' || c > 'f') && (c < 'A' || c > 'F') && (c < '0' || c > '9') {
-			l.input.unreadRune(c)
-			break
-		}
-		l.adjustPos(c)
-		token = append(token, c)
+func numError(err error, kind, s string) error {
+	ne, ok := err.(*strconv.NumError)
+	if !ok {
+		return err
 	}
-	return token
+	if ne.Err == strconv.ErrRange {
+		return fmt.Errorf("value out of range for %s: %s", kind, s)
+	}
+	// syntax error
+	return fmt.Errorf("invalid syntax in %s value: %s", kind, s)
 }
 
 func (l *protoLex) readIdentifier(sofar []rune) []rune {

--- a/desc/protoparse/lexer.go
+++ b/desc/protoparse/lexer.go
@@ -221,7 +221,7 @@ func (l *protoLex) Lex(lval *protoSymType) int {
 
 		l.offset += n
 		l.adjustPos(c)
-		if strings.ContainsRune("\n\r\t ", c) {
+		if strings.ContainsRune("\n\r\t\f\v ", c) {
 			l.ws = append(l.ws, c)
 			continue
 		}

--- a/desc/protoparse/linker_test.go
+++ b/desc/protoparse/linker_test.go
@@ -168,6 +168,18 @@ func TestLinkerValidation(t *testing.T) {
 		},
 		{
 			map[string]string{
+				"foo.proto": "message foo{} message bar{} service foobar{ rpc foo(foo) returns (bar); }",
+			},
+			"foo.proto:1:53: method foobar.foo: invalid request type: foobar.foo is a method, not a message",
+		},
+		{
+			map[string]string{
+				"foo.proto": "message foo{} message bar{} service foobar{ rpc foo(bar) returns (foo); }",
+			},
+			"foo.proto:1:67: method foobar.foo: invalid response type: foobar.foo is a method, not a message",
+		},
+		{
+			map[string]string{
 				"foo.proto": "package fu.baz; message foobar{ extensions 1; } extend foobar { optional string a = 2; }",
 			},
 			"foo.proto:1:85: field fu.baz.a: tag 2 is not in valid range for extended type fu.baz.foobar",
@@ -196,7 +208,7 @@ func TestLinkerValidation(t *testing.T) {
 					extend google.protobuf.ServiceOptions        { optional string svc_foo = 12000; }
 					extend google.protobuf.MethodOptions         { optional string mtd_foo = 12000; }
 					option (fil_foo) = "file";
-					message Bar {
+					message Foo {
 						option (msg_foo) = "message";
 						oneof foo {
 							option (oof_foo) = "oneof";
@@ -210,7 +222,7 @@ func TestLinkerValidation(t *testing.T) {
 					}
 					service FooService {
 						option (svc_foo) = "service";
-						rpc Bar(Bar) returns (Bar) {
+						rpc Bar(Foo) returns (Foo) {
 							option (mtd_foo) = "method";
 						}
 					}

--- a/desc/protoparse/reporting_test.go
+++ b/desc/protoparse/reporting_test.go
@@ -98,17 +98,17 @@ func TestErrorReporting(t *testing.T) {
 						BAZ = 2;
 					}
 					service Bar {
-						rpc Foo (Foo) returns (Foo);
-						rpc Foo (Frob) returns (Nitz);
+						rpc Foobar (Foo) returns (Foo);
+						rpc Foobar (Frob) returns (Nitz);
 					}
 					`,
 			},
 			expectedErrs: []string{
 				"test.proto:8:49: duplicate symbol BAZ: already defined as enum value; protobuf uses C++ scoping rules for enum values, so they exist in the scope enclosing the enum",
 				"test.proto:10:41: duplicate symbol Bar: already defined as enum",
-				"test.proto:12:49: duplicate symbol Bar.Foo: already defined as method",
-				"test.proto:12:58: method Bar.Foo: unknown request type Frob",
-				"test.proto:12:73: method Bar.Foo: unknown response type Nitz",
+				"test.proto:12:49: duplicate symbol Bar.Foobar: already defined as method",
+				"test.proto:12:61: method Bar.Foobar: unknown request type Frob",
+				"test.proto:12:76: method Bar.Foobar: unknown response type Nitz",
 			},
 		},
 		{

--- a/desc/protoparse/validate_test.go
+++ b/desc/protoparse/validate_test.go
@@ -352,6 +352,10 @@ func TestBasicValidation(t *testing.T) {
 		},
 		{
 			contents: `0.0.0.0.0`,
+			errMsg:   `test.proto:1:1: invalid syntax in float value: 0.0.0.0.0`,
+		},
+		{
+			contents: `0.0`,
 			errMsg:   `test.proto:1:1: syntax error: unexpected float literal`,
 		},
 	}


### PR DESCRIPTION
Addresses #413. The linked issue mentioned three separate problems: two issues were programs that protoparse would accept but protoc would reject; one was the reverse, a case that protoparse rejects but protoc accepts.

They are addressed in three distinct commits on this branch.