### PR TITLE
Printer fields to control expanding short options and message literals to multi-line

### DIFF
--- a/desc/protoprint/print.go
+++ b/desc/protoprint/print.go
@@ -139,6 +139,31 @@ type Printer struct {
 	// When printing fully-qualified names, they will be preceded by a dot, to
 	// avoid any ambiguity that they might be relative vs. fully-qualified.
 	ForceFullyQualifiedNames bool
+
+	// The number of options that trigger short options expressions to be
+	// rendered using multiple lines. Short options expressions are those
+	// found on fields and enum values, that use brackets ("[" and "]") and
+	// comma-separated options. If more options than this are present, they
+	// will be expanded to multiple lines (one option per line).
+	//
+	// If unset (e.g. if zero), a default threshold of 3 is used.
+	ShortOptionsExpansionThresholdCount int
+
+	// The length of printed options that trigger short options expressions to
+	// be rendered using multiple lines. If the short options contain more than
+	// one option and their printed length is longer than this threshold, they
+	// will be expanded to multiple lines (one option per line).
+	//
+	// If unset (e.g. if zero), a default threshold of 50 is used.
+	ShortOptionsExpansionThresholdLength int
+
+	// The length of a printed option value message literal that triggers the
+	// message literal to be rendered using multiple lines instead of using a
+	// compact single-line form. The message must include at least two fields
+	// or contain a field that is a nested message to be expanded.
+	//
+	// If unset (e.g. if zero), a default threshold of 50 is used.
+	MessageLiteralExpansionThresholdLength int
 }
 
 // CommentType is a kind of comments in a proto source file. This can be used
@@ -990,10 +1015,7 @@ func (p *Printer) printField(fld *desc.FieldDescriptor, mf *dynamic.MessageFacto
 			opts[-internal.Field_jsonNameTag] = []option{{name: "json_name", val: jsn}}
 		}
 
-		elements := elementAddrs{dsc: fld, opts: opts}
-		elements.addrs = optionsAsElementAddrs(internal.Field_optionsTag, 0, opts)
-		p.sort(elements, sourceInfo, path)
-		p.printOptionElementsShort(elements, w, sourceInfo, path, indent)
+		p.printOptionsShort(fld, opts, internal.Field_optionsTag, w, sourceInfo, path, indent)
 
 		if group {
 			fmt.Fprintln(w, "{")
@@ -1161,7 +1183,7 @@ func (p *Printer) printExtensionRanges(parent *desc.MessageDescriptor, ranges []
 		})
 	}
 	dsc := extensionRange{owner: parent, extRange: ranges[0]}
-	p.printOptionsShort(dsc, opts, mf, internal.ExtensionRange_optionsTag, w, sourceInfo, elPath, indent)
+	p.extractAndPrintOptionsShort(dsc, opts, mf, internal.ExtensionRange_optionsTag, w, sourceInfo, elPath, indent)
 
 	fmt.Fprintln(w, ";")
 }
@@ -1319,7 +1341,7 @@ func (p *Printer) printEnumValue(evd *desc.EnumValueDescriptor, mf *dynamic.Mess
 		numSi := sourceInfo.Get(append(path, internal.EnumVal_numberTag))
 		p.printElementString(numSi, w, indent, fmt.Sprintf("%d", evd.GetNumber()))
 
-		p.printOptionsShort(evd, evd.GetOptions(), mf, internal.EnumVal_optionsTag, w, sourceInfo, path, indent)
+		p.extractAndPrintOptionsShort(evd, evd.GetOptions(), mf, internal.EnumVal_optionsTag, w, sourceInfo, path, indent)
 
 		fmt.Fprint(w, ";")
 	})
@@ -1441,15 +1463,16 @@ func (p *Printer) printOptionsLong(opts []option, w *writer, sourceInfo internal
 		func(i int32) *descriptor.SourceCodeInfo_Location {
 			return sourceInfo.Get(append(path, i))
 		},
-		func(w *writer, indent int, opt option) {
+		func(w *writer, indent int, opt option, _ bool) {
 			p.indent(w, indent)
 			fmt.Fprint(w, "option ")
 			p.printOption(opt.name, opt.val, w, indent)
 			fmt.Fprint(w, ";")
-		})
+		},
+		false)
 }
 
