### PR TITLE
protoparse: don't allow options that try to set more than one field in a oneof

### DIFF
--- a/desc/protoparse/linker_test.go
+++ b/desc/protoparse/linker_test.go
@@ -512,6 +512,29 @@ func TestLinkerValidation(t *testing.T) {
 			},
 			"foo.proto:6:30: message Baz: option (foo): field Bar not found",
 		},
+		{
+			map[string]string{
+				"foo.proto": "syntax = \"proto3\";\n" +
+					"import \"google/protobuf/descriptor.proto\";\n" +
+					"message Foo { oneof bar { string baz = 1; string buzz = 2; } }\n" +
+					"extend google.protobuf.MessageOptions { optional Foo foo = 10001; }\n" +
+					"message Baz { option (foo) = { baz: \"abc\" buzz: \"xyz\" }; }\n",
+			},
+			`foo.proto:5:43: message Baz: option (foo): oneof "bar" already has field "baz" set`,
+		},
+		{
+			map[string]string{
+				"foo.proto": "syntax = \"proto3\";\n" +
+					"import \"google/protobuf/descriptor.proto\";\n" +
+					"message Foo { oneof bar { string baz = 1; string buzz = 2; } }\n" +
+					"extend google.protobuf.MessageOptions { optional Foo foo = 10001; }\n" +
+					"message Baz {\n" +
+					"  option (foo).baz = \"abc\";\n" +
+					"  option (foo).buzz = \"xyz\";\n" +
+					"}",
+			},
+			`foo.proto:7:16: message Baz: option (foo).buzz: oneof "bar" already has field "baz" set`,
+		},
 	}
 	for i, tc := range testCases {
 		acc := func(filename string) (io.ReadCloser, error) {

--- a/desc/protoparse/options.go
+++ b/desc/protoparse/options.go
@@ -1165,6 +1165,17 @@ func setOptionField(res *parseResult, mc *messageContext, dm *dynamic.Message, f
 	if err != nil {
 		return err
 	}
+
+	if ood := fld.GetOneOf(); ood != nil {
+		existingFld, _, err := dm.TryGetOneOfField(ood)
+		if err != nil {
+			return errorWithPos(name.Start(), "%verror querying value: %s", mc, err)
+		}
+		if existingFld != nil && existingFld.GetNumber() != fld.GetNumber() {
+			return errorWithPos(name.Start(), "%voneof %q already has field %q set", mc, ood.GetName(), fieldName(existingFld))
+		}
+	}
+
 	if fld.IsRepeated() {
 		err = dm.TryAddRepeatedField(fld, v)
 	} else {


### PR DESCRIPTION
This fixes #430.

_However_, the new behavior will still not perfectly match that of protoc due to a bug in protoc: https://github.com/protocolbuffers/protobuf/issues/9125

With this change, protoparse will reject options that try to set more than one field in a oneof in both scenarios:
  1. when a message is set all at once using a message literal
  2. when a message is set piecemeal, with an option per field

But, until that protobuf issue is resolved, protoc only rejects options in the first scenario. The issue has been accepted and labeled a bug by the protobuf team, so I'm hopeful 🤞. I may even dig into protoc code to see how hard it would be for me to contribute a fix.