### PR TITLE
grpcreflect: handle case where server sends back multiple files

### DIFF
--- a/grpcreflect/client.go
+++ b/grpcreflect/client.go
@@ -159,7 +159,11 @@ func (cr *Client) FileByFilename(filename string) (*desc.FileDescriptor, error) 
 			FileByFilename: filename,
 		},
 	}
-	fd, err := cr.getAndCacheFileDescriptors(req, filename, "")
+	accept := func(fd *desc.FileDescriptor) bool {
+		return fd.GetName() == filename
+	}
+
+	fd, err := cr.getAndCacheFileDescriptors(req, filename, "", accept)
 	if isNotFound(err) {
 		// file not found? see if we can look up via alternate name
 		if alternate, ok := internal.StdFileAliases[filename]; ok {
@@ -168,7 +172,7 @@ func (cr *Client) FileByFilename(filename string) (*desc.FileDescriptor, error) 
 					FileByFilename: alternate,
 				},
 			}
-			fd, err = cr.getAndCacheFileDescriptors(req, alternate, filename)
+			fd, err = cr.getAndCacheFileDescriptors(req, alternate, filename, accept)
 			if isNotFound(err) {
 				err = fileNotFound(filename, nil)
 			}
@@ -197,7 +201,10 @@ func (cr *Client) FileContainingSymbol(symbol string) (*desc.FileDescriptor, err
 			FileContainingSymbol: symbol,
 		},
 	}
-	fd, err := cr.getAndCacheFileDescriptors(req, "", "")
+	accept := func(fd *desc.FileDescriptor) bool {
+		return fd.FindSymbol(symbol) != nil
+	}
+	fd, err := cr.getAndCacheFileDescriptors(req, "", "", accept)
 	if isNotFound(err) {
 		err = symbolNotFound(symbol, symbolTypeUnknown, nil)
 	} else if e, ok := err.(*elementNotFoundError); ok {
@@ -226,7 +233,10 @@ func (cr *Client) FileContainingExtension(extendedMessageName string, extensionN
 			},
 		},
 	}
-	fd, err := cr.getAndCacheFileDescriptors(req, "", "")
+	accept := func(fd *desc.FileDescriptor) bool {
+		return fd.FindExtension(extendedMessageName, extensionNumber) != nil
+	}
+	fd, err := cr.getAndCacheFileDescriptors(req, "", "", accept)
 	if isNotFound(err) {
 		err = extensionNotFound(extendedMessageName, extensionNumber, nil)
 	} else if e, ok := err.(*elementNotFoundError); ok {
@@ -235,7 +245,7 @@ func (cr *Client) FileContainingExtension(extendedMessageName string, extensionN
 	return fd, err
 }
 
-func (cr *Client) getAndCacheFileDescriptors(req *rpb.ServerReflectionRequest, expectedName, alias string) (*desc.FileDescriptor, error) {
+func (cr *Client) getAndCacheFileDescriptors(req *rpb.ServerReflectionRequest, expectedName, alias string, accept func(*desc.FileDescriptor) bool) (*desc.FileDescriptor, error) {
 	resp, err := cr.send(req)
 	if err != nil {
 		return nil, err
@@ -253,7 +263,8 @@ func (cr *Client) getAndCacheFileDescriptors(req *rpb.ServerReflectionRequest, e
 	// should be the answer). If we're looking for a file by name, we can be
 	// smarter and make sure to grab one by name instead of just grabbing the
 	// first one.
-	var firstFd *dpb.FileDescriptorProto
+	var fds []*dpb.FileDescriptorProto
+	var result *desc.FileDescriptor
 	for _, fdBytes := range fdResp.FileDescriptorProto {
 		fd := &dpb.FileDescriptorProto{}
 		if err = proto.Unmarshal(fdBytes, fd); err != nil {
@@ -267,10 +278,9 @@ func (cr *Client) getAndCacheFileDescriptors(req *rpb.ServerReflectionRequest, e
 
 		cr.cacheMu.Lock()
 		// see if this file was created and cached concurrently
-		if firstFd == nil {
+		if result == nil {
 			if d, ok := cr.filesByName[fd.GetName()]; ok {
-				cr.cacheMu.Unlock()
-				return d, nil
+				result = d
 			}
 		}
 		// store in cache of raw descriptor protos, but don't overwrite existing protos
@@ -280,15 +290,26 @@ func (cr *Client) getAndCacheFileDescriptors(req *rpb.ServerReflectionRequest, e
 			cr.protosByName[fd.GetName()] = fd
 		}
 		cr.cacheMu.Unlock()
-		if firstFd == nil {
-			firstFd = fd
-		}
-	}
-	if firstFd == nil {
-		return nil, &ProtocolError{reflect.TypeOf(firstFd).Elem()}
+
+		fds = append(fds, fd)
 	}
 
-	return cr.descriptorFromProto(firstFd)
+	if result != nil {
+		return result, nil
+	}
+
+	// find the right result from the files returned
+	for _, fd := range fds {
+		result, err := cr.descriptorFromProto(fd)
+		if err != nil {
+			return nil, err
+		}
+		if accept(result) {
+			return result, nil
+		}
+	}
+
+	return nil, status.Errorf(codes.NotFound, "response does not include expected file")
 }
 
 func (cr *Client) descriptorFromProto(fd *dpb.FileDescriptorProto) (*desc.FileDescriptor, error) {

--- a/grpcreflect/client_test.go
+++ b/grpcreflect/client_test.go
@@ -265,8 +265,8 @@ func TestMultipleFiles(t *testing.T) {
 		svr.Stop()
 	}()
 
-	dialCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
-	defer cancel()
+	dialCtx, dialCancel := context.WithTimeout(ctx, 3*time.Second)
+	defer dialCancel()
 	cc, err := grpc.DialContext(dialCtx, l.Addr().String(), grpc.WithInsecure(), grpc.WithBlock())
 	testutil.Ok(t, err, "failed ot dial %v", l.Addr().String())
 	cl := rpb.NewServerReflectionClient(cc)


### PR DESCRIPTION
This was previously assuming that, when the server sent back multiple files in response to a request for file descriptors, that the first file was the actual one requested and the rest might include its transitive dependencies.

However, the order of the returned files is not actually specified in the proto that defines the server reflection interface. So, for robustness, the client needs to be smarter about how to pick the right file.

Fixes #466.