### PR TITLE
use grpc.ClientConnInterface and reflection.GRPCServer interfaces

### DIFF
--- a/dynamic/grpcdynamic/stub.go
+++ b/dynamic/grpcdynamic/stub.go
@@ -27,12 +27,7 @@ type Stub struct {
 // type used to construct Stubs. But the use of this interface allows
 // construction of stubs that use alternate concrete types as the transport for
 // RPC operations.
-type Channel interface {
-	Invoke(ctx context.Context, method string, args, reply interface{}, opts ...grpc.CallOption) error
-	NewStream(ctx context.Context, desc *grpc.StreamDesc, method string, opts ...grpc.CallOption) (grpc.ClientStream, error)
-}
-
-var _ Channel = (*grpc.ClientConn)(nil)
+type Channel = grpc.ClientConnInterface
 
 // NewStub creates a new RPC stub that uses the given channel for dispatching RPCs.
 func NewStub(channel Channel) Stub {

--- a/grpcreflect/server.go
+++ b/grpcreflect/server.go
@@ -4,13 +4,19 @@ import (
 	"fmt"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
 
 	"github.com/jhump/protoreflect/desc"
 )
 
+// GRPCServer is the interface provided by a gRPC server. In addition to being a
+// service registrar (for registering services and handlers), it also has an
+// accessor for retrieving metadata about all registered services.
+type GRPCServer = reflection.GRPCServer
+
 // LoadServiceDescriptors loads the service descriptors for all services exposed by the
 // given GRPC server.
-func LoadServiceDescriptors(s *grpc.Server) (map[string]*desc.ServiceDescriptor, error) {
+func LoadServiceDescriptors(s GRPCServer) (map[string]*desc.ServiceDescriptor, error) {
 	descs := map[string]*desc.ServiceDescriptor{}
 	for name, info := range s.GetServiceInfo() {
 		file, ok := info.Metadata.(string)

--- a/grpcreflect/server_test.go
+++ b/grpcreflect/server_test.go
@@ -37,3 +37,24 @@ func TestLoadServiceDescriptors(t *testing.T) {
 		testutil.Eq(t, c.response, md.GetOutputType().GetFullyQualifiedName())
 	}
 }
+
+func TestLoadServiceDescriptor(t *testing.T) {
+	sd, err := LoadServiceDescriptor(testprotos.TestService_ServiceDesc)
+	testutil.Ok(t, err)
+
+	cases := []struct{ method, request, response string }{
+		{"DoSomething", "testprotos.TestRequest", "jhump.protoreflect.desc.Bar"},
+		{"DoSomethingElse", "testprotos.TestMessage", "testprotos.TestResponse"},
+		{"DoSomethingAgain", "jhump.protoreflect.desc.Bar", "testprotos.AnotherTestMessage"},
+		{"DoSomethingForever", "testprotos.TestRequest", "testprotos.TestResponse"},
+	}
+
+	testutil.Eq(t, len(cases), len(sd.GetMethods()))
+
+	for i, c := range cases {
+		md := sd.GetMethods()[i]
+		testutil.Eq(t, c.method, md.GetName())
+		testutil.Eq(t, c.request, md.GetInputType().GetFullyQualifiedName())
+		testutil.Eq(t, c.response, md.GetOutputType().GetFullyQualifiedName())
+	}
+}

--- a/internal/testprotos/gen.go
+++ b/internal/testprotos/gen.go
@@ -1,3 +1,5 @@
 package testprotos
 
 //go:generate ./make_protos.sh
+
+var TestService_ServiceDesc = &_TestService_serviceDesc


### PR DESCRIPTION
Use interfaces defined in the grpc-go repo. This eliminates the redundant definition of the method set for `grpcdynamic.Channel`. It also updates the `grpcreflect.LoadServiceDescriptors` function to support values other than a `*grpc.Server` that support the necessary methods. Finally, it adds a missing test for the `grpcreflect.LoadServiceDescriptor` function.