### PR TITLE
forbid 0x00 bytes in comments

### DIFF
--- a/desc/protoparse/lexer_test.go
+++ b/desc/protoparse/lexer_test.go
@@ -259,6 +259,8 @@ func TestLexerErrors(t *testing.T) {
 		{str: "^", errMsg: "invalid character"},
 		{str: "\uAAAA", errMsg: "invalid character"},
 		{str: "\U0010FFFF", errMsg: "invalid character"},
+		{str: "// foo \x00", errMsg: "invalid control character"},
+		{str: "/* foo \x00", errMsg: "invalid control character"},
 	}
 	for i, tc := range testCases {
 		l := newTestLexer(strings.NewReader(tc.str))


### PR DESCRIPTION
fixes #448

This is similar to #447 except it deal with comments and the only character that `protoparse` handles differently from `protoc` in comments is `0x00`