### PR TITLE
fix octal escapes in object keys at MarshalJSONPB

### DIFF
--- a/dynamic/json.go
+++ b/dynamic/json.go
@@ -368,7 +368,7 @@ func marshalKnownFieldMapEntryJSON(b *indentBuffer, mk interface{}, vfd *desc.Fi
 	default:
 		return fmt.Errorf("invalid map key value: %v (%v)", mk, rk.Type())
 	}
-	err := writeString(b, strkey)
+	err := writeJsonString(b, strkey)
 	if err != nil {
 		return err
 	}

--- a/dynamic/marshal_test.go
+++ b/dynamic/marshal_test.go
@@ -155,7 +155,7 @@ var mapKeyFieldsMsg = &testprotos.MapKeyFields{
 	P: map[uint64]string{22: "foo", 23: "bar", 24: "baz"},
 	Q: map[int32]string{25: "foo", 26: "bar", 27: "baz"},
 	R: map[int64]string{28: "foo", 29: "bar", 30: "baz"},
-	S: map[string]string{"a": "foo", "b": "bar", "c": "baz"},
+	S: map[string]string{"a": "foo", "b": "bar", "❤": "baz"},
 	T: map[bool]string{true: "foo", false: "bar"},
 }
 


### PR DESCRIPTION
fix of https://github.com/jhump/protoreflect/issues/480