### PR TITLE
protoparse: fix another edge case with options and oneofs

### DIFF
--- a/desc/protoparse/linker_test.go
+++ b/desc/protoparse/linker_test.go
@@ -535,6 +535,32 @@ func TestLinkerValidation(t *testing.T) {
 			},
 			`foo.proto:7:16: message Baz: option (foo).buzz: oneof "bar" already has field "baz" set`,
 		},
+		{
+			map[string]string{
+				"foo.proto": "syntax = \"proto3\";\n" +
+					"import \"google/protobuf/descriptor.proto\";\n" +
+					"message Foo { oneof bar { google.protobuf.DescriptorProto baz = 1; google.protobuf.DescriptorProto buzz = 2; } }\n" +
+					"extend google.protobuf.MessageOptions { optional Foo foo = 10001; }\n" +
+					"message Baz {\n" +
+					"  option (foo).baz.name = \"abc\";\n" +
+					"  option (foo).buzz.name = \"xyz\";\n" +
+					"}",
+			},
+			`foo.proto:7:16: message Baz: option (foo).buzz.name: oneof "bar" already has field "baz" set`,
+		},
+		{
+			map[string]string{
+				"foo.proto": "syntax = \"proto3\";\n" +
+					"import \"google/protobuf/descriptor.proto\";\n" +
+					"message Foo { oneof bar { google.protobuf.DescriptorProto baz = 1; google.protobuf.DescriptorProto buzz = 2; } }\n" +
+					"extend google.protobuf.MessageOptions { optional Foo foo = 10001; }\n" +
+					"message Baz {\n" +
+					"  option (foo).baz.options.(foo).baz.name = \"abc\";\n" +
+					"  option (foo).baz.options.(foo).buzz.name = \"xyz\";\n" +
+					"}",
+			},
+			`foo.proto:7:34: message Baz: option (foo).baz.options.(foo).buzz.name: oneof "bar" already has field "baz" set`,
+		},
 	}
 	for i, tc := range testCases {
 		acc := func(filename string) (io.ReadCloser, error) {

--- a/desc/protoparse/options.go
+++ b/desc/protoparse/options.go
@@ -1086,6 +1086,15 @@ func interpretField(res *parseResult, mc *messageContext, element descriptorish,
 			v, err = dm.TryGetField(fld)
 			fdm, _ = v.(*dynamic.Message)
 		} else {
+			if ood := fld.GetOneOf(); ood != nil {
+				existingFld, _, err := dm.TryGetOneOfField(ood)
+				if err != nil {
+					return nil, res.errs.handleErrorWithPos(node.Start(), "%verror querying value: %s", mc, err)
+				}
+				if existingFld != nil && existingFld.GetNumber() != fld.GetNumber() {
+					return nil, res.errs.handleErrorWithPos(node.Start(), "%voneof %q already has field %q set", mc, ood.GetName(), fieldName(existingFld))
+				}
+			}
 			fdm = dynamic.NewMessage(fld.GetMessageType())
 			err = dm.TrySetField(fld, fdm)
 		}


### PR DESCRIPTION
Another fix related to #430.

This is actually another class of oneof mis-use in options that `protoc` fails to validate (see https://github.com/protocolbuffers/protobuf/issues/9125).