### PR TITLE
protoparse: fix panic in linker

### DIFF
--- a/desc/protoparse/linker.go
+++ b/desc/protoparse/linker.go
@@ -145,7 +145,7 @@ func (l *linker) createDescriptorPool() error {
 					file1, file2 = file2, file1
 					desc1, desc2 = desc2, desc1
 				}
-				node := l.files[file2].nodes[desc2]
+				node := l.files[file2].getNode(desc2)
 				if err := l.errs.handleErrorWithPos(node.Start(), "duplicate symbol %s: already defined as %s in %q", k, descriptorType(desc1), file1); err != nil {
 					return err
 				}

--- a/desc/protoparse/linker_test.go
+++ b/desc/protoparse/linker_test.go
@@ -156,6 +156,17 @@ func TestLinkerValidation(t *testing.T) {
 		},
 		{
 			map[string]string{
+				"foo.proto": `
+					syntax = "proto3";
+					import "google/protobuf/descriptor.proto";
+					package google.protobuf;
+					message DescriptorProto { }
+				`,
+			},
+			`google/protobuf/descriptor.proto: duplicate symbol google.protobuf.DescriptorProto: already defined as message in "foo.proto"`,
+		},
+		{
+			map[string]string{
 				"foo.proto": "package fu.baz; extend foobar { optional string a = 1; }",
 			},
 			"foo.proto:1:24: unknown extendee type foobar",

--- a/desc/protoparse/parser.go
+++ b/desc/protoparse/parser.go
@@ -706,6 +706,13 @@ func (r *parseResult) getMethodNode(m *dpb.MethodDescriptorProto) ast.RPCDeclNod
 	return r.nodes[m].(ast.RPCDeclNode)
 }
 
+func (r *parseResult) getNode(m proto.Message) ast.Node {
+	if r.nodes == nil {
+		return ast.NewNoSourceNode(r.fd.GetName())
+	}
+	return r.nodes[m]
+}
+
 func (r *parseResult) putFileNode(f *dpb.FileDescriptorProto, n *ast.FileNode) {
 	r.nodes[f] = n
 }


### PR DESCRIPTION
This can occur if there is a symbol collision between a file that has an AST (e.g. one that was parsed from source) and one that does not (e.g. a "well-known" import that was supplied as a descriptor).

The added test case reproduces the panic described in #476. And the small patch (to use `getNode` function, which handles the case when file has no AST nodes) resolves it.