### PR TITLE
Make ranges consistent with protoc

### DIFF
--- a/desc/protoparse/descriptor_protos.go
+++ b/desc/protoparse/descriptor_protos.go
@@ -279,7 +279,7 @@ func (r *parseResult) asExtensionRanges(node *ast.ExtensionRangeNode, maxTag int
 	opts := r.asUninterpretedOptions(node.Options.GetElements())
 	ers := make([]*dpb.DescriptorProto_ExtensionRange, len(node.Ranges))
 	for i, rng := range node.Ranges {
-		start, end := getRangeBounds(r, rng, 0, maxTag)
+		start, end := getRangeBounds(r, rng, 1, maxTag)
 		er := &dpb.DescriptorProto_ExtensionRange{
 			Start: proto.Int32(start),
 			End:   proto.Int32(end + 1),
@@ -506,7 +506,7 @@ func isMessageSetWireFormat(res *parseResult, scope string, md *dpb.DescriptorPr
 }
 
 func (r *parseResult) asMessageReservedRange(rng *ast.RangeNode, maxTag int32) *dpb.DescriptorProto_ReservedRange {
-	start, end := getRangeBounds(r, rng, 0, maxTag)
+	start, end := getRangeBounds(r, rng, 1, maxTag)
 	rr := &dpb.DescriptorProto_ReservedRange{
 		Start: proto.Int32(start),
 		End:   proto.Int32(end + 1),

--- a/desc/protoparse/validate_test.go
+++ b/desc/protoparse/validate_test.go
@@ -224,19 +224,27 @@ func TestBasicValidation(t *testing.T) {
 		},
 		{
 			contents: `message Foo { reserved 1 to 5000000000; }`,
-			errMsg:   `test.proto:1:29: range end 5000000000 is out of range: should be between 0 and 536870911`,
+			errMsg:   `test.proto:1:29: range end 5000000000 is out of range: should be between 1 and 536870911`,
+		},
+		{
+			contents: `message Foo { reserved 0 to 5; }`,
+			errMsg:   `test.proto:1:24: range start 0 is out of range: should be between 1 and 536870911`,
 		},
 		{
 			contents: `message Foo { extensions 3000000000; }`,
-			errMsg:   `test.proto:1:26: range start 3000000000 is out of range: should be between 0 and 536870911`,
+			errMsg:   `test.proto:1:26: range start 3000000000 is out of range: should be between 1 and 536870911`,
+		},
+		{
+			contents: `message Foo { extensions 0 to 10; }`,
+			errMsg:   `test.proto:1:26: range start 0 is out of range: should be between 1 and 536870911`,
 		},
 		{
 			contents: `message Foo { extensions 3000000000 to 3000000001; }`,
-			errMsg:   `test.proto:1:26: range start 3000000000 is out of range: should be between 0 and 536870911`,
+			errMsg:   `test.proto:1:26: range start 3000000000 is out of range: should be between 1 and 536870911`,
 		},
 		{
 			contents: `message Foo { extensions 100 to 3000000000; }`,
-			errMsg:   `test.proto:1:33: range end 3000000000 is out of range: should be between 0 and 536870911`,
+			errMsg:   `test.proto:1:33: range end 3000000000 is out of range: should be between 1 and 536870911`,
 		},
 		{
 			contents: `message Foo { reserved "foo", "foo"; }`,

--- a/desc/protoparse/validate_test.go
+++ b/desc/protoparse/validate_test.go
@@ -171,6 +171,10 @@ func TestBasicValidation(t *testing.T) {
 			succeeds: true,
 		},
 		{
+			contents: `syntax = "proto3"; enum Foo { V1 = 0; reserved 1to 20; reserved "V2"; }`,
+			errMsg:   `test.proto:1:49: enum Foo: need space between number and identifier`,
+		},
+		{
 			contents: `enum Foo { V1 = 1; reserved 1 to 20; reserved "V2"; }`,
 			errMsg:   `test.proto:1:17: enum Foo: value V1 is using number 1 which is in reserved range 1 to 20`,
 		},
@@ -203,8 +207,16 @@ func TestBasicValidation(t *testing.T) {
 			errMsg:   `test.proto:1:33: message Foo: reserved ranges overlap: 1 to 10 and 10 to 12`,
 		},
 		{
+			contents: `message Foo { reserved 1to 10; }`,
+			errMsg:   `test.proto:1:25: message Foo: need space between number and identifier`,
+		},
+		{
 			contents: `message Foo { extensions 1 to 10, 10 to 12; }`,
 			errMsg:   `test.proto:1:35: message Foo: extension ranges overlap: 1 to 10 and 10 to 12`,
+		},
+		{
+			contents: `message Foo { extensions 1to 10; }`,
+			errMsg:   `test.proto:1:27: message Foo: need space between number and identifier`,
 		},
 		{
 			contents: `message Foo { reserved 1 to 10; extensions 10 to 12; }`,


### PR DESCRIPTION
This PR contains two fixes to make protoparse more consistent with protoc.

1. The "1to 10" issue described in https://github.com/bufbuild/buf/issues/417.

2. Disallows 0 as a value for "extensions" and "reserved fields" ranges.

For `message Foo { reserved 0 to 10; }` and  `message Foo { extensions 0 to 10; }` protoc errors with "Reserved numbers must be positive integers.", but protoparse allows it. This PR causes protoparsd to return an error like "range start 0 is out of range: should be between 1 and 536870911".