### PR TITLE
Fix make generate on darwin/arm64

### DIFF
--- a/internal/testprotos/make_protos.sh
+++ b/internal/testprotos/make_protos.sh
@@ -15,6 +15,12 @@ case "${PROTOC_OS}" in
     exit 1
 esac
 
+# This is for macs with M1 chips. Precompiled binaries for osx/amd64 are not available for download, so for that case
+# we download the x86_64 version instead. This will work as long as rosetta2 is installed.
+if [ "$PROTOC_OS" = "osx" ] && [ "$PROTOC_ARCH" = "arm64" ]; then
+  PROTOC_ARCH="x86_64"
+fi
+
 PROTOC="./protoc/bin/protoc"
 
 if [[ "$(${PROTOC} --version 2>/dev/null)" != "libprotoc ${PROTOC_VERSION}" ]]; then


### PR DESCRIPTION
fixes #460

This is a hack that makes darwin/arm64 systems download the darwin/amd64 file. This works as long as the system has rosetta2 installed. I assume just about every developer will already have rosetta2 installed.