### PR TITLE
Report errs via linker rather than parseResult

### DIFF
--- a/desc/protoparse/linker.go
+++ b/desc/protoparse/linker.go
@@ -930,7 +930,7 @@ func (l *linker) checkForUnusedImports(filename string) {
 			if pos == nil {
 				pos = ast.UnknownPos(r.fd.GetName())
 			}
-			r.errs.warn(pos, errUnusedImport(dep))
+			l.errs.warn(pos, errUnusedImport(dep))
 		}
 	}
 }


### PR DESCRIPTION
Prevents a panic when dealing with unused well-known types