### PR TITLE
protoparse: disallow duplicate oneof names

### DIFF
--- a/desc/protoparse/linker.go
+++ b/desc/protoparse/linker.go
@@ -180,6 +180,11 @@ func addMessageToPool(r *parseResult, pool map[string]proto.Message, errs *error
 		return err
 	}
 	prefix = fqn + "."
+	for _, ood := range md.OneofDecl {
+		if err := addOneofToPool(r, pool, errs, prefix, ood); err != nil {
+			return err
+		}
+	}
 	for _, fld := range md.Field {
 		if err := addFieldToPool(r, pool, errs, prefix, fld); err != nil {
 			return err
@@ -206,6 +211,11 @@ func addMessageToPool(r *parseResult, pool map[string]proto.Message, errs *error
 func addFieldToPool(r *parseResult, pool map[string]proto.Message, errs *errorHandler, prefix string, fld *dpb.FieldDescriptorProto) error {
 	fqn := prefix + fld.GetName()
 	return addToPool(r, pool, errs, fqn, fld)
+}
+
+func addOneofToPool(r *parseResult, pool map[string]proto.Message, errs *errorHandler, prefix string, ood *dpb.OneofDescriptorProto) error {
+	fqn := prefix + ood.GetName()
+	return addToPool(r, pool, errs, fqn, ood)
 }
 
 func addEnumToPool(r *parseResult, pool map[string]proto.Message, errs *errorHandler, prefix string, ed *dpb.EnumDescriptorProto) error {
@@ -281,6 +291,8 @@ func descriptorType(m proto.Message) string {
 		return "method"
 	case *dpb.FileDescriptorProto:
 		return "file"
+	case *dpb.OneofDescriptorProto:
+		return "oneof"
 	default:
 		// shouldn't be possible
 		return fmt.Sprintf("%T", m)

--- a/desc/protoparse/linker_test.go
+++ b/desc/protoparse/linker_test.go
@@ -537,6 +537,35 @@ func TestLinkerValidation(t *testing.T) {
 		},
 		{
 			map[string]string{
+				"a.proto": "syntax = \"proto3\";\n" +
+					"message m{\n" +
+					"  oneof z{\n" +
+					"    int64 z=1;\n" +
+					"  }\n" +
+					"}",
+			},
+			`a.proto:4:5: duplicate symbol m.z: already defined as oneof`,
+		},
+		{
+			map[string]string{
+				"a.proto": "syntax=\"proto3\";\nmessage m{\n" +
+					"  string z = 1;\n" +
+					"  oneof z{int64 b=2;}\n" +
+					"}",
+			},
+			`a.proto:3:3: duplicate symbol m.z: already defined as oneof`,
+		},
+		{
+			map[string]string{
+				"a.proto": "syntax=\"proto3\";\nmessage m{\n" +
+					"  oneof z{int64 a=1;}\n" +
+					"  oneof z{int64 b=2;}\n" +
+					"}",
+			},
+			`a.proto:4:3: duplicate symbol m.z: already defined as oneof`,
+		},
+		{
+			map[string]string{
 				"foo.proto": "syntax = \"proto3\";\n" +
 					"import \"google/protobuf/descriptor.proto\";\n" +
 					"message Foo { oneof bar { google.protobuf.DescriptorProto baz = 1; google.protobuf.DescriptorProto buzz = 2; } }\n" +


### PR DESCRIPTION
fixes #454

This makes ParseFiles error on duplicate oneof names.

Here's the examples from #454 with protoparse error messages:

```protobuf
syntax = "proto3";
message m{
  oneof z{
    int64 z=1;
  }
}

// protoc error:
// a.proto:4:11: "z" is already defined in "m".

// protoparse error:
// a.proto:4:5: duplicate symbol m.z: already defined as oneof
```

```proto
syntax="proto3";
message m{
  string z = 1;
  oneof z{int64 b=2;}
}

// protoc error:
// a.proto:3:10: "z" is already defined in "m".

// protoparse error:
// a.proto:3:3: duplicate symbol m.z: already defined as oneof

```

```proto
syntax="proto3";
message m{
  oneof z{int64 a=1;}
  oneof z{int64 b=2;}
}

// protoc error:
// a.proto: "z" is already defined in "m".

// protoparse error:
// a.proto:4:3: duplicate symbol m.z: already defined as oneof
```