### PR TITLE
protoparse: Treat all numbers starting with 0 as octal

### DIFF
--- a/desc/protoparse/lexer.go
+++ b/desc/protoparse/lexer.go
@@ -289,7 +289,7 @@ func (l *protoLex) Lex(lval *protoSymType) int {
 			}
 			// integer! (decimal or octal)
 			base := 10
-			if token[0] == '0' && len(token) > 1 && token[1] >= '0' && token[1] <= '7' {
+			if token[0] == '0' {
 				base = 8
 			}
 			ui, err := strconv.ParseUint(token, base, 64)

--- a/desc/protoparse/lexer_test.go
+++ b/desc/protoparse/lexer_test.go
@@ -261,6 +261,8 @@ func TestLexerErrors(t *testing.T) {
 		{str: "\U0010FFFF", errMsg: "invalid character"},
 		{str: "// foo \x00", errMsg: "invalid control character"},
 		{str: "/* foo \x00", errMsg: "invalid control character"},
+		{str: "09", errMsg: "invalid syntax in octal integer value: 09"},
+		{str: "0f", errMsg: "invalid syntax in octal integer value: 0f"},
 	}
 	for i, tc := range testCases {
 		l := newTestLexer(strings.NewReader(tc.str))


### PR DESCRIPTION
fixes #458

```protobuf
syntax="proto3";
message o {
  bool f=09;
}

// protoc error:
// a.proto:3:11: Numbers starting with leading zero must be in octal.
// a.proto:3:10: Integer out of range.

// protoparse error:
// a.proto:3:9: invalid syntax in octal integer value: 09
```