### PR TITLE
Improvements to recently introduced sourceinfo stuff

### DIFF
--- a/desc/builder/builder_test.go
+++ b/desc/builder/builder_test.go
@@ -540,8 +540,9 @@ func roundTripFile(t *testing.T, fd *desc.FileDescriptor) {
 	fdp.PublicDependency = nil
 	fdp.WeakDependency = nil
 
-	// Remove source code info that the builder generated since the original
-	// has none.
+	// Remove source code info: what the builder generates is not expected to
+	// match the original source.
+	fdp.SourceCodeInfo = nil
 	roundTripped.AsFileDescriptorProto().SourceCodeInfo = nil
 
 	// Finally, sort the imports. That way they match the built result (which

--- a/desc/load.go
+++ b/desc/load.go
@@ -8,6 +8,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 
+	"github.com/jhump/protoreflect/desc/sourceinfo"
 	"github.com/jhump/protoreflect/internal"
 )
 
@@ -44,6 +45,7 @@ func loadFileDescriptorLocked(file string, r *ImportResolver) (*FileDescriptor, 
 	if err != nil {
 		return nil, err
 	}
+	fd.SourceCodeInfo = sourceinfo.SourceInfoForFile(file)
 
 	f, err = toFileDescriptorLocked(fd, r)
 	if err != nil {

--- a/desc/load.go
+++ b/desc/load.go
@@ -45,7 +45,6 @@ func loadFileDescriptorLocked(file string, r *ImportResolver) (*FileDescriptor, 
 	if err != nil {
 		return nil, err
 	}
-	fd.SourceCodeInfo = sourceinfo.SourceInfoForFile(file)
 
 	f, err = toFileDescriptorLocked(fd, r)
 	if err != nil {
@@ -56,6 +55,7 @@ func loadFileDescriptorLocked(file string, r *ImportResolver) (*FileDescriptor, 
 }
 
 func toFileDescriptorLocked(fd *dpb.FileDescriptorProto, r *ImportResolver) (*FileDescriptor, error) {
+	fd.SourceCodeInfo = sourceinfo.SourceInfoForFile(fd.GetName())
 	deps := make([]*FileDescriptor, len(fd.GetDependency()))
 	for i, dep := range fd.GetDependency() {
 		resolvedDep := r.ResolveImport(fd.GetName(), dep)

--- a/desc/protoparse/linker_test.go
+++ b/desc/protoparse/linker_test.go
@@ -87,6 +87,9 @@ func checkFiles(t *testing.T, act, exp *desc.FileDescriptor, checked map[string]
 	}
 	checked[act.GetName()] = struct{}{}
 
+	// remove any source code info from expected value, since actual won't have any
+	exp.AsFileDescriptorProto().SourceCodeInfo = nil
+
 	testutil.Require(t, proto.Equal(exp.AsFileDescriptorProto(), act.AsProto()), "linked descriptor did not match output from protoc:\nwanted: %s\ngot: %s", toString(exp.AsProto()), toString(act.AsProto()))
 
 	for i, dep := range act.GetDependencies() {

--- a/desc/protoprint/testfiles/desc_test2-compact.proto
+++ b/desc/protoprint/testfiles/desc_test2-compact.proto
@@ -1,9 +1,9 @@
 syntax = "proto2";
+option go_package = "github.com/jhump/protoreflect/internal/testprotos";
 package testprotos;
 import "desc_test1.proto";
 import "pkg/desc_test_pkg.proto";
 import "nopkg/desc_test_nopkg.proto";
-option go_package = "github.com/jhump/protoreflect/internal/testprotos";
 message Frobnitz {
   optional TestMessage a = 1;
   optional AnotherTestMessage b = 2;

--- a/desc/protoprint/testfiles/desc_test2-default.proto
+++ b/desc/protoprint/testfiles/desc_test2-default.proto
@@ -1,5 +1,7 @@
 syntax = "proto2";
 
+option go_package = "github.com/jhump/protoreflect/internal/testprotos";
+
 package testprotos;
 
 import "desc_test1.proto";
@@ -7,8 +9,6 @@ import "desc_test1.proto";
 import "pkg/desc_test_pkg.proto";
 
 import "nopkg/desc_test_nopkg.proto";
-
-option go_package = "github.com/jhump/protoreflect/internal/testprotos";
 
 message Frobnitz {
   optional TestMessage a = 1;

--- a/desc/protoprint/testfiles/desc_test2-multiline-style-comments.proto
+++ b/desc/protoprint/testfiles/desc_test2-multiline-style-comments.proto
@@ -1,5 +1,7 @@
 syntax = "proto2";
 
+option go_package = "github.com/jhump/protoreflect/internal/testprotos";
+
 package testprotos;
 
 import "desc_test1.proto";
@@ -7,8 +9,6 @@ import "desc_test1.proto";
 import "pkg/desc_test_pkg.proto";
 
 import "nopkg/desc_test_nopkg.proto";
-
-option go_package = "github.com/jhump/protoreflect/internal/testprotos";
 
 message Frobnitz {
 	optional TestMessage a = 1;

--- a/desc/protoprint/testfiles/desc_test2-no-trailing-comments.proto
+++ b/desc/protoprint/testfiles/desc_test2-no-trailing-comments.proto
@@ -1,5 +1,7 @@
 syntax = "proto2";
 
+option go_package = "github.com/jhump/protoreflect/internal/testprotos";
+
 package testprotos;
 
 import "desc_test1.proto";
@@ -7,8 +9,6 @@ import "desc_test1.proto";
 import "pkg/desc_test_pkg.proto";
 
 import "nopkg/desc_test_nopkg.proto";
-
-option go_package = "github.com/jhump/protoreflect/internal/testprotos";
 
 message Frobnitz {
   optional TestMessage a = 1;

--- a/desc/protoprint/testfiles/desc_test2-only-doc-comments.proto
+++ b/desc/protoprint/testfiles/desc_test2-only-doc-comments.proto
@@ -1,5 +1,7 @@
 syntax = "proto2";
 
+option go_package = "github.com/jhump/protoreflect/internal/testprotos";
+
 package testprotos;
 
 import "desc_test1.proto";
@@ -7,8 +9,6 @@ import "desc_test1.proto";
 import "pkg/desc_test_pkg.proto";
 
 import "nopkg/desc_test_nopkg.proto";
-
-option go_package = "github.com/jhump/protoreflect/internal/testprotos";
 
 message Frobnitz {
   optional TestMessage a = 1;

--- a/desc/protoprint/testfiles/desc_test2-trailing-on-next-line.proto
+++ b/desc/protoprint/testfiles/desc_test2-trailing-on-next-line.proto
@@ -1,5 +1,7 @@
 syntax = "proto2";
 
+option go_package = "github.com/jhump/protoreflect/internal/testprotos";
+
 package testprotos;
 
 import "desc_test1.proto";
@@ -7,8 +9,6 @@ import "desc_test1.proto";
 import "pkg/desc_test_pkg.proto";
 
 import "nopkg/desc_test_nopkg.proto";
-
-option go_package = "github.com/jhump/protoreflect/internal/testprotos";
 
 message Frobnitz {
   optional TestMessage a = 1;

--- a/desc/sourceinfo/srcinforeflection/serverreflection.go
+++ b/desc/sourceinfo/srcinforeflection/serverreflection.go
@@ -2,6 +2,12 @@
 // that includes source code info, if the protoc-gen-gosrcinfo plugin was used
 // for the files that contain the descriptors being served. This allows for
 // sending comment information to dynamic/reflective clients.
+//
+// NOTE: This package is EXPERIMENTAL! It may not see the light of day in an
+// actual release. Instead, the hope is that the core gRPC reflection package
+// can be updated in a way to more easily accommodate customizations, such as
+// the caller wanting to use sourceinfo.GlobalFiles as the source of descriptors.
+// Related: https://github.com/grpc/grpc-go/pull/5197
 package srcinforeflection
 
 import (

--- a/dynamic/dynamic_message_test.go
+++ b/dynamic/dynamic_message_test.go
@@ -2045,6 +2045,9 @@ func TestGetDescriptor(t *testing.T) {
 		testutil.Eq(t, expectedPath, actualPath, "%s: descriptor paths are not the same", testCase.name)
 
 		actualFd, err := internal.DecodeFileDescriptor("TestMessage", actualBytes)
+		// desc.LoadMessageDescriptorForMessage above can incorporate source code info that will
+		// not be present when directly calling generated messages's Descriptor method
+		actualFd.SourceCodeInfo = nil
 		testutil.Ok(t, err, "%s: failed to decode descriptor from bytes", testCase.name)
 		expectedFd, err := internal.DecodeFileDescriptor("TestMessage", expectedBytes)
 		testutil.Ok(t, err, "%s: failed to decode descriptor from bytes", testCase.name)

--- a/internal/testprotos/desc_test1.pb.srcinfo.go
+++ b/internal/testprotos/desc_test1.pb.srcinfo.go
@@ -5,7 +5,7 @@ package testprotos
 
 import "github.com/jhump/protoreflect/desc/sourceinfo"
 import "google.golang.org/protobuf/proto"
-import descriptorpb "google.golang.org/protobuf/types/descriptorpb"
+import "google.golang.org/protobuf/types/descriptorpb"
 
 var srcInfo_desc_test1 = []byte{
 	0x0a, 0x06, 0x12, 0x04, 0x00, 0x00, 0x76, 0x01, 0x0a, 0x08, 0x0a, 0x01, 0x0c, 0x12, 0x03, 0x00,

--- a/internal/testprotos/desc_test2.pb.srcinfo.go
+++ b/internal/testprotos/desc_test2.pb.srcinfo.go
@@ -5,7 +5,7 @@ package testprotos
 
 import "github.com/jhump/protoreflect/desc/sourceinfo"
 import "google.golang.org/protobuf/proto"
-import descriptorpb "google.golang.org/protobuf/types/descriptorpb"
+import "google.golang.org/protobuf/types/descriptorpb"
 
 var srcInfo_desc_test2 = []byte{
 	0x0a, 0x06, 0x12, 0x04, 0x00, 0x00, 0x2a, 0x01, 0x0a, 0x08, 0x0a, 0x01, 0x0c, 0x12, 0x03, 0x00,

--- a/internal/testprotos/desc_test_comments.pb.srcinfo.go
+++ b/internal/testprotos/desc_test_comments.pb.srcinfo.go
@@ -5,7 +5,7 @@ package testprotos
 
 import "github.com/jhump/protoreflect/desc/sourceinfo"
 import "google.golang.org/protobuf/proto"
-import descriptorpb "google.golang.org/protobuf/types/descriptorpb"
+import "google.golang.org/protobuf/types/descriptorpb"
 
 var srcInfo_desc_test_comments = []byte{
 	0x0a, 0x07, 0x12, 0x05, 0x07, 0x00, 0x9b, 0x01, 0x01, 0x0a, 0xa1, 0x01, 0x0a, 0x01, 0x0c, 0x12,

--- a/internal/testprotos/desc_test_complex.pb.srcinfo.go
+++ b/internal/testprotos/desc_test_complex.pb.srcinfo.go
@@ -5,7 +5,7 @@ package testprotos
 
 import "github.com/jhump/protoreflect/desc/sourceinfo"
 import "google.golang.org/protobuf/proto"
-import descriptorpb "google.golang.org/protobuf/types/descriptorpb"
+import "google.golang.org/protobuf/types/descriptorpb"
 
 var srcInfo_desc_test_complex = []byte{
 	0x0a, 0x07, 0x12, 0x05, 0x00, 0x00, 0xa7, 0x02, 0x01, 0x0a, 0x08, 0x0a, 0x01, 0x0c, 0x12, 0x03,

--- a/internal/testprotos/desc_test_defaults.pb.srcinfo.go
+++ b/internal/testprotos/desc_test_defaults.pb.srcinfo.go
@@ -5,7 +5,7 @@ package testprotos
 
 import "github.com/jhump/protoreflect/desc/sourceinfo"
 import "google.golang.org/protobuf/proto"
-import descriptorpb "google.golang.org/protobuf/types/descriptorpb"
+import "google.golang.org/protobuf/types/descriptorpb"
 
 var srcInfo_desc_test_defaults = []byte{
 	0x0a, 0x06, 0x12, 0x04, 0x00, 0x00, 0x7b, 0x01, 0x0a, 0x09, 0x0a, 0x01, 0x0c, 0x12, 0x04, 0x00,

--- a/internal/testprotos/desc_test_field_types.pb.srcinfo.go
+++ b/internal/testprotos/desc_test_field_types.pb.srcinfo.go
@@ -5,7 +5,7 @@ package testprotos
 
 import "github.com/jhump/protoreflect/desc/sourceinfo"
 import "google.golang.org/protobuf/proto"
-import descriptorpb "google.golang.org/protobuf/types/descriptorpb"
+import "google.golang.org/protobuf/types/descriptorpb"
 
 var srcInfo_desc_test_field_types = []byte{
 	0x0a, 0x06, 0x12, 0x04, 0x00, 0x00, 0x75, 0x01, 0x0a, 0x08, 0x0a, 0x01, 0x0c, 0x12, 0x03, 0x00,

--- a/internal/testprotos/desc_test_oneof.pb.srcinfo.go
+++ b/internal/testprotos/desc_test_oneof.pb.srcinfo.go
@@ -5,7 +5,7 @@ package testprotos
 
 import "github.com/jhump/protoreflect/desc/sourceinfo"
 import "google.golang.org/protobuf/proto"
-import descriptorpb "google.golang.org/protobuf/types/descriptorpb"
+import "google.golang.org/protobuf/types/descriptorpb"
 
 var srcInfo_desc_test_oneof = []byte{
 	0x0a, 0x06, 0x12, 0x04, 0x00, 0x00, 0x11, 0x01, 0x0a, 0x08, 0x0a, 0x01, 0x0c, 0x12, 0x03, 0x00,

--- a/internal/testprotos/desc_test_options.pb.srcinfo.go
+++ b/internal/testprotos/desc_test_options.pb.srcinfo.go
@@ -5,7 +5,7 @@ package testprotos
 
 import "github.com/jhump/protoreflect/desc/sourceinfo"
 import "google.golang.org/protobuf/proto"
-import descriptorpb "google.golang.org/protobuf/types/descriptorpb"
+import "google.golang.org/protobuf/types/descriptorpb"
 
 var srcInfo_desc_test_options = []byte{
 	0x0a, 0x06, 0x12, 0x04, 0x00, 0x00, 0x3e, 0x01, 0x0a, 0x08, 0x0a, 0x01, 0x0c, 0x12, 0x03, 0x00,

--- a/internal/testprotos/desc_test_proto3.pb.srcinfo.go
+++ b/internal/testprotos/desc_test_proto3.pb.srcinfo.go
@@ -5,7 +5,7 @@ package testprotos
 
 import "github.com/jhump/protoreflect/desc/sourceinfo"
 import "google.golang.org/protobuf/proto"
-import descriptorpb "google.golang.org/protobuf/types/descriptorpb"
+import "google.golang.org/protobuf/types/descriptorpb"
 
 var srcInfo_desc_test_proto3 = []byte{
 	0x0a, 0x06, 0x12, 0x04, 0x00, 0x00, 0x22, 0x01, 0x0a, 0x08, 0x0a, 0x01, 0x0c, 0x12, 0x03, 0x00,

--- a/internal/testprotos/desc_test_value.pb.srcinfo.go
+++ b/internal/testprotos/desc_test_value.pb.srcinfo.go
@@ -5,7 +5,7 @@ package testprotos
 
 import "github.com/jhump/protoreflect/desc/sourceinfo"
 import "google.golang.org/protobuf/proto"
-import descriptorpb "google.golang.org/protobuf/types/descriptorpb"
+import "google.golang.org/protobuf/types/descriptorpb"
 
 var srcInfo_desc_test_value = []byte{
 	0x0a, 0x06, 0x12, 0x04, 0x00, 0x00, 0x0b, 0x01, 0x0a, 0x08, 0x0a, 0x01, 0x0c, 0x12, 0x03, 0x00,

--- a/internal/testprotos/desc_test_wellknowntypes.pb.srcinfo.go
+++ b/internal/testprotos/desc_test_wellknowntypes.pb.srcinfo.go
@@ -5,7 +5,7 @@ package testprotos
 
 import "github.com/jhump/protoreflect/desc/sourceinfo"
 import "google.golang.org/protobuf/proto"
-import descriptorpb "google.golang.org/protobuf/types/descriptorpb"
+import "google.golang.org/protobuf/types/descriptorpb"
 
 var srcInfo_desc_test_wellknowntypes = []byte{
 	0x0a, 0x06, 0x12, 0x04, 0x00, 0x00, 0x1d, 0x01, 0x0a, 0x08, 0x0a, 0x01, 0x0c, 0x12, 0x03, 0x00,

--- a/internal/testprotos/grpc/test.pb.srcinfo.go
+++ b/internal/testprotos/grpc/test.pb.srcinfo.go
@@ -5,7 +5,7 @@ package grpc
 
 import "github.com/jhump/protoreflect/desc/sourceinfo"
 import "google.golang.org/protobuf/proto"
-import descriptorpb "google.golang.org/protobuf/types/descriptorpb"
+import "google.golang.org/protobuf/types/descriptorpb"
 
 var srcInfo_grpc_test = []byte{
 	0x0a, 0x07, 0x12, 0x05, 0x10, 0x00, 0xe5, 0x01, 0x01, 0x0a, 0xb8, 0x05, 0x0a, 0x01, 0x0c, 0x12,

--- a/internal/testprotos/nopkg/desc_test_nopkg.pb.srcinfo.go
+++ b/internal/testprotos/nopkg/desc_test_nopkg.pb.srcinfo.go
@@ -5,7 +5,7 @@ package nopkg
 
 import "github.com/jhump/protoreflect/desc/sourceinfo"
 import "google.golang.org/protobuf/proto"
-import descriptorpb "google.golang.org/protobuf/types/descriptorpb"
+import "google.golang.org/protobuf/types/descriptorpb"
 
 var srcInfo_nopkg_desc_test_nopkg = []byte{
 	0x0a, 0x06, 0x12, 0x04, 0x00, 0x00, 0x04, 0x30, 0x0a, 0x08, 0x0a, 0x01, 0x0c, 0x12, 0x03, 0x00,

--- a/internal/testprotos/nopkg/desc_test_nopkg_new.pb.srcinfo.go
+++ b/internal/testprotos/nopkg/desc_test_nopkg_new.pb.srcinfo.go
@@ -5,7 +5,7 @@ package nopkg
 
 import "github.com/jhump/protoreflect/desc/sourceinfo"
 import "google.golang.org/protobuf/proto"
-import descriptorpb "google.golang.org/protobuf/types/descriptorpb"
+import "google.golang.org/protobuf/types/descriptorpb"
 
 var srcInfo_nopkg_desc_test_nopkg_new = []byte{
 	0x0a, 0x06, 0x12, 0x04, 0x00, 0x00, 0x16, 0x01, 0x0a, 0x08, 0x0a, 0x01, 0x0c, 0x12, 0x03, 0x00,

--- a/internal/testprotos/pkg/desc_test_pkg.pb.srcinfo.go
+++ b/internal/testprotos/pkg/desc_test_pkg.pb.srcinfo.go
@@ -5,7 +5,7 @@ package pkg
 
 import "github.com/jhump/protoreflect/desc/sourceinfo"
 import "google.golang.org/protobuf/proto"
-import descriptorpb "google.golang.org/protobuf/types/descriptorpb"
+import "google.golang.org/protobuf/types/descriptorpb"
 
 var srcInfo_pkg_desc_test_pkg = []byte{
 	0x0a, 0x06, 0x12, 0x04, 0x00, 0x00, 0x14, 0x01, 0x0a, 0x08, 0x0a, 0x01, 0x0c, 0x12, 0x03, 0x00,


### PR DESCRIPTION
The biggest change here is that `desc.Load*` functions will always add source code info to the returned descriptors, if available.

So the `desc` package now works "out of the box" to include source info if you are also using the `protoc-gen-gosrcinfo` plugin. And for users of the v2 protobuf API, one can swap in `sourceinfo.GlobalFiles` in place of `protoregistry.GlobalFiles`.

This PR also tweaks the output of `protoc-gen-gosrcinfo`, to eliminate an unnecessary import alias. And it adds a comment about the fact that the `srcinforeflection` package is experimental. With luck, a change can instead be upstreamed into the core gRPC reflection implementation that allows easily injecting `sourceinfo.GlobalFiles`.