### PR TITLE
another fix to parsing numeric literals

### DIFF
--- a/desc/protoparse/lexer.go
+++ b/desc/protoparse/lexer.go
@@ -370,6 +370,14 @@ func (l *protoLex) Lex(lval *protoSymType) int {
 }
 
 func parseFloat(token string) (float64, error) {
+	// strconv.ParseFloat allows _ to separate digits, but protobuf does not
+	if strings.ContainsRune(token, '_') {
+		return 0, &strconv.NumError{
+			Func: "parseFloat",
+			Num:  token,
+			Err:  strconv.ErrSyntax,
+		}
+	}
 	f, err := strconv.ParseFloat(token, 64)
 	if err == nil {
 		return f, nil

--- a/desc/protoparse/lexer_test.go
+++ b/desc/protoparse/lexer_test.go
@@ -247,6 +247,8 @@ func TestLexerErrors(t *testing.T) {
 		{str: `0b0111`, errMsg: "invalid syntax"},
 		{str: `0o765432`, errMsg: "invalid syntax"},
 		{str: `1_000_000`, errMsg: "invalid syntax"},
+		{str: `1_000.000_001e6`, errMsg: "invalid syntax"},
+		{str: `0X1F_FFP-16`, errMsg: "invalid syntax"},
 		{str: `/* foobar`, errMsg: "unexpected EOF"},
 	}
 	for i, tc := range testCases {


### PR DESCRIPTION
In the same vein as #436, this prevents `protoparse` from accepting some quirks that the Go language supports for float literals that protobuf does not.

The `strconv.ParseFloat` function is used to help with parsing numeric literals. However, as of Go 1.13, some features were added to the language and also added to the `strconv` functions. For floats, this included support for hexadecimal float literals and for `_` to be used as a digit separator (for improved readability).

The hex floats were not inadvertently supported in `protoparse` because `ParseUint` is used when a numeric literal starts with `0x`. _But_ the digit separators were inadvertently supported by `protoparse`.

So this change fixes that and also adds test cases to make sure that float literals supported by Go but not by protobuf are not incorrectly also supported by `protoparse`.