-func (p *Printer) printOptionsShort(dsc interface{}, optsMsg proto.Message, mf *dynamic.MessageFactory, optsTag int32, w *writer, sourceInfo internal.SourceInfoMap, path []int32, indent int) {
+func (p *Printer) extractAndPrintOptionsShort(dsc interface{}, optsMsg proto.Message, mf *dynamic.MessageFactory, optsTag int32, w *writer, sourceInfo internal.SourceInfoMap, path []int32, indent int) {
 	d, ok := dsc.(desc.Descriptor)
 	if !ok {
 		d = dsc.(extensionRange).owner
@@ -1461,20 +1484,64 @@ func (p *Printer) printOptionsShort(dsc interface{}, optsMsg proto.Message, mf *
 		}
 		return
 	}
-
-	elements := elementAddrs{dsc: dsc, opts: opts}
-	elements.addrs = optionsAsElementAddrs(optsTag, 0, opts)
-	p.sort(elements, sourceInfo, path)
-	p.printOptionElementsShort(elements, w, sourceInfo, path, indent)
+	p.printOptionsShort(dsc, opts, optsTag, w, sourceInfo, path, indent)
 }
 
-func (p *Printer) printOptionElementsShort(addrs elementAddrs, w *writer, sourceInfo internal.SourceInfoMap, path []int32, indent int) {
-	if len(addrs.addrs) == 0 {
+func (p *Printer) printOptionsShort(dsc interface{}, opts map[int32][]option, optsTag int32, w *writer, sourceInfo internal.SourceInfoMap, path []int32, indent int) {
+	elements := elementAddrs{dsc: dsc, opts: opts}
+	elements.addrs = optionsAsElementAddrs(optsTag, 0, opts)
+	if len(elements.addrs) == 0 {
 		return
 	}
-	first := true
-	fmt.Fprint(w, "[")
-	for _, addr := range addrs.addrs {
+	p.sort(elements, sourceInfo, path)
+
+	// we render expanded form if there are many options
+	count := 0
+	for _, addr := range elements.addrs {
+		opts := elements.at(addr).([]option)
+		count += len(opts)
+	}
+	threshold := p.ShortOptionsExpansionThresholdCount
+	if threshold <= 0 {
+		threshold = 3
+	}
+
+	if count > threshold {
+		p.printOptionElementsShort(elements, w, sourceInfo, path, indent, true)
+	} else {
+		var tmp bytes.Buffer
+		tmpW := *w
+		tmpW.Writer = &tmp
+		p.printOptionElementsShort(elements, &tmpW, sourceInfo, path, indent, false)
+		threshold := p.ShortOptionsExpansionThresholdLength
+		if threshold <= 0 {
+			threshold = 50
+		}
+		// we subtract 3 so we don't consider the leading " [" and trailing "]"
+		if tmp.Len()-3 > threshold {
+			p.printOptionElementsShort(elements, w, sourceInfo, path, indent, true)
+		} else {
+			// not too long: commit what we rendered
+			b := tmp.Bytes()
+			if w.space && len(b) > 0 && b[0] == ' ' {
+				// don't write extra space
+				b = b[1:]
+			}
+			w.Write(b)
+			w.newline = tmpW.newline
+			w.space = tmpW.space
+		}
+	}
+}
+
+func (p *Printer) printOptionElementsShort(addrs elementAddrs, w *writer, sourceInfo internal.SourceInfoMap, path []int32, indent int, expand bool) {
+	if expand {
+		fmt.Fprintln(w, "[")
+		indent++
+	} else {
+		fmt.Fprint(w, "[")
+	}
+	for i, addr := range addrs.addrs {
 		opts := addrs.at(addr).([]option)
 		var childPath []int32
 		if addr.elementIndex < 0 {
@@ -1483,7 +1550,11 @@ func (p *Printer) printOptionElementsShort(addrs elementAddrs, w *writer, source
 		} else {
 			childPath = append(path, addr.elementType, int32(addr.elementIndex))
 		}
-		p.printOptions(opts, w, inline(indent),
+		optIndent := indent
+		if !expand {
+			optIndent = inline(indent)
+		}
+		p.printOptions(opts, w, optIndent,
 			func(i int32) *descriptor.SourceCodeInfo_Location {
 				p := childPath
 				if addr.elementIndex >= 0 {
@@ -1491,24 +1562,36 @@ func (p *Printer) printOptionElementsShort(addrs elementAddrs, w *writer, source
 				}
 				return sourceInfo.Get(p)
 			},
-			func(w *writer, indent int, opt option) {
-				if first {
-					first = false
-				} else {
-					fmt.Fprint(w, ", ")
+			func(w *writer, indent int, opt option, more bool) {
+				if expand {
+					p.indent(w, indent)
 				}
 				p.printOption(opt.name, opt.val, w, indent)
-				fmt.Fprint(w, " ") // trailing space
-			})
+				if more {
+					if expand {
+						fmt.Fprintln(w, ",")
+					} else {
+						fmt.Fprint(w, ", ")
+					}
+				}
+			},
+			i < len(addrs.addrs)-1)
+	}
+	if expand {
+		p.indent(w, indent-1)
 	}
 	fmt.Fprint(w, "] ")
 }
 
-func (p *Printer) printOptions(opts []option, w *writer, indent int, siFetch func(i int32) *descriptor.SourceCodeInfo_Location, fn func(w *writer, indent int, opt option)) {
+func (p *Printer) printOptions(opts []option, w *writer, indent int, siFetch func(i int32) *descriptor.SourceCodeInfo_Location, fn func(w *writer, indent int, opt option, more bool), haveMore bool) {
 	for i, opt := range opts {
+		more := haveMore
+		if !more {
+			more = i < len(opts)-1
+		}
 		si := siFetch(int32(i))
 		p.printElement(false, si, w, indent, func(w *writer) {
-			fn(w, indent, opt)
+			fn(w, indent, opt, more)
 		})
 	}
 }
@@ -1581,15 +1664,68 @@ func (p *Printer) printOption(name string, optVal interface{}, w *writer, indent
 	case *desc.EnumValueDescriptor:
 		fmt.Fprintf(w, "%s", optVal.GetName())
 	case proto.Message:
-		// TODO: if value is too long, marshal to text format with indentation to
-		// make output prettier (also requires correctly indenting subsequent lines)
-
 		// TODO: alternate approach so we can apply p.ForceFullyQualifiedNames
 		// inside the resulting value?
 
-		fmt.Fprintf(w, "{ %s }", proto.CompactTextString(optVal))
+		if indent < 0 {
+			// if printing inline, always use compact form
+			fmt.Fprintf(w, "{ %s }", proto.CompactTextString(optVal))
+			return
+		}
+		m := proto.TextMarshaler{
+			Compact:   true,
+			ExpandAny: true,
+		}
+		str := m.Text(optVal)
+		fieldCount := strings.Count(str, ":")
+		nestedCount := strings.Count(str, "{") + strings.Count(str, "<")
+		if fieldCount <= 1 && nestedCount == 0 {
+			// can't expand
+			fmt.Fprintf(w, "{ %s }", str)
+			return
+		}
+		threshold := p.MessageLiteralExpansionThresholdLength
+		if threshold == 0 {
+			threshold = 50
+		}
+		if len(str) <= threshold {
+			// no need to expand
+			fmt.Fprintf(w, "{ %s }", str)
+			return
+		}
+
+		// multi-line form
+		m.Compact = false
+		str = m.Text(optVal)
+		fmt.Fprintln(w, "{")
+		p.indentMessageLiteral(w, indent+1, str)
+		p.indent(w, indent)
+		fmt.Fprint(w, "}")
 	default:
 		panic(fmt.Sprintf("unknown type of value %T for field %s", optVal, name))
+	}
+}
+
+func (p *Printer) indentMessageLiteral(w *writer, indent int, val string) {
+	lines := strings.Split(val, "\n")
+	for _, l := range lines {
+		if l == "" {
+			continue
+		}
+		if p.Indent != "  " {
+			var prefix int
+			for i := 0; i < len(l); i++ {
+				if l[i] != ' ' {
+					prefix = i
+					break
+				}
+			}
+			// replace text marshaller indent (2 spaces) with p.Indent
+			prefixStr := strings.ReplaceAll(l[:prefix], "  ", p.Indent)
+			l = prefixStr + l[prefix:]
+		}
+		p.indent(w, indent)
+		fmt.Fprintln(w, l)
 	}
 }
 
@@ -2433,7 +2569,7 @@ func (w *writer) Write(p []byte) (int, error) {
 	if w.space {
 		// skip any trailing space if the following
 		// character is semicolon, comma, or close bracket
-		if p[0] != ';' && p[0] != ',' && p[0] != ']' {
+		if p[0] != ';' && p[0] != ',' {
 			_, err := w.Writer.Write([]byte{' '})
 			if err != nil {
 				w.err = err

--- a/desc/protoprint/print_test.go
+++ b/desc/protoprint/print_test.go
@@ -62,7 +62,7 @@ func reverseByName(a, b Element) bool {
 func TestPrinter(t *testing.T) {
 	prs := map[string]*Printer{
 		"default":                             {},
-		"compact":                             {Compact: true},
+		"compact":                             {Compact: true, ShortOptionsExpansionThresholdCount: 5, ShortOptionsExpansionThresholdLength: 100, MessageLiteralExpansionThresholdLength: 80},
 		"no-trailing-comments":                {OmitComments: CommentsTrailing},
 		"trailing-on-next-line":               {TrailingCommentsOnSeparateLine: true},
 		"only-doc-comments":                   {OmitComments: CommentsNonDoc},

--- a/desc/protoprint/testfiles/desc_test_comments-custom-sort.proto
+++ b/desc/protoprint/testfiles/desc_test_comments-custom-sort.proto
@@ -55,7 +55,10 @@ message Request {
 
   reserved 30 to 50, 10 to 20;
 
-  extensions 201 to 250 [(testprotos.exfubarb) = "\000\001\002\003\004\005\006\007", (testprotos.exfubar) = "splat!"];
+  extensions 201 to 250 [
+    (testprotos.exfubarb) = "\000\001\002\003\004\005\006\007",
+    (testprotos.exfubar) = "splat!"
+  ];
 
   extensions 100 to 200;
 
@@ -72,11 +75,17 @@ message Request {
 
     PEACH = 3;
 
-    MARIO = 1 [(testprotos.evfubars) = -314, (testprotos.evfubar) = 278];
+    MARIO = 1 [
+      (testprotos.evfubars) = -314,
+      (testprotos.evfubar) = 278
+    ];
 
     MAGIKOOPA = 8;
 
-    LUIGI = 2 [(testprotos.evfubaruf) = 100, (testprotos.evfubaru) = 200];
+    LUIGI = 2 [
+      (testprotos.evfubaruf) = 100,
+      (testprotos.evfubaru) = 200
+    ];
 
     KAMEK = 8;
 
@@ -124,7 +133,12 @@ message Request {
   optional string name = 2 [default = "fubar"];
 
   // A field comment
-  repeated int32 ids = 1 [(testprotos.ffubarb) = "xyz", (testprotos.ffubar) = "abc", packed = true, json_name = "|foo|"]; // field trailer #1...
+  repeated int32 ids = 1 [
+    (testprotos.ffubarb) = "xyz",
+    (testprotos.ffubar) = "abc",
+    packed = true,
+    json_name = "|foo|"
+  ]; // field trailer #1...
 
   // Group comment
   optional group Extras = 3 {

--- a/desc/protoprint/testfiles/desc_test_comments-default.proto
+++ b/desc/protoprint/testfiles/desc_test_comments-default.proto
@@ -25,7 +25,12 @@ message Request {
   option deprecated = true; // deprecated!
 
   // A field comment
-  repeated int32 ids = 1 [packed = true, json_name = "|foo|", (testprotos.ffubar) = "abc", (testprotos.ffubarb) = "xyz"]; // field trailer #1...
+  repeated int32 ids = 1 [
+    packed = true,
+    json_name = "|foo|",
+    (testprotos.ffubar) = "abc",
+    (testprotos.ffubarb) = "xyz"
+  ]; // field trailer #1...
 
   // lead mfubar
   option (testprotos.mfubar) = true; // trailing mfubar
@@ -41,7 +46,10 @@ message Request {
 
   extensions 100 to 200;
 
-  extensions 201 to 250 [(testprotos.exfubarb) = "\000\001\002\003\004\005\006\007", (testprotos.exfubar) = "splat!"];
+  extensions 201 to 250 [
+    (testprotos.exfubarb) = "\000\001\002\003\004\005\006\007",
+    (testprotos.exfubar) = "splat!"
+  ];
 
   reserved 10 to 20, 30 to 50;
 
@@ -70,9 +78,15 @@ message Request {
     // allow_alias comments!
     option allow_alias = true;
 
-    MARIO = 1 [(testprotos.evfubars) = -314, (testprotos.evfubar) = 278];
+    MARIO = 1 [
+      (testprotos.evfubars) = -314,
+      (testprotos.evfubar) = 278
+    ];
 
-    LUIGI = 2 [(testprotos.evfubaruf) = 100, (testprotos.evfubaru) = 200];
+    LUIGI = 2 [
+      (testprotos.evfubaruf) = 100,
+      (testprotos.evfubaru) = 200
+    ];
 
     PEACH = 3;
 

--- a/desc/protoprint/testfiles/desc_test_comments-multiline-style-comments.proto
+++ b/desc/protoprint/testfiles/desc_test_comments-multiline-style-comments.proto
@@ -27,7 +27,12 @@ message Request {
 	option deprecated = true; /* deprecated! */
 
 	/* A field comment */
-	repeated int32 ids = 1 [packed = true, json_name = "|foo|", (testprotos.ffubar) = "abc", (testprotos.ffubarb) = "xyz"]; /* field trailer #1... */
+	repeated int32 ids = 1 [
+		packed = true,
+		json_name = "|foo|",
+		(testprotos.ffubar) = "abc",
+		(testprotos.ffubarb) = "xyz"
+	]; /* field trailer #1... */
 
 	/* lead mfubar */
 	option (testprotos.mfubar) = true; /* trailing mfubar */
@@ -43,7 +48,10 @@ message Request {
 
 	extensions 100 to 200;
 
-	extensions 201 to 250 [(testprotos.exfubarb) = "\000\001\002\003\004\005\006\007", (testprotos.exfubar) = "splat!"];
+	extensions 201 to 250 [
+		(testprotos.exfubarb) = "\000\001\002\003\004\005\006\007",
+		(testprotos.exfubar) = "splat!"
+	];
 
 	reserved 10 to 20, 30 to 50;
 
@@ -72,9 +80,15 @@ message Request {
 		/* allow_alias comments! */
 		option allow_alias = true;
 
-		MARIO = 1 [(testprotos.evfubars) = -314, (testprotos.evfubar) = 278];
+		MARIO = 1 [
+			(testprotos.evfubars) = -314,
+			(testprotos.evfubar) = 278
+		];
 
-		LUIGI = 2 [(testprotos.evfubaruf) = 100, (testprotos.evfubaru) = 200];
+		LUIGI = 2 [
+			(testprotos.evfubaruf) = 100,
+			(testprotos.evfubaru) = 200
+		];
 
 		PEACH = 3;
 

--- a/desc/protoprint/testfiles/desc_test_comments-no-trailing-comments.proto
+++ b/desc/protoprint/testfiles/desc_test_comments-no-trailing-comments.proto
@@ -25,7 +25,12 @@ message Request {
   option deprecated = true;
 
   // A field comment
-  repeated int32 ids = 1 [packed = true, json_name = "|foo|", (testprotos.ffubar) = "abc", (testprotos.ffubarb) = "xyz"];
+  repeated int32 ids = 1 [
+    packed = true,
+    json_name = "|foo|",
+    (testprotos.ffubar) = "abc",
+    (testprotos.ffubarb) = "xyz"
+  ];
 
   // lead mfubar
   option (testprotos.mfubar) = true;
@@ -41,7 +46,10 @@ message Request {
 
   extensions 100 to 200;
 
-  extensions 201 to 250 [(testprotos.exfubarb) = "\000\001\002\003\004\005\006\007", (testprotos.exfubar) = "splat!"];
+  extensions 201 to 250 [
+    (testprotos.exfubarb) = "\000\001\002\003\004\005\006\007",
+    (testprotos.exfubar) = "splat!"
+  ];
 
   reserved 10 to 20, 30 to 50;
 
@@ -66,9 +74,15 @@ message Request {
     // allow_alias comments!
     option allow_alias = true;
 
-    MARIO = 1 [(testprotos.evfubars) = -314, (testprotos.evfubar) = 278];
+    MARIO = 1 [
+      (testprotos.evfubars) = -314,
+      (testprotos.evfubar) = 278
+    ];
 
-    LUIGI = 2 [(testprotos.evfubaruf) = 100, (testprotos.evfubaru) = 200];
+    LUIGI = 2 [
+      (testprotos.evfubaruf) = 100,
+      (testprotos.evfubaru) = 200
+    ];
 
     PEACH = 3;
 

--- a/desc/protoprint/testfiles/desc_test_comments-only-doc-comments.proto
+++ b/desc/protoprint/testfiles/desc_test_comments-only-doc-comments.proto
@@ -13,7 +13,12 @@ message Request {
   option deprecated = true;
 
   // A field comment
-  repeated int32 ids = 1 [packed = true, json_name = "|foo|", (testprotos.ffubar) = "abc", (testprotos.ffubarb) = "xyz"];
+  repeated int32 ids = 1 [
+    packed = true,
+    json_name = "|foo|",
+    (testprotos.ffubar) = "abc",
+    (testprotos.ffubarb) = "xyz"
+  ];
 
   option (testprotos.mfubar) = true;
 
@@ -22,7 +27,10 @@ message Request {
 
   extensions 100 to 200;
 
-  extensions 201 to 250 [(testprotos.exfubarb) = "\000\001\002\003\004\005\006\007", (testprotos.exfubar) = "splat!"];
+  extensions 201 to 250 [
+    (testprotos.exfubarb) = "\000\001\002\003\004\005\006\007",
+    (testprotos.exfubar) = "splat!"
+  ];
 
   reserved 10 to 20, 30 to 50;
 
@@ -45,9 +53,15 @@ message Request {
   enum MarioCharacters {
     option allow_alias = true;
 
-    MARIO = 1 [(testprotos.evfubars) = -314, (testprotos.evfubar) = 278];
+    MARIO = 1 [
+      (testprotos.evfubars) = -314,
+      (testprotos.evfubar) = 278
+    ];
 
-    LUIGI = 2 [(testprotos.evfubaruf) = 100, (testprotos.evfubaru) = 200];
+    LUIGI = 2 [
+      (testprotos.evfubaruf) = 100,
+      (testprotos.evfubaru) = 200
+    ];
 
     PEACH = 3;
 

--- a/desc/protoprint/testfiles/desc_test_comments-sorted-AND-multiline-style-comments.proto
+++ b/desc/protoprint/testfiles/desc_test_comments-sorted-AND-multiline-style-comments.proto
@@ -33,7 +33,12 @@ message Request {
   option (testprotos.mfubar) = true; /* trailing mfubar */
 
   /* A field comment */
-  repeated int32 ids = 1 [json_name = "|foo|", packed = true, (testprotos.ffubar) = "abc", (testprotos.ffubarb) = "xyz"]; /* field trailer #1... */
+  repeated int32 ids = 1 [
+    json_name = "|foo|",
+    packed = true,
+    (testprotos.ffubar) = "abc",
+    (testprotos.ffubarb) = "xyz"
+  ]; /* field trailer #1... */
 
   /* some detached comments */
 
@@ -95,9 +100,15 @@ message Request {
 
     SNIFIT = -101;
 
-    MARIO = 1 [(testprotos.evfubar) = 278, (testprotos.evfubars) = -314];
+    MARIO = 1 [
+      (testprotos.evfubar) = 278,
+      (testprotos.evfubars) = -314
+    ];
 
-    LUIGI = 2 [(testprotos.evfubaru) = 200, (testprotos.evfubaruf) = 100];
+    LUIGI = 2 [
+      (testprotos.evfubaru) = 200,
+      (testprotos.evfubaruf) = 100
+    ];
 
     PEACH = 3;
 
@@ -118,7 +129,10 @@ message Request {
 
   extensions 100 to 200;
 
-  extensions 201 to 250 [(testprotos.exfubar) = "splat!", (testprotos.exfubarb) = "\000\001\002\003\004\005\006\007"];
+  extensions 201 to 250 [
+    (testprotos.exfubar) = "splat!",
+    (testprotos.exfubarb) = "\000\001\002\003\004\005\006\007"
+  ];
 
   reserved 10 to 20, 30 to 50;
 

--- a/desc/protoprint/testfiles/desc_test_comments-sorted.proto
+++ b/desc/protoprint/testfiles/desc_test_comments-sorted.proto
@@ -22,7 +22,12 @@ message Request {
    option (testprotos.mfubar) = true; // trailing mfubar
 
    // A field comment
-   repeated int32 ids = 1 [json_name = "|foo|", packed = true, (testprotos.ffubar) = "abc", (testprotos.ffubarb) = "xyz"]; // field trailer #1...
+   repeated int32 ids = 1 [
+      json_name = "|foo|",
+      packed = true,
+      (testprotos.ffubar) = "abc",
+      (testprotos.ffubarb) = "xyz"
+   ]; // field trailer #1...
 
    // label comment
    optional string name = 2 [default = "fubar"];
@@ -78,9 +83,15 @@ message Request {
 
       SNIFIT = -101;
 
-      MARIO = 1 [(testprotos.evfubar) = 278, (testprotos.evfubars) = -314];
+      MARIO = 1 [
+         (testprotos.evfubar) = 278,
+         (testprotos.evfubars) = -314
+      ];
 
-      LUIGI = 2 [(testprotos.evfubaru) = 200, (testprotos.evfubaruf) = 100];
+      LUIGI = 2 [
+         (testprotos.evfubaru) = 200,
+         (testprotos.evfubaruf) = 100
+      ];
 
       PEACH = 3;
 
@@ -101,7 +112,10 @@ message Request {
 
    extensions 100 to 200;
 
-   extensions 201 to 250 [(testprotos.exfubar) = "splat!", (testprotos.exfubarb) = "\000\001\002\003\004\005\006\007"];
+   extensions 201 to 250 [
+      (testprotos.exfubar) = "splat!",
+      (testprotos.exfubarb) = "\000\001\002\003\004\005\006\007"
+   ];
 
    reserved 10 to 20, 30 to 50;
 

--- a/desc/protoprint/testfiles/desc_test_comments-trailing-on-next-line.proto
+++ b/desc/protoprint/testfiles/desc_test_comments-trailing-on-next-line.proto
@@ -27,7 +27,12 @@ message Request {
   // deprecated!
 
   // A field comment
-  repeated int32 ids = 1 [packed = true, json_name = "|foo|", (testprotos.ffubar) = "abc", (testprotos.ffubarb) = "xyz"];
+  repeated int32 ids = 1 [
+    packed = true,
+    json_name = "|foo|",
+    (testprotos.ffubar) = "abc",
+    (testprotos.ffubarb) = "xyz"
+  ];
   // field trailer #1...
 
   // lead mfubar
@@ -45,7 +50,10 @@ message Request {
 
   extensions 100 to 200;
 
-  extensions 201 to 250 [(testprotos.exfubarb) = "\000\001\002\003\004\005\006\007", (testprotos.exfubar) = "splat!"];
+  extensions 201 to 250 [
+    (testprotos.exfubarb) = "\000\001\002\003\004\005\006\007",
+    (testprotos.exfubar) = "splat!"
+  ];
 
   reserved 10 to 20, 30 to 50;
 
@@ -75,9 +83,15 @@ message Request {
     // allow_alias comments!
     option allow_alias = true;
 
-    MARIO = 1 [(testprotos.evfubars) = -314, (testprotos.evfubar) = 278];
+    MARIO = 1 [
+      (testprotos.evfubars) = -314,
+      (testprotos.evfubar) = 278
+    ];
 
-    LUIGI = 2 [(testprotos.evfubaruf) = 100, (testprotos.evfubaru) = 200];
+    LUIGI = 2 [
+      (testprotos.evfubaruf) = 100,
+      (testprotos.evfubaru) = 200
+    ];
 
     PEACH = 3;
 

--- a/desc/protoprint/testfiles/desc_test_complex-compact.proto
+++ b/desc/protoprint/testfiles/desc_test_complex-compact.proto
@@ -65,12 +65,82 @@ extend google.protobuf.MessageOptions {
   optional MessageWithMap map_vals = 20030;
 }
 message Another {
-  option (rept) = { foo:"abc" array:1 array:2 array:3 s:<name:"foo" id:123 > r:<name:"f" > r:<name:"s" > r:<id:456 >  };
-  option (rept) = { foo:"def" array:3 array:2 array:1 s:<name:"bar" id:321 > r:<name:"g" > r:<name:"s" >  };
+  option (rept) = {
+    foo: "abc"
+    array: 1
+    array: 2
+    array: 3
+    s: <
+      name: "foo"
+      id: 123
+    >
+    r: <
+      name: "f"
+    >
+    r: <
+      name: "s"
+    >
+    r: <
+      id: 456
+    >
+  };
+  option (rept) = {
+    foo: "def"
+    array: 3
+    array: 2
+    array: 1
+    s: <
+      name: "bar"
+      id: 321
+    >
+    r: <
+      name: "g"
+    >
+    r: <
+      name: "s"
+    >
+  };
   option (rept) = { foo:"def"  };
   option (eee) = V1;
-  option (a) = { test:<foo:"m&m" array:1 array:2 s:<name:"yolo" id:98765 > m:<key:"bar" value:200 > m:<key:"foo" value:100 > [foo.bar.Test.Nested._NestedNested._garblez]:"whoah!" > fff:OK  };
-  option (map_vals) = { vals:<key:"" value:<> > vals:<key:"bar" value:<name:"baz" > > vals:<key:"foo" value:<> >  }; // no key, no value
+  option (a) = {
+    test: <
+      foo: "m&m"
+      array: 1
+      array: 2
+      s: <
+        name: "yolo"
+        id: 98765
+      >
+      m: <
+        key: "bar"
+        value: 200
+      >
+      m: <
+        key: "foo"
+        value: 100
+      >
+      [foo.bar.Test.Nested._NestedNested._garblez]: "whoah!"
+    >
+    fff: OK
+  };
+  option (map_vals) = {
+    vals: <
+      key: ""
+      value: <
+      >
+    >
+    vals: <
+      key: "bar"
+      value: <
+        name: "baz"
+      >
+    >
+    vals: <
+      key: "foo"
+      value: <
+      >
+    >
+  }; // no key, no value
   optional Test test = 1;
   optional Test.Nested._NestedNested.EEE fff = 2 [default = V1];
 }
@@ -129,7 +199,18 @@ extend google.protobuf.FieldOptions {
   optional Rule rules = 1234;
 }
 message IsAuthorizedReq {
-  repeated string subjects = 1 [(rules) = { repeated:<min_items:1 items:<string:<pattern:"^(?:(?:team:(?:local|ldap))|user):[[:alnum:]_-]+$" > > >  }];
+  repeated string subjects = 1 [
+    (rules) = {
+      repeated: <
+        min_items: 1
+        items: <
+          string: <
+            pattern: "^(?:(?:team:(?:local|ldap))|user):[[:alnum:]_-]+$"
+          >
+        >
+      >
+    }
+  ];
 }
 // tests cases where field names collide with keywords
 message KeywordCollisions {
@@ -208,6 +289,80 @@ extend google.protobuf.FieldOptions {
   optional KeywordCollisions boom = 20036;
 }
 message KeywordCollisionOptions {
-  optional uint64 id = 1 [(syntax) = true, (import) = true, (public) = true, (weak) = true, (package) = true, (string) = "string", (bytes) = "bytes", (bool) = true, (float) = 3.140000, (double) = 3.141590, (int32) = 32, (int64) = 64, (uint32) = 3200, (uint64) = 6400, (sint32) = -32, (sint64) = -64, (fixed32) = 3232, (fixed64) = 6464, (sfixed32) = -3232, (sfixed64) = -6464, (optional) = true, (repeated) = true, (required) = true, (message) = true, (enum) = true, (service) = true, (rpc) = true, (option) = true, (extend) = true, (extensions) = true, (reserved) = true, (to) = true, (true) = 111, (false) = -111, (default) = 222];
-  optional string name = 2 [(boom) = { syntax:true import:true public:true weak:true package:true string:"string" bytes:"bytes" int32:32 int64:64 uint32:3200 uint64:6400 sint32:-32 sint64:-64 fixed32:3232 fixed64:6464 sfixed32:-3232 sfixed64:-6464 bool:true float:3.14 double:3.14159 optional:true repeated:true required:true message:true enum:true service:true rpc:true option:true extend:true extensions:true reserved:true to:true true:111 false:-111 default:222  }];
+  optional uint64 id = 1 [
+    (syntax) = true,
+    (import) = true,
+    (public) = true,
+    (weak) = true,
+    (package) = true,
+    (string) = "string",
+    (bytes) = "bytes",
+    (bool) = true,
+    (float) = 3.140000,
+    (double) = 3.141590,
+    (int32) = 32,
+    (int64) = 64,
+    (uint32) = 3200,
+    (uint64) = 6400,
+    (sint32) = -32,
+    (sint64) = -64,
+    (fixed32) = 3232,
+    (fixed64) = 6464,
+    (sfixed32) = -3232,
+    (sfixed64) = -6464,
+    (optional) = true,
+    (repeated) = true,
+    (required) = true,
+    (message) = true,
+    (enum) = true,
+    (service) = true,
+    (rpc) = true,
+    (option) = true,
+    (extend) = true,
+    (extensions) = true,
+    (reserved) = true,
+    (to) = true,
+    (true) = 111,
+    (false) = -111,
+    (default) = 222
+  ];
+  optional string name = 2 [
+    (boom) = {
+      syntax: true
+      import: true
+      public: true
+      weak: true
+      package: true
+      string: "string"
+      bytes: "bytes"
+      int32: 32
+      int64: 64
+      uint32: 3200
+      uint64: 6400
+      sint32: -32
+      sint64: -64
+      fixed32: 3232
+      fixed64: 6464
+      sfixed32: -3232
+      sfixed64: -6464
+      bool: true
+      float: 3.14
+      double: 3.14159
+      optional: true
+      repeated: true
+      required: true
+      message: true
+      enum: true
+      service: true
+      rpc: true
+      option: true
+      extend: true
+      extensions: true
+      reserved: true
+      to: true
+      true: 111
+      false: -111
+      default: 222
+    }
+  ];
 }

--- a/desc/protoprint/testfiles/desc_test_complex-custom-sort.proto
+++ b/desc/protoprint/testfiles/desc_test_complex-custom-sort.proto
@@ -98,11 +98,23 @@ extend google.protobuf.ExtensionRangeOptions {
 
 service TestTestService {
   rpc UserAuth ( Test ) returns ( Test ) {
-    option (validator) = { authenticated:true permission:<action:LOGIN entity:"client" >  };
+    option (validator) = {
+      authenticated: true
+      permission: <
+        action: LOGIN
+        entity: "client"
+      >
+    };
   }
 
   rpc Get ( Test ) returns ( Test ) {
-    option (validator) = { authenticated:true permission:<action:READ entity:"user" >  };
+    option (validator) = {
+      authenticated: true
+      permission: <
+        action: READ
+        entity: "user"
+      >
+    };
   }
 }
 
@@ -172,10 +184,16 @@ message Test {
       message NestedNestedNested {
         optional Test Test = 1;
 
-        option (rept) = { foo:"hoo" [foo.bar.Test.Nested._NestedNested._garblez]:"spoo"  };
+        option (rept) = {
+          foo: "hoo"
+          [foo.bar.Test.Nested._NestedNested._garblez]: "spoo"
+        };
       }
 
-      option (rept) = { foo:"goo" [foo.bar.Test.Nested._NestedNested._garblez]:"boo"  };
+      option (rept) = {
+        foo: "goo"
+        [foo.bar.Test.Nested._NestedNested._garblez]: "boo"
+      };
 
       option (fooblez) = 10101;
     }
@@ -328,13 +346,98 @@ message KeywordCollisions {
 }
 
 message KeywordCollisionOptions {
-  optional string name = 2 [(boom) = { syntax:true import:true public:true weak:true package:true string:"string" bytes:"bytes" int32:32 int64:64 uint32:3200 uint64:6400 sint32:-32 sint64:-64 fixed32:3232 fixed64:6464 sfixed32:-3232 sfixed64:-6464 bool:true float:3.14 double:3.14159 optional:true repeated:true required:true message:true enum:true service:true rpc:true option:true extend:true extensions:true reserved:true to:true true:111 false:-111 default:222  }];
+  optional string name = 2 [
+    (boom) = {
+      syntax: true
+      import: true
+      public: true
+      weak: true
+      package: true
+      string: "string"
+      bytes: "bytes"
+      int32: 32
+      int64: 64
+      uint32: 3200
+      uint64: 6400
+      sint32: -32
+      sint64: -64
+      fixed32: 3232
+      fixed64: 6464
+      sfixed32: -3232
+      sfixed64: -6464
+      bool: true
+      float: 3.14
+      double: 3.14159
+      optional: true
+      repeated: true
+      required: true
+      message: true
+      enum: true
+      service: true
+      rpc: true
+      option: true
+      extend: true
+      extensions: true
+      reserved: true
+      to: true
+      true: 111
+      false: -111
+      default: 222
+    }
+  ];
 
-  optional uint64 id = 1 [(weak) = true, (uint64) = 6400, (uint32) = 3200, (true) = 111, (to) = true, (syntax) = true, (string) = "string", (sint64) = -64, (sint32) = -32, (sfixed64) = -6464, (sfixed32) = -3232, (service) = true, (rpc) = true, (reserved) = true, (required) = true, (repeated) = true, (public) = true, (package) = true, (optional) = true, (option) = true, (message) = true, (int64) = 64, (int32) = 32, (import) = true, (float) = 3.140000, (fixed64) = 6464, (fixed32) = 3232, (false) = -111, (extensions) = true, (extend) = true, (enum) = true, (double) = 3.141590, (default) = 222, (bytes) = "bytes", (bool) = true];
+  optional uint64 id = 1 [
+    (weak) = true,
+    (uint64) = 6400,
+    (uint32) = 3200,
+    (true) = 111,
+    (to) = true,
+    (syntax) = true,
+    (string) = "string",
+    (sint64) = -64,
+    (sint32) = -32,
+    (sfixed64) = -6464,
+    (sfixed32) = -3232,
+    (service) = true,
+    (rpc) = true,
+    (reserved) = true,
+    (required) = true,
+    (repeated) = true,
+    (public) = true,
+    (package) = true,
+    (optional) = true,
+    (option) = true,
+    (message) = true,
+    (int64) = 64,
+    (int32) = 32,
+    (import) = true,
+    (float) = 3.140000,
+    (fixed64) = 6464,
+    (fixed32) = 3232,
+    (false) = -111,
+    (extensions) = true,
+    (extend) = true,
+    (enum) = true,
+    (double) = 3.141590,
+    (default) = 222,
+    (bytes) = "bytes",
+    (bool) = true
+  ];
 }
 
 message IsAuthorizedReq {
-  repeated string subjects = 1 [(rules) = { repeated:<min_items:1 items:<string:<pattern:"^(?:(?:team:(?:local|ldap))|user):[[:alnum:]_-]+$" > > >  }];
+  repeated string subjects = 1 [
+    (rules) = {
+      repeated: <
+        min_items: 1
+        items: <
+          string: <
+            pattern: "^(?:(?:team:(?:local|ldap))|user):[[:alnum:]_-]+$"
+          >
+        >
+      >
+    }
+  ];
 }
 
 message Another {
@@ -342,15 +445,85 @@ message Another {
 
   optional Test.Nested._NestedNested.EEE fff = 2 [default = V1];
 
-  option (rept) = { foo:"abc" array:1 array:2 array:3 s:<name:"foo" id:123 > r:<name:"f" > r:<name:"s" > r:<id:456 >  };
-  option (rept) = { foo:"def" array:3 array:2 array:1 s:<name:"bar" id:321 > r:<name:"g" > r:<name:"s" >  };
+  option (rept) = {
+    foo: "abc"
+    array: 1
+    array: 2
+    array: 3
+    s: <
+      name: "foo"
+      id: 123
+    >
+    r: <
+      name: "f"
+    >
+    r: <
+      name: "s"
+    >
+    r: <
+      id: 456
+    >
+  };
+  option (rept) = {
+    foo: "def"
+    array: 3
+    array: 2
+    array: 1
+    s: <
+      name: "bar"
+      id: 321
+    >
+    r: <
+      name: "g"
+    >
+    r: <
+      name: "s"
+    >
+  };
   option (rept) = { foo:"def"  };
 
-  option (map_vals) = { vals:<key:"" value:<> > vals:<key:"bar" value:<name:"baz" > > vals:<key:"foo" value:<> >  }; // no key, no value
+  option (map_vals) = {
+    vals: <
+      key: ""
+      value: <
+      >
+    >
+    vals: <
+      key: "bar"
+      value: <
+        name: "baz"
+      >
+    >
+    vals: <
+      key: "foo"
+      value: <
+      >
+    >
+  }; // no key, no value
 
   option (eee) = V1;
 
-  option (a) = { test:<foo:"m&m" array:1 array:2 s:<name:"yolo" id:98765 > m:<key:"bar" value:200 > m:<key:"foo" value:100 > [foo.bar.Test.Nested._NestedNested._garblez]:"whoah!" > fff:OK  };
+  option (a) = {
+    test: <
+      foo: "m&m"
+      array: 1
+      array: 2
+      s: <
+        name: "yolo"
+        id: 98765
+      >
+      m: <
+        key: "bar"
+        value: 200
+      >
+      m: <
+        key: "foo"
+        value: 100
+      >
+      [foo.bar.Test.Nested._NestedNested._garblez]: "whoah!"
+    >
+    fff: OK
+  };
 }
 
 option go_package = "github.com/jhump/protoreflect/internal/testprotos";

--- a/desc/protoprint/testfiles/desc_test_complex-default.proto
+++ b/desc/protoprint/testfiles/desc_test_complex-default.proto
@@ -61,10 +61,16 @@ message Test {
         optional string _garblez = 100;
       }
 
-      option (rept) = { foo:"goo" [foo.bar.Test.Nested._NestedNested._garblez]:"boo"  };
+      option (rept) = {
+        foo: "goo"
+        [foo.bar.Test.Nested._NestedNested._garblez]: "boo"
+      };
 
       message NestedNestedNested {
-        option (rept) = { foo:"hoo" [foo.bar.Test.Nested._NestedNested._garblez]:"spoo"  };
+        option (rept) = {
+          foo: "hoo"
+          [foo.bar.Test.Nested._NestedNested._garblez]: "spoo"
+        };
 
         optional Test Test = 1;
       }
@@ -105,15 +111,85 @@ extend google.protobuf.MessageOptions {
 }
 
 message Another {
-  option (rept) = { foo:"abc" array:1 array:2 array:3 s:<name:"foo" id:123 > r:<name:"f" > r:<name:"s" > r:<id:456 >  };
-  option (rept) = { foo:"def" array:3 array:2 array:1 s:<name:"bar" id:321 > r:<name:"g" > r:<name:"s" >  };
+  option (rept) = {
+    foo: "abc"
+    array: 1
+    array: 2
+    array: 3
+    s: <
+      name: "foo"
+      id: 123
+    >
+    r: <
+      name: "f"
+    >
+    r: <
+      name: "s"
+    >
+    r: <
+      id: 456
+    >
+  };
+  option (rept) = {
+    foo: "def"
+    array: 3
+    array: 2
+    array: 1
+    s: <
+      name: "bar"
+      id: 321
+    >
+    r: <
+      name: "g"
+    >
+    r: <
+      name: "s"
+    >
+  };
   option (rept) = { foo:"def"  };
 
   option (eee) = V1;
 
-  option (a) = { test:<foo:"m&m" array:1 array:2 s:<name:"yolo" id:98765 > m:<key:"bar" value:200 > m:<key:"foo" value:100 > [foo.bar.Test.Nested._NestedNested._garblez]:"whoah!" > fff:OK  };
+  option (a) = {
+    test: <
+      foo: "m&m"
+      array: 1
+      array: 2
+      s: <
+        name: "yolo"
+        id: 98765
+      >
+      m: <
+        key: "bar"
+        value: 200
+      >
+      m: <
+        key: "foo"
+        value: 100
+      >
+      [foo.bar.Test.Nested._NestedNested._garblez]: "whoah!"
+    >
+    fff: OK
+  };
 
-  option (map_vals) = { vals:<key:"" value:<> > vals:<key:"bar" value:<name:"baz" > > vals:<key:"foo" value:<> >  }; // no key, no value
+  option (map_vals) = {
+    vals: <
+      key: ""
+      value: <
+      >
+    >
+    vals: <
+      key: "bar"
+      value: <
+        name: "baz"
+      >
+    >
+    vals: <
+      key: "foo"
+      value: <
+      >
+    >
+  }; // no key, no value
 
   optional Test test = 1;
 
@@ -146,11 +222,23 @@ extend google.protobuf.MethodOptions {
 
 service TestTestService {
   rpc UserAuth ( Test ) returns ( Test ) {
-    option (validator) = { authenticated:true permission:<action:LOGIN entity:"client" >  };
+    option (validator) = {
+      authenticated: true
+      permission: <
+        action: LOGIN
+        entity: "client"
+      >
+    };
   }
 
   rpc Get ( Test ) returns ( Test ) {
-    option (validator) = { authenticated:true permission:<action:READ entity:"user" >  };
+    option (validator) = {
+      authenticated: true
+      permission: <
+        action: READ
+        entity: "user"
+      >
+    };
   }
 }
 
@@ -201,7 +289,18 @@ extend google.protobuf.FieldOptions {
 }
 
 message IsAuthorizedReq {
-  repeated string subjects = 1 [(rules) = { repeated:<min_items:1 items:<string:<pattern:"^(?:(?:team:(?:local|ldap))|user):[[:alnum:]_-]+$" > > >  }];
+  repeated string subjects = 1 [
+    (rules) = {
+      repeated: <
+        min_items: 1
+        items: <
+          string: <
+            pattern: "^(?:(?:team:(?:local|ldap))|user):[[:alnum:]_-]+$"
+          >
+        >
+      >
+    }
+  ];
 }
 
 // tests cases where field names collide with keywords
@@ -353,7 +452,81 @@ extend google.protobuf.FieldOptions {
 }
 
 message KeywordCollisionOptions {
-  optional uint64 id = 1 [(syntax) = true, (import) = true, (public) = true, (weak) = true, (package) = true, (string) = "string", (bytes) = "bytes", (bool) = true, (float) = 3.140000, (double) = 3.141590, (int32) = 32, (int64) = 64, (uint32) = 3200, (uint64) = 6400, (sint32) = -32, (sint64) = -64, (fixed32) = 3232, (fixed64) = 6464, (sfixed32) = -3232, (sfixed64) = -6464, (optional) = true, (repeated) = true, (required) = true, (message) = true, (enum) = true, (service) = true, (rpc) = true, (option) = true, (extend) = true, (extensions) = true, (reserved) = true, (to) = true, (true) = 111, (false) = -111, (default) = 222];
+  optional uint64 id = 1 [
+    (syntax) = true,
+    (import) = true,
+    (public) = true,
+    (weak) = true,
+    (package) = true,
+    (string) = "string",
+    (bytes) = "bytes",
+    (bool) = true,
+    (float) = 3.140000,
+    (double) = 3.141590,
+    (int32) = 32,
+    (int64) = 64,
+    (uint32) = 3200,
+    (uint64) = 6400,
+    (sint32) = -32,
+    (sint64) = -64,
+    (fixed32) = 3232,
+    (fixed64) = 6464,
+    (sfixed32) = -3232,
+    (sfixed64) = -6464,
+    (optional) = true,
+    (repeated) = true,
+    (required) = true,
+    (message) = true,
+    (enum) = true,
+    (service) = true,
+    (rpc) = true,
+    (option) = true,
+    (extend) = true,
+    (extensions) = true,
+    (reserved) = true,
+    (to) = true,
+    (true) = 111,
+    (false) = -111,
+    (default) = 222
+  ];
 
-  optional string name = 2 [(boom) = { syntax:true import:true public:true weak:true package:true string:"string" bytes:"bytes" int32:32 int64:64 uint32:3200 uint64:6400 sint32:-32 sint64:-64 fixed32:3232 fixed64:6464 sfixed32:-3232 sfixed64:-6464 bool:true float:3.14 double:3.14159 optional:true repeated:true required:true message:true enum:true service:true rpc:true option:true extend:true extensions:true reserved:true to:true true:111 false:-111 default:222  }];
+  optional string name = 2 [
+    (boom) = {
+      syntax: true
+      import: true
+      public: true
+      weak: true
+      package: true
+      string: "string"
+      bytes: "bytes"
+      int32: 32
+      int64: 64
+      uint32: 3200
+      uint64: 6400
+      sint32: -32
+      sint64: -64
+      fixed32: 3232
+      fixed64: 6464
+      sfixed32: -3232
+      sfixed64: -6464
+      bool: true
+      float: 3.14
+      double: 3.14159
+      optional: true
+      repeated: true
+      required: true
+      message: true
+      enum: true
+      service: true
+      rpc: true
+      option: true
+      extend: true
+      extensions: true
+      reserved: true
+      to: true
+      true: 111
+      false: -111
+      default: 222
+    }
+  ];
 }

--- a/desc/protoprint/testfiles/desc_test_complex-multiline-style-comments.proto
+++ b/desc/protoprint/testfiles/desc_test_complex-multiline-style-comments.proto
@@ -61,10 +61,16 @@ message Test {
 				optional string _garblez = 100;
 			}
 
-			option (rept) = { foo:"goo" [foo.bar.Test.Nested._NestedNested._garblez]:"boo"  };
+			option (rept) = {
+				foo: "goo"
+				[foo.bar.Test.Nested._NestedNested._garblez]: "boo"
+			};
 
 			message NestedNestedNested {
-				option (rept) = { foo:"hoo" [foo.bar.Test.Nested._NestedNested._garblez]:"spoo"  };
+				option (rept) = {
+					foo: "hoo"
+					[foo.bar.Test.Nested._NestedNested._garblez]: "spoo"
+				};
 
 				optional Test Test = 1;
 			}
@@ -105,15 +111,85 @@ extend google.protobuf.MessageOptions {
 }
 
 message Another {
-	option (rept) = { foo:"abc" array:1 array:2 array:3 s:<name:"foo" id:123 > r:<name:"f" > r:<name:"s" > r:<id:456 >  };
-	option (rept) = { foo:"def" array:3 array:2 array:1 s:<name:"bar" id:321 > r:<name:"g" > r:<name:"s" >  };
+	option (rept) = {
+		foo: "abc"
+		array: 1
+		array: 2
+		array: 3
+		s: <
+			name: "foo"
+			id: 123
+		>
+		r: <
+			name: "f"
+		>
+		r: <
+			name: "s"
+		>
+		r: <
+			id: 456
+		>
+	};
+	option (rept) = {
+		foo: "def"
+		array: 3
+		array: 2
+		array: 1
+		s: <
+			name: "bar"
+			id: 321
+		>
+		r: <
+			name: "g"
+		>
+		r: <
+			name: "s"
+		>
+	};
 	option (rept) = { foo:"def"  };
 
 	option (eee) = V1;
 
-	option (a) = { test:<foo:"m&m" array:1 array:2 s:<name:"yolo" id:98765 > m:<key:"bar" value:200 > m:<key:"foo" value:100 > [foo.bar.Test.Nested._NestedNested._garblez]:"whoah!" > fff:OK  };
+	option (a) = {
+		test: <
+			foo: "m&m"
+			array: 1
+			array: 2
+			s: <
+				name: "yolo"
+				id: 98765
+			>
+			m: <
+				key: "bar"
+				value: 200
+			>
+			m: <
+				key: "foo"
+				value: 100
+			>
+			[foo.bar.Test.Nested._NestedNested._garblez]: "whoah!"
+		>
+		fff: OK
+	};
 
-	option (map_vals) = { vals:<key:"" value:<> > vals:<key:"bar" value:<name:"baz" > > vals:<key:"foo" value:<> >  }; /* no key, no value */
+	option (map_vals) = {
+		vals: <
+			key: ""
+			value: <
+			>
+		>
+		vals: <
+			key: "bar"
+			value: <
+				name: "baz"
+			>
+		>
+		vals: <
+			key: "foo"
+			value: <
+			>
+		>
+	}; /* no key, no value */
 
 	optional Test test = 1;
 
@@ -146,11 +222,23 @@ extend google.protobuf.MethodOptions {
 
 service TestTestService {
 	rpc UserAuth ( Test ) returns ( Test ) {
-		option (validator) = { authenticated:true permission:<action:LOGIN entity:"client" >  };
+		option (validator) = {
+			authenticated: true
+			permission: <
+				action: LOGIN
+				entity: "client"
+			>
+		};
 	}
 
 	rpc Get ( Test ) returns ( Test ) {
-		option (validator) = { authenticated:true permission:<action:READ entity:"user" >  };
+		option (validator) = {
+			authenticated: true
+			permission: <
+				action: READ
+				entity: "user"
+			>
+		};
 	}
 }
 
@@ -201,7 +289,18 @@ extend google.protobuf.FieldOptions {
 }
 
 message IsAuthorizedReq {
-	repeated string subjects = 1 [(rules) = { repeated:<min_items:1 items:<string:<pattern:"^(?:(?:team:(?:local|ldap))|user):[[:alnum:]_-]+$" > > >  }];
+	repeated string subjects = 1 [
+		(rules) = {
+			repeated: <
+				min_items: 1
+				items: <
+					string: <
+						pattern: "^(?:(?:team:(?:local|ldap))|user):[[:alnum:]_-]+$"
+					>
+				>
+			>
+		}
+	];
 }
 
 /* tests cases where field names collide with keywords */
@@ -353,7 +452,81 @@ extend google.protobuf.FieldOptions {
 }
 
 message KeywordCollisionOptions {
-	optional uint64 id = 1 [(syntax) = true, (import) = true, (public) = true, (weak) = true, (package) = true, (string) = "string", (bytes) = "bytes", (bool) = true, (float) = 3.140000, (double) = 3.141590, (int32) = 32, (int64) = 64, (uint32) = 3200, (uint64) = 6400, (sint32) = -32, (sint64) = -64, (fixed32) = 3232, (fixed64) = 6464, (sfixed32) = -3232, (sfixed64) = -6464, (optional) = true, (repeated) = true, (required) = true, (message) = true, (enum) = true, (service) = true, (rpc) = true, (option) = true, (extend) = true, (extensions) = true, (reserved) = true, (to) = true, (true) = 111, (false) = -111, (default) = 222];
+	optional uint64 id = 1 [
+		(syntax) = true,
+		(import) = true,
+		(public) = true,
+		(weak) = true,
+		(package) = true,
+		(string) = "string",
+		(bytes) = "bytes",
+		(bool) = true,
+		(float) = 3.140000,
+		(double) = 3.141590,
+		(int32) = 32,
+		(int64) = 64,
+		(uint32) = 3200,
+		(uint64) = 6400,
+		(sint32) = -32,
+		(sint64) = -64,
+		(fixed32) = 3232,
+		(fixed64) = 6464,
+		(sfixed32) = -3232,
+		(sfixed64) = -6464,
+		(optional) = true,
+		(repeated) = true,
+		(required) = true,
+		(message) = true,
+		(enum) = true,
+		(service) = true,
+		(rpc) = true,
+		(option) = true,
+		(extend) = true,
+		(extensions) = true,
+		(reserved) = true,
+		(to) = true,
+		(true) = 111,
+		(false) = -111,
+		(default) = 222
+	];
 
-	optional string name = 2 [(boom) = { syntax:true import:true public:true weak:true package:true string:"string" bytes:"bytes" int32:32 int64:64 uint32:3200 uint64:6400 sint32:-32 sint64:-64 fixed32:3232 fixed64:6464 sfixed32:-3232 sfixed64:-6464 bool:true float:3.14 double:3.14159 optional:true repeated:true required:true message:true enum:true service:true rpc:true option:true extend:true extensions:true reserved:true to:true true:111 false:-111 default:222  }];
+	optional string name = 2 [
+		(boom) = {
+			syntax: true
+			import: true
+			public: true
+			weak: true
+			package: true
+			string: "string"
+			bytes: "bytes"
+			int32: 32
+			int64: 64
+			uint32: 3200
+			uint64: 6400
+			sint32: -32
+			sint64: -64
+			fixed32: 3232
+			fixed64: 6464
+			sfixed32: -3232
+			sfixed64: -6464
+			bool: true
+			float: 3.14
+			double: 3.14159
+			optional: true
+			repeated: true
+			required: true
+			message: true
+			enum: true
+			service: true
+			rpc: true
+			option: true
+			extend: true
+			extensions: true
+			reserved: true
+			to: true
+			true: 111
+			false: -111
+			default: 222
+		}
+	];
 }

--- a/desc/protoprint/testfiles/desc_test_complex-no-trailing-comments.proto
+++ b/desc/protoprint/testfiles/desc_test_complex-no-trailing-comments.proto
@@ -61,10 +61,16 @@ message Test {
         optional string _garblez = 100;
       }
 
-      option (rept) = { foo:"goo" [foo.bar.Test.Nested._NestedNested._garblez]:"boo"  };
+      option (rept) = {
+        foo: "goo"
+        [foo.bar.Test.Nested._NestedNested._garblez]: "boo"
+      };
 
       message NestedNestedNested {
-        option (rept) = { foo:"hoo" [foo.bar.Test.Nested._NestedNested._garblez]:"spoo"  };
+        option (rept) = {
+          foo: "hoo"
+          [foo.bar.Test.Nested._NestedNested._garblez]: "spoo"
+        };
 
         optional Test Test = 1;
       }
@@ -105,15 +111,85 @@ extend google.protobuf.MessageOptions {
 }
 
 message Another {
-  option (rept) = { foo:"abc" array:1 array:2 array:3 s:<name:"foo" id:123 > r:<name:"f" > r:<name:"s" > r:<id:456 >  };
-  option (rept) = { foo:"def" array:3 array:2 array:1 s:<name:"bar" id:321 > r:<name:"g" > r:<name:"s" >  };
+  option (rept) = {
+    foo: "abc"
+    array: 1
+    array: 2
+    array: 3
+    s: <
+      name: "foo"
+      id: 123
+    >
+    r: <
+      name: "f"
+    >
+    r: <
+      name: "s"
+    >
+    r: <
+      id: 456
+    >
+  };
+  option (rept) = {
+    foo: "def"
+    array: 3
+    array: 2
+    array: 1
+    s: <
+      name: "bar"
+      id: 321
+    >
+    r: <
+      name: "g"
+    >
+    r: <
+      name: "s"
+    >
+  };
   option (rept) = { foo:"def"  };
 
   option (eee) = V1;
 
-  option (a) = { test:<foo:"m&m" array:1 array:2 s:<name:"yolo" id:98765 > m:<key:"bar" value:200 > m:<key:"foo" value:100 > [foo.bar.Test.Nested._NestedNested._garblez]:"whoah!" > fff:OK  };
+  option (a) = {
+    test: <
+      foo: "m&m"
+      array: 1
+      array: 2
+      s: <
+        name: "yolo"
+        id: 98765
+      >
+      m: <
+        key: "bar"
+        value: 200
+      >
+      m: <
+        key: "foo"
+        value: 100
+      >
+      [foo.bar.Test.Nested._NestedNested._garblez]: "whoah!"
+    >
+    fff: OK
+  };
 
-  option (map_vals) = { vals:<key:"" value:<> > vals:<key:"bar" value:<name:"baz" > > vals:<key:"foo" value:<> >  };
+  option (map_vals) = {
+    vals: <
+      key: ""
+      value: <
+      >
+    >
+    vals: <
+      key: "bar"
+      value: <
+        name: "baz"
+      >
+    >
+    vals: <
+      key: "foo"
+      value: <
+      >
+    >
+  };
 
   optional Test test = 1;
 
@@ -146,11 +222,23 @@ extend google.protobuf.MethodOptions {
 
 service TestTestService {
   rpc UserAuth ( Test ) returns ( Test ) {
-    option (validator) = { authenticated:true permission:<action:LOGIN entity:"client" >  };
+    option (validator) = {
+      authenticated: true
+      permission: <
+        action: LOGIN
+        entity: "client"
+      >
+    };
   }
 
   rpc Get ( Test ) returns ( Test ) {
-    option (validator) = { authenticated:true permission:<action:READ entity:"user" >  };
+    option (validator) = {
+      authenticated: true
+      permission: <
+        action: READ
+        entity: "user"
+      >
+    };
   }
 }
 
@@ -201,7 +289,18 @@ extend google.protobuf.FieldOptions {
 }
 
 message IsAuthorizedReq {
-  repeated string subjects = 1 [(rules) = { repeated:<min_items:1 items:<string:<pattern:"^(?:(?:team:(?:local|ldap))|user):[[:alnum:]_-]+$" > > >  }];
+  repeated string subjects = 1 [
+    (rules) = {
+      repeated: <
+        min_items: 1
+        items: <
+          string: <
+            pattern: "^(?:(?:team:(?:local|ldap))|user):[[:alnum:]_-]+$"
+          >
+        >
+      >
+    }
+  ];
 }
 
 // tests cases where field names collide with keywords
@@ -353,7 +452,81 @@ extend google.protobuf.FieldOptions {
 }
 
 message KeywordCollisionOptions {
-  optional uint64 id = 1 [(syntax) = true, (import) = true, (public) = true, (weak) = true, (package) = true, (string) = "string", (bytes) = "bytes", (bool) = true, (float) = 3.140000, (double) = 3.141590, (int32) = 32, (int64) = 64, (uint32) = 3200, (uint64) = 6400, (sint32) = -32, (sint64) = -64, (fixed32) = 3232, (fixed64) = 6464, (sfixed32) = -3232, (sfixed64) = -6464, (optional) = true, (repeated) = true, (required) = true, (message) = true, (enum) = true, (service) = true, (rpc) = true, (option) = true, (extend) = true, (extensions) = true, (reserved) = true, (to) = true, (true) = 111, (false) = -111, (default) = 222];
+  optional uint64 id = 1 [
+    (syntax) = true,
+    (import) = true,
+    (public) = true,
+    (weak) = true,
+    (package) = true,
+    (string) = "string",
+    (bytes) = "bytes",
+    (bool) = true,
+    (float) = 3.140000,
+    (double) = 3.141590,
+    (int32) = 32,
+    (int64) = 64,
+    (uint32) = 3200,
+    (uint64) = 6400,
+    (sint32) = -32,
+    (sint64) = -64,
+    (fixed32) = 3232,
+    (fixed64) = 6464,
+    (sfixed32) = -3232,
+    (sfixed64) = -6464,
+    (optional) = true,
+    (repeated) = true,
+    (required) = true,
+    (message) = true,
+    (enum) = true,
+    (service) = true,
+    (rpc) = true,
+    (option) = true,
+    (extend) = true,
+    (extensions) = true,
+    (reserved) = true,
+    (to) = true,
+    (true) = 111,
+    (false) = -111,
+    (default) = 222
+  ];
 
-  optional string name = 2 [(boom) = { syntax:true import:true public:true weak:true package:true string:"string" bytes:"bytes" int32:32 int64:64 uint32:3200 uint64:6400 sint32:-32 sint64:-64 fixed32:3232 fixed64:6464 sfixed32:-3232 sfixed64:-6464 bool:true float:3.14 double:3.14159 optional:true repeated:true required:true message:true enum:true service:true rpc:true option:true extend:true extensions:true reserved:true to:true true:111 false:-111 default:222  }];
+  optional string name = 2 [
+    (boom) = {
+      syntax: true
+      import: true
+      public: true
+      weak: true
+      package: true
+      string: "string"
+      bytes: "bytes"
+      int32: 32
+      int64: 64
+      uint32: 3200
+      uint64: 6400
+      sint32: -32
+      sint64: -64
+      fixed32: 3232
+      fixed64: 6464
+      sfixed32: -3232
+      sfixed64: -6464
+      bool: true
+      float: 3.14
+      double: 3.14159
+      optional: true
+      repeated: true
+      required: true
+      message: true
+      enum: true
+      service: true
+      rpc: true
+      option: true
+      extend: true
+      extensions: true
+      reserved: true
+      to: true
+      true: 111
+      false: -111
+      default: 222
+    }
+  ];
 }

--- a/desc/protoprint/testfiles/desc_test_complex-only-doc-comments.proto
+++ b/desc/protoprint/testfiles/desc_test_complex-only-doc-comments.proto
@@ -61,10 +61,16 @@ message Test {
         optional string _garblez = 100;
       }
 
-      option (rept) = { foo:"goo" [foo.bar.Test.Nested._NestedNested._garblez]:"boo"  };
+      option (rept) = {
+        foo: "goo"
+        [foo.bar.Test.Nested._NestedNested._garblez]: "boo"
+      };
 
       message NestedNestedNested {
-        option (rept) = { foo:"hoo" [foo.bar.Test.Nested._NestedNested._garblez]:"spoo"  };
+        option (rept) = {
+          foo: "hoo"
+          [foo.bar.Test.Nested._NestedNested._garblez]: "spoo"
+        };
 
         optional Test Test = 1;
       }
@@ -105,15 +111,85 @@ extend google.protobuf.MessageOptions {
 }
 
 message Another {
-  option (rept) = { foo:"abc" array:1 array:2 array:3 s:<name:"foo" id:123 > r:<name:"f" > r:<name:"s" > r:<id:456 >  };
-  option (rept) = { foo:"def" array:3 array:2 array:1 s:<name:"bar" id:321 > r:<name:"g" > r:<name:"s" >  };
+  option (rept) = {
+    foo: "abc"
+    array: 1
+    array: 2
+    array: 3
+    s: <
+      name: "foo"
+      id: 123
+    >
+    r: <
+      name: "f"
+    >
+    r: <
+      name: "s"
+    >
+    r: <
+      id: 456
+    >
+  };
+  option (rept) = {
+    foo: "def"
+    array: 3
+    array: 2
+    array: 1
+    s: <
+      name: "bar"
+      id: 321
+    >
+    r: <
+      name: "g"
+    >
+    r: <
+      name: "s"
+    >
+  };
   option (rept) = { foo:"def"  };
 
   option (eee) = V1;
 
-  option (a) = { test:<foo:"m&m" array:1 array:2 s:<name:"yolo" id:98765 > m:<key:"bar" value:200 > m:<key:"foo" value:100 > [foo.bar.Test.Nested._NestedNested._garblez]:"whoah!" > fff:OK  };
+  option (a) = {
+    test: <
+      foo: "m&m"
+      array: 1
+      array: 2
+      s: <
+        name: "yolo"
+        id: 98765
+      >
+      m: <
+        key: "bar"
+        value: 200
+      >
+      m: <
+        key: "foo"
+        value: 100
+      >
+      [foo.bar.Test.Nested._NestedNested._garblez]: "whoah!"
+    >
+    fff: OK
+  };
 
-  option (map_vals) = { vals:<key:"" value:<> > vals:<key:"bar" value:<name:"baz" > > vals:<key:"foo" value:<> >  };
+  option (map_vals) = {
+    vals: <
+      key: ""
+      value: <
+      >
+    >
+    vals: <
+      key: "bar"
+      value: <
+        name: "baz"
+      >
+    >
+    vals: <
+      key: "foo"
+      value: <
+      >
+    >
+  };
 
   optional Test test = 1;
 
@@ -146,11 +222,23 @@ extend google.protobuf.MethodOptions {
 
 service TestTestService {
   rpc UserAuth ( Test ) returns ( Test ) {
-    option (validator) = { authenticated:true permission:<action:LOGIN entity:"client" >  };
+    option (validator) = {
+      authenticated: true
+      permission: <
+        action: LOGIN
+        entity: "client"
+      >
+    };
   }
 
   rpc Get ( Test ) returns ( Test ) {
-    option (validator) = { authenticated:true permission:<action:READ entity:"user" >  };
+    option (validator) = {
+      authenticated: true
+      permission: <
+        action: READ
+        entity: "user"
+      >
+    };
   }
 }
 
@@ -201,7 +289,18 @@ extend google.protobuf.FieldOptions {
 }
 
 message IsAuthorizedReq {
-  repeated string subjects = 1 [(rules) = { repeated:<min_items:1 items:<string:<pattern:"^(?:(?:team:(?:local|ldap))|user):[[:alnum:]_-]+$" > > >  }];
+  repeated string subjects = 1 [
+    (rules) = {
+      repeated: <
+        min_items: 1
+        items: <
+          string: <
+            pattern: "^(?:(?:team:(?:local|ldap))|user):[[:alnum:]_-]+$"
+          >
+        >
+      >
+    }
+  ];
 }
 
 message KeywordCollisions {
@@ -351,7 +450,81 @@ extend google.protobuf.FieldOptions {
 }
 
 message KeywordCollisionOptions {
-  optional uint64 id = 1 [(syntax) = true, (import) = true, (public) = true, (weak) = true, (package) = true, (string) = "string", (bytes) = "bytes", (bool) = true, (float) = 3.140000, (double) = 3.141590, (int32) = 32, (int64) = 64, (uint32) = 3200, (uint64) = 6400, (sint32) = -32, (sint64) = -64, (fixed32) = 3232, (fixed64) = 6464, (sfixed32) = -3232, (sfixed64) = -6464, (optional) = true, (repeated) = true, (required) = true, (message) = true, (enum) = true, (service) = true, (rpc) = true, (option) = true, (extend) = true, (extensions) = true, (reserved) = true, (to) = true, (true) = 111, (false) = -111, (default) = 222];
+  optional uint64 id = 1 [
+    (syntax) = true,
+    (import) = true,
+    (public) = true,
+    (weak) = true,
+    (package) = true,
+    (string) = "string",
+    (bytes) = "bytes",
+    (bool) = true,
+    (float) = 3.140000,
+    (double) = 3.141590,
+    (int32) = 32,
+    (int64) = 64,
+    (uint32) = 3200,
+    (uint64) = 6400,
+    (sint32) = -32,
+    (sint64) = -64,
+    (fixed32) = 3232,
+    (fixed64) = 6464,
+    (sfixed32) = -3232,
+    (sfixed64) = -6464,
+    (optional) = true,
+    (repeated) = true,
+    (required) = true,
+    (message) = true,
+    (enum) = true,
+    (service) = true,
+    (rpc) = true,
+    (option) = true,
+    (extend) = true,
+    (extensions) = true,
+    (reserved) = true,
+    (to) = true,
+    (true) = 111,
+    (false) = -111,
+    (default) = 222
+  ];
 
-  optional string name = 2 [(boom) = { syntax:true import:true public:true weak:true package:true string:"string" bytes:"bytes" int32:32 int64:64 uint32:3200 uint64:6400 sint32:-32 sint64:-64 fixed32:3232 fixed64:6464 sfixed32:-3232 sfixed64:-6464 bool:true float:3.14 double:3.14159 optional:true repeated:true required:true message:true enum:true service:true rpc:true option:true extend:true extensions:true reserved:true to:true true:111 false:-111 default:222  }];
+  optional string name = 2 [
+    (boom) = {
+      syntax: true
+      import: true
+      public: true
+      weak: true
+      package: true
+      string: "string"
+      bytes: "bytes"
+      int32: 32
+      int64: 64
+      uint32: 3200
+      uint64: 6400
+      sint32: -32
+      sint64: -64
+      fixed32: 3232
+      fixed64: 6464
+      sfixed32: -3232
+      sfixed64: -6464
+      bool: true
+      float: 3.14
+      double: 3.14159
+      optional: true
+      repeated: true
+      required: true
+      message: true
+      enum: true
+      service: true
+      rpc: true
+      option: true
+      extend: true
+      extensions: true
+      reserved: true
+      to: true
+      true: 111
+      false: -111
+      default: 222
+    }
+  ];
 }

--- a/desc/protoprint/testfiles/desc_test_complex-sorted-AND-multiline-style-comments.proto
+++ b/desc/protoprint/testfiles/desc_test_complex-sorted-AND-multiline-style-comments.proto
@@ -7,14 +7,84 @@ import "google/protobuf/descriptor.proto";
 option go_package = "github.com/jhump/protoreflect/internal/testprotos";
 
 message Another {
-  option (a) = { test:<foo:"m&m" array:1 array:2 s:<name:"yolo" id:98765 > m:<key:"bar" value:200 > m:<key:"foo" value:100 > [foo.bar.Test.Nested._NestedNested._garblez]:"whoah!" > fff:OK  };
+  option (a) = {
+    test: <
+      foo: "m&m"
+      array: 1
+      array: 2
+      s: <
+        name: "yolo"
+        id: 98765
+      >
+      m: <
+        key: "bar"
+        value: 200
+      >
+      m: <
+        key: "foo"
+        value: 100
+      >
+      [foo.bar.Test.Nested._NestedNested._garblez]: "whoah!"
+    >
+    fff: OK
+  };
 
   option (eee) = V1;
 
-  option (map_vals) = { vals:<key:"" value:<> > vals:<key:"bar" value:<name:"baz" > > vals:<key:"foo" value:<> >  }; /* no key, no value */
+  option (map_vals) = {
+    vals: <
+      key: ""
+      value: <
+      >
+    >
+    vals: <
+      key: "bar"
+      value: <
+        name: "baz"
+      >
+    >
+    vals: <
+      key: "foo"
+      value: <
+      >
+    >
+  }; /* no key, no value */
 
-  option (rept) = { foo:"abc" array:1 array:2 array:3 s:<name:"foo" id:123 > r:<name:"f" > r:<name:"s" > r:<id:456 >  };
-  option (rept) = { foo:"def" array:3 array:2 array:1 s:<name:"bar" id:321 > r:<name:"g" > r:<name:"s" >  };
+  option (rept) = {
+    foo: "abc"
+    array: 1
+    array: 2
+    array: 3
+    s: <
+      name: "foo"
+      id: 123
+    >
+    r: <
+      name: "f"
+    >
+    r: <
+      name: "s"
+    >
+    r: <
+      id: 456
+    >
+  };
+  option (rept) = {
+    foo: "def"
+    array: 3
+    array: 2
+    array: 1
+    s: <
+      name: "bar"
+      id: 321
+    >
+    r: <
+      name: "g"
+    >
+    r: <
+      name: "s"
+    >
+  };
   option (rept) = { foo:"def"  };
 
   optional Test test = 1;
@@ -23,13 +93,98 @@ message Another {
 }
 
 message IsAuthorizedReq {
-  repeated string subjects = 1 [(rules) = { repeated:<min_items:1 items:<string:<pattern:"^(?:(?:team:(?:local|ldap))|user):[[:alnum:]_-]+$" > > >  }];
+  repeated string subjects = 1 [
+    (rules) = {
+      repeated: <
+        min_items: 1
+        items: <
+          string: <
+            pattern: "^(?:(?:team:(?:local|ldap))|user):[[:alnum:]_-]+$"
+          >
+        >
+      >
+    }
+  ];
 }
 
 message KeywordCollisionOptions {
-  optional uint64 id = 1 [(bool) = true, (bytes) = "bytes", (default) = 222, (double) = 3.141590, (enum) = true, (extend) = true, (extensions) = true, (false) = -111, (fixed32) = 3232, (fixed64) = 6464, (float) = 3.140000, (import) = true, (int32) = 32, (int64) = 64, (message) = true, (option) = true, (optional) = true, (package) = true, (public) = true, (repeated) = true, (required) = true, (reserved) = true, (rpc) = true, (service) = true, (sfixed32) = -3232, (sfixed64) = -6464, (sint32) = -32, (sint64) = -64, (string) = "string", (syntax) = true, (to) = true, (true) = 111, (uint32) = 3200, (uint64) = 6400, (weak) = true];
+  optional uint64 id = 1 [
+    (bool) = true,
+    (bytes) = "bytes",
+    (default) = 222,
+    (double) = 3.141590,
+    (enum) = true,
+    (extend) = true,
+    (extensions) = true,
+    (false) = -111,
+    (fixed32) = 3232,
+    (fixed64) = 6464,
+    (float) = 3.140000,
+    (import) = true,
+    (int32) = 32,
+    (int64) = 64,
+    (message) = true,
+    (option) = true,
+    (optional) = true,
+    (package) = true,
+    (public) = true,
+    (repeated) = true,
+    (required) = true,
+    (reserved) = true,
+    (rpc) = true,
+    (service) = true,
+    (sfixed32) = -3232,
+    (sfixed64) = -6464,
+    (sint32) = -32,
+    (sint64) = -64,
+    (string) = "string",
+    (syntax) = true,
+    (to) = true,
+    (true) = 111,
+    (uint32) = 3200,
+    (uint64) = 6400,
+    (weak) = true
+  ];
 
-  optional string name = 2 [(boom) = { syntax:true import:true public:true weak:true package:true string:"string" bytes:"bytes" int32:32 int64:64 uint32:3200 uint64:6400 sint32:-32 sint64:-64 fixed32:3232 fixed64:6464 sfixed32:-3232 sfixed64:-6464 bool:true float:3.14 double:3.14159 optional:true repeated:true required:true message:true enum:true service:true rpc:true option:true extend:true extensions:true reserved:true to:true true:111 false:-111 default:222  }];
+  optional string name = 2 [
+    (boom) = {
+      syntax: true
+      import: true
+      public: true
+      weak: true
+      package: true
+      string: "string"
+      bytes: "bytes"
+      int32: 32
+      int64: 64
+      uint32: 3200
+      uint64: 6400
+      sint32: -32
+      sint64: -64
+      fixed32: 3232
+      fixed64: 6464
+      sfixed32: -3232
+      sfixed64: -6464
+      bool: true
+      float: 3.14
+      double: 3.14159
+      optional: true
+      repeated: true
+      required: true
+      message: true
+      enum: true
+      service: true
+      rpc: true
+      option: true
+      extend: true
+      extensions: true
+      reserved: true
+      to: true
+      true: 111
+      false: -111
+      default: 222
+    }
+  ];
 }
 
 /* tests cases where field names collide with keywords */
@@ -181,10 +336,16 @@ message Test {
     message _NestedNested {
       option (fooblez) = 10101;
 
-      option (rept) = { foo:"goo" [foo.bar.Test.Nested._NestedNested._garblez]:"boo"  };
+      option (rept) = {
+        foo: "goo"
+        [foo.bar.Test.Nested._NestedNested._garblez]: "boo"
+      };
 
       message NestedNestedNested {
-        option (rept) = { foo:"hoo" [foo.bar.Test.Nested._NestedNested._garblez]:"spoo"  };
+        option (rept) = {
+          foo: "hoo"
+          [foo.bar.Test.Nested._NestedNested._garblez]: "spoo"
+        };
 
         optional Test Test = 1;
       }
@@ -254,11 +415,23 @@ enum EnumWithReservations {
 
 service TestTestService {
   rpc Get ( Test ) returns ( Test ) {
-    option (validator) = { authenticated:true permission:<action:READ entity:"user" >  };
+    option (validator) = {
+      authenticated: true
+      permission: <
+        action: READ
+        entity: "user"
+      >
+    };
   }
 
   rpc UserAuth ( Test ) returns ( Test ) {
-    option (validator) = { authenticated:true permission:<action:LOGIN entity:"client" >  };
+    option (validator) = {
+      authenticated: true
+      permission: <
+        action: LOGIN
+        entity: "client"
+      >
+    };
   }
 }
 

--- a/desc/protoprint/testfiles/desc_test_complex-sorted.proto
+++ b/desc/protoprint/testfiles/desc_test_complex-sorted.proto
@@ -7,14 +7,84 @@ import "google/protobuf/descriptor.proto";
 option go_package = "github.com/jhump/protoreflect/internal/testprotos";
 
 message Another {
-   option (a) = { test:<foo:"m&m" array:1 array:2 s:<name:"yolo" id:98765 > m:<key:"bar" value:200 > m:<key:"foo" value:100 > [foo.bar.Test.Nested._NestedNested._garblez]:"whoah!" > fff:OK  };
+   option (a) = {
+      test: <
+         foo: "m&m"
+         array: 1
+         array: 2
+         s: <
+            name: "yolo"
+            id: 98765
+         >
+         m: <
+            key: "bar"
+            value: 200
+         >
+         m: <
+            key: "foo"
+            value: 100
+         >
+         [foo.bar.Test.Nested._NestedNested._garblez]: "whoah!"
+      >
+      fff: OK
+   };
 
    option (eee) = V1;
 
-   option (map_vals) = { vals:<key:"" value:<> > vals:<key:"bar" value:<name:"baz" > > vals:<key:"foo" value:<> >  }; // no key, no value
+   option (map_vals) = {
+      vals: <
+         key: ""
+         value: <
+         >
+      >
+      vals: <
+         key: "bar"
+         value: <
+            name: "baz"
+         >
+      >
+      vals: <
+         key: "foo"
+         value: <
+         >
+      >
+   }; // no key, no value
 
-   option (rept) = { foo:"abc" array:1 array:2 array:3 s:<name:"foo" id:123 > r:<name:"f" > r:<name:"s" > r:<id:456 >  };
-   option (rept) = { foo:"def" array:3 array:2 array:1 s:<name:"bar" id:321 > r:<name:"g" > r:<name:"s" >  };
+   option (rept) = {
+      foo: "abc"
+      array: 1
+      array: 2
+      array: 3
+      s: <
+         name: "foo"
+         id: 123
+      >
+      r: <
+         name: "f"
+      >
+      r: <
+         name: "s"
+      >
+      r: <
+         id: 456
+      >
+   };
+   option (rept) = {
+      foo: "def"
+      array: 3
+      array: 2
+      array: 1
+      s: <
+         name: "bar"
+         id: 321
+      >
+      r: <
+         name: "g"
+      >
+      r: <
+         name: "s"
+      >
+   };
    option (rept) = { foo:"def"  };
 
    optional Test test = 1;
@@ -23,13 +93,98 @@ message Another {
 }
 
 message IsAuthorizedReq {
-   repeated string subjects = 1 [(rules) = { repeated:<min_items:1 items:<string:<pattern:"^(?:(?:team:(?:local|ldap))|user):[[:alnum:]_-]+$" > > >  }];
+   repeated string subjects = 1 [
+      (rules) = {
+         repeated: <
+            min_items: 1
+            items: <
+               string: <
+                  pattern: "^(?:(?:team:(?:local|ldap))|user):[[:alnum:]_-]+$"
+               >
+            >
+         >
+      }
+   ];
 }
 
 message KeywordCollisionOptions {
-   optional uint64 id = 1 [(bool) = true, (bytes) = "bytes", (default) = 222, (double) = 3.141590, (enum) = true, (extend) = true, (extensions) = true, (false) = -111, (fixed32) = 3232, (fixed64) = 6464, (float) = 3.140000, (import) = true, (int32) = 32, (int64) = 64, (message) = true, (option) = true, (optional) = true, (package) = true, (public) = true, (repeated) = true, (required) = true, (reserved) = true, (rpc) = true, (service) = true, (sfixed32) = -3232, (sfixed64) = -6464, (sint32) = -32, (sint64) = -64, (string) = "string", (syntax) = true, (to) = true, (true) = 111, (uint32) = 3200, (uint64) = 6400, (weak) = true];
+   optional uint64 id = 1 [
+      (bool) = true,
+      (bytes) = "bytes",
+      (default) = 222,
+      (double) = 3.141590,
+      (enum) = true,
+      (extend) = true,
+      (extensions) = true,
+      (false) = -111,
+      (fixed32) = 3232,
+      (fixed64) = 6464,
+      (float) = 3.140000,
+      (import) = true,
+      (int32) = 32,
+      (int64) = 64,
+      (message) = true,
+      (option) = true,
+      (optional) = true,
+      (package) = true,
+      (public) = true,
+      (repeated) = true,
+      (required) = true,
+      (reserved) = true,
+      (rpc) = true,
+      (service) = true,
+      (sfixed32) = -3232,
+      (sfixed64) = -6464,
+      (sint32) = -32,
+      (sint64) = -64,
+      (string) = "string",
+      (syntax) = true,
+      (to) = true,
+      (true) = 111,
+      (uint32) = 3200,
+      (uint64) = 6400,
+      (weak) = true
+   ];
 
-   optional string name = 2 [(boom) = { syntax:true import:true public:true weak:true package:true string:"string" bytes:"bytes" int32:32 int64:64 uint32:3200 uint64:6400 sint32:-32 sint64:-64 fixed32:3232 fixed64:6464 sfixed32:-3232 sfixed64:-6464 bool:true float:3.14 double:3.14159 optional:true repeated:true required:true message:true enum:true service:true rpc:true option:true extend:true extensions:true reserved:true to:true true:111 false:-111 default:222  }];
+   optional string name = 2 [
+      (boom) = {
+         syntax: true
+         import: true
+         public: true
+         weak: true
+         package: true
+         string: "string"
+         bytes: "bytes"
+         int32: 32
+         int64: 64
+         uint32: 3200
+         uint64: 6400
+         sint32: -32
+         sint64: -64
+         fixed32: 3232
+         fixed64: 6464
+         sfixed32: -3232
+         sfixed64: -6464
+         bool: true
+         float: 3.14
+         double: 3.14159
+         optional: true
+         repeated: true
+         required: true
+         message: true
+         enum: true
+         service: true
+         rpc: true
+         option: true
+         extend: true
+         extensions: true
+         reserved: true
+         to: true
+         true: 111
+         false: -111
+         default: 222
+      }
+   ];
 }
 
 message KeywordCollisions {
@@ -179,10 +334,16 @@ message Test {
       message _NestedNested {
          option (fooblez) = 10101;
 
-         option (rept) = { foo:"goo" [foo.bar.Test.Nested._NestedNested._garblez]:"boo"  };
+         option (rept) = {
+            foo: "goo"
+            [foo.bar.Test.Nested._NestedNested._garblez]: "boo"
+         };
 
          message NestedNestedNested {
-            option (rept) = { foo:"hoo" [foo.bar.Test.Nested._NestedNested._garblez]:"spoo"  };
+            option (rept) = {
+               foo: "hoo"
+               [foo.bar.Test.Nested._NestedNested._garblez]: "spoo"
+            };
 
             optional Test Test = 1;
          }
@@ -252,11 +413,23 @@ enum EnumWithReservations {
 
 service TestTestService {
    rpc Get ( Test ) returns ( Test ) {
-      option (validator) = { authenticated:true permission:<action:READ entity:"user" >  };
+      option (validator) = {
+         authenticated: true
+         permission: <
+            action: READ
+            entity: "user"
+         >
+      };
    }
 
    rpc UserAuth ( Test ) returns ( Test ) {
-      option (validator) = { authenticated:true permission:<action:LOGIN entity:"client" >  };
+      option (validator) = {
+         authenticated: true
+         permission: <
+            action: LOGIN
+            entity: "client"
+         >
+      };
    }
 }
 

--- a/desc/protoprint/testfiles/desc_test_complex-trailing-on-next-line.proto
+++ b/desc/protoprint/testfiles/desc_test_complex-trailing-on-next-line.proto
@@ -61,10 +61,16 @@ message Test {
         optional string _garblez = 100;
       }
 
-      option (rept) = { foo:"goo" [foo.bar.Test.Nested._NestedNested._garblez]:"boo"  };
+      option (rept) = {
+        foo: "goo"
+        [foo.bar.Test.Nested._NestedNested._garblez]: "boo"
+      };
 
       message NestedNestedNested {
-        option (rept) = { foo:"hoo" [foo.bar.Test.Nested._NestedNested._garblez]:"spoo"  };
+        option (rept) = {
+          foo: "hoo"
+          [foo.bar.Test.Nested._NestedNested._garblez]: "spoo"
+        };
 
         optional Test Test = 1;
       }
@@ -105,15 +111,85 @@ extend google.protobuf.MessageOptions {
 }
 
 message Another {
-  option (rept) = { foo:"abc" array:1 array:2 array:3 s:<name:"foo" id:123 > r:<name:"f" > r:<name:"s" > r:<id:456 >  };
-  option (rept) = { foo:"def" array:3 array:2 array:1 s:<name:"bar" id:321 > r:<name:"g" > r:<name:"s" >  };
+  option (rept) = {
+    foo: "abc"
+    array: 1
+    array: 2
+    array: 3
+    s: <
+      name: "foo"
+      id: 123
+    >
+    r: <
+      name: "f"
+    >
+    r: <
+      name: "s"
+    >
+    r: <
+      id: 456
+    >
+  };
+  option (rept) = {
+    foo: "def"
+    array: 3
+    array: 2
+    array: 1
+    s: <
+      name: "bar"
+      id: 321
+    >
+    r: <
+      name: "g"
+    >
+    r: <
+      name: "s"
+    >
+  };
   option (rept) = { foo:"def"  };
 
   option (eee) = V1;
 
-  option (a) = { test:<foo:"m&m" array:1 array:2 s:<name:"yolo" id:98765 > m:<key:"bar" value:200 > m:<key:"foo" value:100 > [foo.bar.Test.Nested._NestedNested._garblez]:"whoah!" > fff:OK  };
+  option (a) = {
+    test: <
+      foo: "m&m"
+      array: 1
+      array: 2
+      s: <
+        name: "yolo"
+        id: 98765
+      >
+      m: <
+        key: "bar"
+        value: 200
+      >
+      m: <
+        key: "foo"
+        value: 100
+      >
+      [foo.bar.Test.Nested._NestedNested._garblez]: "whoah!"
+    >
+    fff: OK
+  };
 
-  option (map_vals) = { vals:<key:"" value:<> > vals:<key:"bar" value:<name:"baz" > > vals:<key:"foo" value:<> >  };
+  option (map_vals) = {
+    vals: <
+      key: ""
+      value: <
+      >
+    >
+    vals: <
+      key: "bar"
+      value: <
+        name: "baz"
+      >
+    >
+    vals: <
+      key: "foo"
+      value: <
+      >
+    >
+  };
   // no key, no value
 
   optional Test test = 1;
@@ -147,11 +223,23 @@ extend google.protobuf.MethodOptions {
 
 service TestTestService {
   rpc UserAuth ( Test ) returns ( Test ) {
-    option (validator) = { authenticated:true permission:<action:LOGIN entity:"client" >  };
+    option (validator) = {
+      authenticated: true
+      permission: <
+        action: LOGIN
+        entity: "client"
+      >
+    };
   }
 
   rpc Get ( Test ) returns ( Test ) {
-    option (validator) = { authenticated:true permission:<action:READ entity:"user" >  };
+    option (validator) = {
+      authenticated: true
+      permission: <
+        action: READ
+        entity: "user"
+      >
+    };
   }
 }
 
@@ -202,7 +290,18 @@ extend google.protobuf.FieldOptions {
 }
 
 message IsAuthorizedReq {
-  repeated string subjects = 1 [(rules) = { repeated:<min_items:1 items:<string:<pattern:"^(?:(?:team:(?:local|ldap))|user):[[:alnum:]_-]+$" > > >  }];
+  repeated string subjects = 1 [
+    (rules) = {
+      repeated: <
+        min_items: 1
+        items: <
+          string: <
+            pattern: "^(?:(?:team:(?:local|ldap))|user):[[:alnum:]_-]+$"
+          >
+        >
+      >
+    }
+  ];
 }
 
 // tests cases where field names collide with keywords
@@ -354,7 +453,81 @@ extend google.protobuf.FieldOptions {
 }
 
 message KeywordCollisionOptions {
-  optional uint64 id = 1 [(syntax) = true, (import) = true, (public) = true, (weak) = true, (package) = true, (string) = "string", (bytes) = "bytes", (bool) = true, (float) = 3.140000, (double) = 3.141590, (int32) = 32, (int64) = 64, (uint32) = 3200, (uint64) = 6400, (sint32) = -32, (sint64) = -64, (fixed32) = 3232, (fixed64) = 6464, (sfixed32) = -3232, (sfixed64) = -6464, (optional) = true, (repeated) = true, (required) = true, (message) = true, (enum) = true, (service) = true, (rpc) = true, (option) = true, (extend) = true, (extensions) = true, (reserved) = true, (to) = true, (true) = 111, (false) = -111, (default) = 222];
+  optional uint64 id = 1 [
+    (syntax) = true,
+    (import) = true,
+    (public) = true,
+    (weak) = true,
+    (package) = true,
+    (string) = "string",
+    (bytes) = "bytes",
+    (bool) = true,
+    (float) = 3.140000,
+    (double) = 3.141590,
+    (int32) = 32,
+    (int64) = 64,
+    (uint32) = 3200,
+    (uint64) = 6400,
+    (sint32) = -32,
+    (sint64) = -64,
+    (fixed32) = 3232,
+    (fixed64) = 6464,
+    (sfixed32) = -3232,
+    (sfixed64) = -6464,
+    (optional) = true,
+    (repeated) = true,
+    (required) = true,
+    (message) = true,
+    (enum) = true,
+    (service) = true,
+    (rpc) = true,
+    (option) = true,
+    (extend) = true,
+    (extensions) = true,
+    (reserved) = true,
+    (to) = true,
+    (true) = 111,
+    (false) = -111,
+    (default) = 222
+  ];
 
-  optional string name = 2 [(boom) = { syntax:true import:true public:true weak:true package:true string:"string" bytes:"bytes" int32:32 int64:64 uint32:3200 uint64:6400 sint32:-32 sint64:-64 fixed32:3232 fixed64:6464 sfixed32:-3232 sfixed64:-6464 bool:true float:3.14 double:3.14159 optional:true repeated:true required:true message:true enum:true service:true rpc:true option:true extend:true extensions:true reserved:true to:true true:111 false:-111 default:222  }];
+  optional string name = 2 [
+    (boom) = {
+      syntax: true
+      import: true
+      public: true
+      weak: true
+      package: true
+      string: "string"
+      bytes: "bytes"
+      int32: 32
+      int64: 64
+      uint32: 3200
+      uint64: 6400
+      sint32: -32
+      sint64: -64
+      fixed32: 3232
+      fixed64: 6464
+      sfixed32: -3232
+      sfixed64: -6464
+      bool: true
+      float: 3.14
+      double: 3.14159
+      optional: true
+      repeated: true
+      required: true
+      message: true
+      enum: true
+      service: true
+      rpc: true
+      option: true
+      extend: true
+      extensions: true
+      reserved: true
+      to: true
+      true: 111
+      false: -111
+      default: 222
+    }
+  ];
 }

--- a/desc/protoprint/testfiles/test-non-files-compact.txt
+++ b/desc/protoprint/testfiles/test-non-files-compact.txt
@@ -11,7 +11,12 @@ message Request {
   option deprecated = true;
   option (.testprotos.mfubar) = true;
   // A field comment
-  repeated int32 ids = 1 [json_name = "|foo|", packed = true, (.testprotos.ffubar) = "abc", (.testprotos.ffubarb) = "xyz"];
+  repeated int32 ids = 1 [
+    json_name = "|foo|",
+    packed = true,
+    (.testprotos.ffubar) = "abc",
+    (.testprotos.ffubarb) = "xyz"
+  ];
   // label comment
   optional string name = 2 [default = "fubar"];
   // Group comment
@@ -41,8 +46,14 @@ message Request {
     option (.testprotos.efubar) = 123;
     option (.testprotos.efubars) = -321;
     SNIFIT = -101;
-    MARIO = 1 [(.testprotos.evfubar) = 278, (.testprotos.evfubars) = -314];
-    LUIGI = 2 [(.testprotos.evfubaru) = 200, (.testprotos.evfubaruf) = 100];
+    MARIO = 1 [
+      (.testprotos.evfubar) = 278,
+      (.testprotos.evfubars) = -314
+    ];
+    LUIGI = 2 [
+      (.testprotos.evfubaru) = 200,
+      (.testprotos.evfubaruf) = 100
+    ];
     PEACH = 3;
     BOWSER = 4;
     WARIO = 5;
@@ -53,7 +64,10 @@ message Request {
     MAGIKOOPA = 8;
   }
   extensions 100 to 200;
-  extensions 201 to 250 [(.testprotos.exfubar) = "splat!", (.testprotos.exfubarb) = "\000\001\002\003\004\005\006\007"];
+  extensions 201 to 250 [
+    (.testprotos.exfubar) = "splat!",
+    (.testprotos.exfubarb) = "\000\001\002\003\004\005\006\007"
+  ];
   reserved 10 to 20, 30 to 50;
   reserved "bar", "baz", "foo";
 }
@@ -82,7 +96,12 @@ message Request {
   option deprecated = true;
   option (.testprotos.mfubar) = true;
   // A field comment
-  repeated int32 ids = 1 [json_name = "|foo|", packed = true, (.testprotos.ffubar) = "abc", (.testprotos.ffubarb) = "xyz"];
+  repeated int32 ids = 1 [
+    json_name = "|foo|",
+    packed = true,
+    (.testprotos.ffubar) = "abc",
+    (.testprotos.ffubarb) = "xyz"
+  ];
   // label comment
   optional string name = 2 [default = "fubar"];
   // Group comment
@@ -112,8 +131,14 @@ message Request {
     option (.testprotos.efubar) = 123;
     option (.testprotos.efubars) = -321;
     SNIFIT = -101;
-    MARIO = 1 [(.testprotos.evfubar) = 278, (.testprotos.evfubars) = -314];
-    LUIGI = 2 [(.testprotos.evfubaru) = 200, (.testprotos.evfubaruf) = 100];
+    MARIO = 1 [
+      (.testprotos.evfubar) = 278,
+      (.testprotos.evfubars) = -314
+    ];
+    LUIGI = 2 [
+      (.testprotos.evfubaru) = 200,
+      (.testprotos.evfubaruf) = 100
+    ];
     PEACH = 3;
     BOWSER = 4;
     WARIO = 5;
@@ -124,13 +149,21 @@ message Request {
     MAGIKOOPA = 8;
   }
   extensions 100 to 200;
-  extensions 201 to 250 [(.testprotos.exfubar) = "splat!", (.testprotos.exfubarb) = "\000\001\002\003\004\005\006\007"];
+  extensions 201 to 250 [
+    (.testprotos.exfubar) = "splat!",
+    (.testprotos.exfubarb) = "\000\001\002\003\004\005\006\007"
+  ];
   reserved 10 to 20, 30 to 50;
   reserved "bar", "baz", "foo";
 }
 -------- foo.bar.Request.ids (*desc.FieldDescriptor) --------
 // A field comment
-repeated int32 ids = 1 [json_name = "|foo|", packed = true, (.testprotos.ffubar) = "abc", (.testprotos.ffubarb) = "xyz"];
+repeated int32 ids = 1 [
+  json_name = "|foo|",
+  packed = true,
+  (.testprotos.ffubar) = "abc",
+  (.testprotos.ffubarb) = "xyz"
+];
 -------- foo.bar.Request.name (*desc.FieldDescriptor) --------
 // label comment
 optional string name = 2 [default = "fubar"];
@@ -199,8 +232,14 @@ enum MarioCharacters {
   option (.testprotos.efubar) = 123;
   option (.testprotos.efubars) = -321;
   SNIFIT = -101;
-  MARIO = 1 [(.testprotos.evfubar) = 278, (.testprotos.evfubars) = -314];
-  LUIGI = 2 [(.testprotos.evfubaru) = 200, (.testprotos.evfubaruf) = 100];
+  MARIO = 1 [
+    (.testprotos.evfubar) = 278,
+    (.testprotos.evfubars) = -314
+  ];
+  LUIGI = 2 [
+    (.testprotos.evfubaru) = 200,
+    (.testprotos.evfubaruf) = 100
+  ];
   PEACH = 3;
   BOWSER = 4;
   WARIO = 5;
@@ -211,9 +250,15 @@ enum MarioCharacters {
   MAGIKOOPA = 8;
 }
 -------- foo.bar.Request.MarioCharacters.MARIO (*desc.EnumValueDescriptor) --------
-MARIO = 1 [(.testprotos.evfubar) = 278, (.testprotos.evfubars) = -314];
+MARIO = 1 [
+  (.testprotos.evfubar) = 278,
+  (.testprotos.evfubars) = -314
+];
 -------- foo.bar.Request.MarioCharacters.LUIGI (*desc.EnumValueDescriptor) --------
-LUIGI = 2 [(.testprotos.evfubaru) = 200, (.testprotos.evfubaruf) = 100];
+LUIGI = 2 [
+  (.testprotos.evfubaru) = 200,
+  (.testprotos.evfubaruf) = 100
+];
 -------- foo.bar.Request.MarioCharacters.PEACH (*desc.EnumValueDescriptor) --------
 PEACH = 3;
 -------- foo.bar.Request.MarioCharacters.BOWSER (*desc.EnumValueDescriptor) --------

--- a/desc/protoprint/testfiles/test-non-files-full.txt
+++ b/desc/protoprint/testfiles/test-non-files-full.txt
@@ -30,7 +30,14 @@ message /* detached message name */ /* request with a capital R */ Request /* tr
        * tag trailer
        * that spans multiple lines...
        * more than two.
-       */ [packed = true /* packed! */, json_name = "|foo|" /* custom JSON! */, (testprotos.ffubar) = "abc", (testprotos.ffubarb) = "xyz"]; // field trailer #1...
+       */ [
+    packed = true,
+    // packed!
+    json_name = "|foo|",
+    // custom JSON!
+    (testprotos.ffubar) = "abc",
+    (testprotos.ffubarb) = "xyz"
+  ]; // field trailer #1...
 
   // lead mfubar
   option (testprotos.mfubar) = true; // trailing mfubar
@@ -42,11 +49,17 @@ message /* detached message name */ /* request with a capital R */ Request /* tr
   // Another field comment
 
   // label comment
-  optional /* type comment */ string /* name comment */ name = 2 [/* default lead */ default = "fubar" /* default trail */];
+  optional /* type comment */ string /* name comment */ name = 2 [
+    // default lead
+    default = "fubar" // default trail
+  ];
 
   extensions 100 to 200;
 
-  extensions 201 to 250 [(testprotos.exfubarb) = "\000\001\002\003\004\005\006\007", (testprotos.exfubar) = "splat!"];
+  extensions 201 to 250 [
+    (testprotos.exfubarb) = "\000\001\002\003\004\005\006\007",
+    (testprotos.exfubar) = "splat!"
+  ];
 
   reserved 10 to 20, 30 to 50;
 
@@ -75,9 +88,15 @@ message /* detached message name */ /* request with a capital R */ Request /* tr
     // allow_alias comments!
     option allow_alias = true;
 
-    MARIO = 1 [(testprotos.evfubars) = -314, (testprotos.evfubar) = 278];
+    MARIO = 1 [
+      (testprotos.evfubars) = -314,
+      (testprotos.evfubar) = 278
+    ];
 
-    LUIGI = 2 [(testprotos.evfubaruf) = 100, (testprotos.evfubaru) = 200];
+    LUIGI = 2 [
+      (testprotos.evfubaruf) = 100,
+      (testprotos.evfubaru) = 200
+    ];
 
     PEACH = 3;
 
@@ -181,7 +200,14 @@ message /* detached message name */ /* request with a capital R */ Request /* tr
        * tag trailer
        * that spans multiple lines...
        * more than two.
-       */ [packed = true /* packed! */, json_name = "|foo|" /* custom JSON! */, (testprotos.ffubar) = "abc", (testprotos.ffubarb) = "xyz"]; // field trailer #1...
+       */ [
+    packed = true,
+    // packed!
+    json_name = "|foo|",
+    // custom JSON!
+    (testprotos.ffubar) = "abc",
+    (testprotos.ffubarb) = "xyz"
+  ]; // field trailer #1...
 
   // lead mfubar
   option (testprotos.mfubar) = true; // trailing mfubar
@@ -193,11 +219,17 @@ message /* detached message name */ /* request with a capital R */ Request /* tr
   // Another field comment
 
   // label comment
-  optional /* type comment */ string /* name comment */ name = 2 [/* default lead */ default = "fubar" /* default trail */];
+  optional /* type comment */ string /* name comment */ name = 2 [
+    // default lead
+    default = "fubar" // default trail
+  ];
 
   extensions 100 to 200;
 
-  extensions 201 to 250 [(testprotos.exfubarb) = "\000\001\002\003\004\005\006\007", (testprotos.exfubar) = "splat!"];
+  extensions 201 to 250 [
+    (testprotos.exfubarb) = "\000\001\002\003\004\005\006\007",
+    (testprotos.exfubar) = "splat!"
+  ];
 
   reserved 10 to 20, 30 to 50;
 
@@ -226,9 +258,15 @@ message /* detached message name */ /* request with a capital R */ Request /* tr
     // allow_alias comments!
     option allow_alias = true;
 
-    MARIO = 1 [(testprotos.evfubars) = -314, (testprotos.evfubar) = 278];
+    MARIO = 1 [
+      (testprotos.evfubars) = -314,
+      (testprotos.evfubar) = 278
+    ];
 
-    LUIGI = 2 [(testprotos.evfubaruf) = 100, (testprotos.evfubaru) = 200];
+    LUIGI = 2 [
+      (testprotos.evfubaruf) = 100,
+      (testprotos.evfubaru) = 200
+    ];
 
     PEACH = 3;
 
@@ -281,7 +319,14 @@ repeated int32 ids = /* detached tag */ /* tag numero uno */ 1 /*
      * tag trailer
      * that spans multiple lines...
      * more than two.
-     */ [packed = true /* packed! */, json_name = "|foo|" /* custom JSON! */, (testprotos.ffubar) = "abc", (testprotos.ffubarb) = "xyz"]; // field trailer #1...
+     */ [
+  packed = true,
+  // packed!
+  json_name = "|foo|",
+  // custom JSON!
+  (testprotos.ffubar) = "abc",
+  (testprotos.ffubarb) = "xyz"
+]; // field trailer #1...
 -------- foo.bar.Request.name (*desc.FieldDescriptor) --------
 // some detached comments
 
@@ -290,7 +335,10 @@ repeated int32 ids = /* detached tag */ /* tag numero uno */ 1 /*
 // Another field comment
 
 // label comment
-optional /* type comment */ string /* name comment */ name = 2 [/* default lead */ default = "fubar" /* default trail */];
+optional /* type comment */ string /* name comment */ name = 2 [
+  // default lead
+  default = "fubar" // default trail
+];
 -------- foo.bar.Request.extras (*desc.FieldDescriptor) --------
 // Group comment
 optional group Extras = 3 {
@@ -376,9 +424,15 @@ enum MarioCharacters /* "super"! */ {
   // allow_alias comments!
   option allow_alias = true;
 
-  MARIO = 1 [(testprotos.evfubars) = -314, (testprotos.evfubar) = 278];
+  MARIO = 1 [
+    (testprotos.evfubars) = -314,
+    (testprotos.evfubar) = 278
+  ];
 
-  LUIGI = 2 [(testprotos.evfubaruf) = 100, (testprotos.evfubaru) = 200];
+  LUIGI = 2 [
+    (testprotos.evfubaruf) = 100,
+    (testprotos.evfubaru) = 200
+  ];
 
   PEACH = 3;
 
@@ -403,9 +457,15 @@ enum MarioCharacters /* "super"! */ {
   option (testprotos.efubar) = 123;
 }
 -------- foo.bar.Request.MarioCharacters.MARIO (*desc.EnumValueDescriptor) --------
-MARIO = 1 [(testprotos.evfubars) = -314, (testprotos.evfubar) = 278];
+MARIO = 1 [
+  (testprotos.evfubars) = -314,
+  (testprotos.evfubar) = 278
+];
 -------- foo.bar.Request.MarioCharacters.LUIGI (*desc.EnumValueDescriptor) --------
-LUIGI = 2 [(testprotos.evfubaruf) = 100, (testprotos.evfubaru) = 200];
+LUIGI = 2 [
+  (testprotos.evfubaruf) = 100,
+  (testprotos.evfubaru) = 200
+];
 -------- foo.bar.Request.MarioCharacters.PEACH (*desc.EnumValueDescriptor) --------
 PEACH = 3;
 -------- foo.bar.Request.MarioCharacters.BOWSER (*desc.EnumValueDescriptor) --------

--- a/desc/protoprint/testfiles/test-preserve-comments.proto
+++ b/desc/protoprint/testfiles/test-preserve-comments.proto
@@ -29,7 +29,14 @@ message /* detached message name */ /* request with a capital R */ Request /* tr
        * tag trailer
        * that spans multiple lines...
        * more than two.
-       */ [packed = true /* packed! */, json_name = "|foo|" /* custom JSON! */, (testprotos.ffubar) = "abc", (testprotos.ffubarb) = "xyz"]; // field trailer #1...
+       */ [
+    packed = true,
+    // packed!
+    json_name = "|foo|",
+    // custom JSON!
+    (testprotos.ffubar) = "abc",
+    (testprotos.ffubarb) = "xyz"
+  ]; // field trailer #1...
 
   // lead mfubar
   option (testprotos.mfubar) = true; // trailing mfubar
@@ -41,11 +48,17 @@ message /* detached message name */ /* request with a capital R */ Request /* tr
   // Another field comment
 
   // label comment
-  optional /* type comment */ string /* name comment */ name = 2 [/* default lead */ default = "fubar" /* default trail */];
+  optional /* type comment */ string /* name comment */ name = 2 [
+    // default lead
+    default = "fubar" // default trail
+  ];
 
   extensions 100 to 200;
 
-  extensions 201 to 250 [(testprotos.exfubarb) = "\000\001\002\003\004\005\006\007", (testprotos.exfubar) = "splat!"];
+  extensions 201 to 250 [
+    (testprotos.exfubarb) = "\000\001\002\003\004\005\006\007",
+    (testprotos.exfubar) = "splat!"
+  ];
 
   reserved 10 to 20, 30 to 50;
 
@@ -74,9 +87,15 @@ message /* detached message name */ /* request with a capital R */ Request /* tr
     // allow_alias comments!
     option allow_alias = true;
 
-    MARIO = 1 [(testprotos.evfubars) = -314, (testprotos.evfubar) = 278];
+    MARIO = 1 [
+      (testprotos.evfubars) = -314,
+      (testprotos.evfubar) = 278
+    ];
 
-    LUIGI = 2 [(testprotos.evfubaruf) = 100, (testprotos.evfubaru) = 200];
+    LUIGI = 2 [
+      (testprotos.evfubaruf) = 100,
+      (testprotos.evfubaru) = 200
+    ];
 
     PEACH = 3;
 

--- a/desc/protoprint/testfiles/test-preserve-doc-comments.proto
+++ b/desc/protoprint/testfiles/test-preserve-doc-comments.proto
@@ -13,7 +13,12 @@ message Request {
   option deprecated = true;
 
   // A field comment
-  repeated int32 ids = 1 [packed = true, json_name = "|foo|", (testprotos.ffubar) = "abc", (testprotos.ffubarb) = "xyz"];
+  repeated int32 ids = 1 [
+    packed = true,
+    json_name = "|foo|",
+    (testprotos.ffubar) = "abc",
+    (testprotos.ffubarb) = "xyz"
+  ];
 
   option (testprotos.mfubar) = true;
 
@@ -22,7 +27,10 @@ message Request {
 
   extensions 100 to 200;
 
-  extensions 201 to 250 [(testprotos.exfubarb) = "\000\001\002\003\004\005\006\007", (testprotos.exfubar) = "splat!"];
+  extensions 201 to 250 [
+    (testprotos.exfubarb) = "\000\001\002\003\004\005\006\007",
+    (testprotos.exfubar) = "splat!"
+  ];
 
   reserved 10 to 20, 30 to 50;
 
@@ -45,9 +53,15 @@ message Request {
   enum MarioCharacters {
     option allow_alias = true;
 
-    MARIO = 1 [(testprotos.evfubars) = -314, (testprotos.evfubar) = 278];
+    MARIO = 1 [
+      (testprotos.evfubars) = -314,
+      (testprotos.evfubar) = 278
+    ];
 
-    LUIGI = 2 [(testprotos.evfubaruf) = 100, (testprotos.evfubaru) = 200];
+    LUIGI = 2 [
+      (testprotos.evfubaruf) = 100,
+      (testprotos.evfubaru) = 200
+    ];
 
     PEACH = 3;
 

--- a/desc/protoprint/testfiles/test-unrecognized-options.proto
+++ b/desc/protoprint/testfiles/test-unrecognized-options.proto
@@ -25,7 +25,9 @@ message Foo {
 
 service TestService {
   rpc Get ( Test ) returns ( Test ) {
-    option (foo) = { bar:<baz:FROB name:"abc"> bar:<baz:NITZ name:"xyz"> };
+    option (foo) = {
+      bar:<baz:FROB name:"abc"> bar:<baz:NITZ name:"xyz">
+    };
   }
 }
 


### PR DESCRIPTION
Caveat: the message literals won't always work as expected since there's not a way in the V1 runtime for marshalling to the text format to supply marshaller options to things that implement `proto.TextMarshaler`, like `*dynamic.Message`. So even though we try to marshal in multi-line mode, if the options are not known at compile-time and must be represented using dynamic messages, the formatting will still sadly be all on one line :/