### PR TITLE
protoparse: improve handling of control chars; don't let \x00 be confused for EOF

### DIFF
--- a/desc/protoparse/lexer.go
+++ b/desc/protoparse/lexer.go
@@ -360,7 +360,11 @@ func (l *protoLex) Lex(lval *protoSymType) int {
 			l.input.unreadRune(cn)
 		}
 
-		if c > 255 {
+		if c < 32 {
+			l.setError(lval, errors.New("invalid control character"))
+			return _ERROR
+		}
+		if !strings.ContainsRune(";,.:=-+(){}[]<>", c) {
 			l.setError(lval, errors.New("invalid character"))
 			return _ERROR
 		}

--- a/desc/protoparse/lexer.go
+++ b/desc/protoparse/lexer.go
@@ -360,7 +360,7 @@ func (l *protoLex) Lex(lval *protoSymType) int {
 			l.input.unreadRune(cn)
 		}
 
-		if c < 32 {
+		if c < 32 || c == 127 {
 			l.setError(lval, errors.New("invalid control character"))
 			return _ERROR
 		}

--- a/desc/protoparse/lexer_test.go
+++ b/desc/protoparse/lexer_test.go
@@ -250,6 +250,15 @@ func TestLexerErrors(t *testing.T) {
 		{str: `1_000.000_001e6`, errMsg: "invalid syntax"},
 		{str: `0X1F_FFP-16`, errMsg: "invalid syntax"},
 		{str: `/* foobar`, errMsg: "unexpected EOF"},
+		{str: "\x00", errMsg: "invalid control character"},
+		{str: "\x03", errMsg: "invalid control character"},
+		{str: "\x1B", errMsg: "invalid control character"},
+		{str: "\x7F", errMsg: "invalid control character"},
+		{str: "#", errMsg: "invalid character"},
+		{str: "?", errMsg: "invalid character"},
+		{str: "^", errMsg: "invalid character"},
+		{str: "\uAAAA", errMsg: "invalid character"},
+		{str: "\U0010FFFF", errMsg: "invalid character"},
 	}
 	for i, tc := range testCases {
 		l := newTestLexer(strings.NewReader(tc.str))


### PR DESCRIPTION
This should improve error messages, too, for invalid characters in the source whose code point is <= 255. These would end up generating an error in the parser, which might refer to the characters are `$unk` since it doesn't have a known symbol for the returned value.

So now we return an error for _any_ invalid character -- at this point in the lexer, the only other allowed values are operators, so we just enumerate all of the valid operators and have the lexer return an error if anything else is encountered.

Fixes #442