### PR TITLE
dynamic.KnownTypeRegistry.GetKnownType should always return a message type

### DIFF
--- a/dynamic/message_factory.go
+++ b/dynamic/message_factory.go
@@ -174,28 +174,33 @@ func isWellKnownType(t reflect.Type) bool {
 // GetKnownType will return the reflect.Type for the given message name if it is
 // known. If it is not known, nil is returned.
 func (r *KnownTypeRegistry) GetKnownType(messageName string) reflect.Type {
-	var msgType reflect.Type
 	if r == nil {
 		// a nil registry behaves the same as zero value instance: only know of well-known types
 		t := proto.MessageType(messageName)
 		if t != nil && isWellKnownType(t) {
-			msgType = t
+			return t
 		}
-	} else {
-		if r.includeDefault {
-			msgType = proto.MessageType(messageName)
-		} else if !r.excludeWkt {
-			t := proto.MessageType(messageName)
-			if t != nil && isWellKnownType(t) {
-				msgType = t
-			}
+		return nil
+	}
+
+	if r.includeDefault {
+		t := proto.MessageType(messageName)
+		if t != nil && isMessage(t) {
+			return t
 		}
-		if msgType == nil {
-			r.mu.RLock()
-			msgType = r.types[messageName]
-			r.mu.RUnlock()
+	} else if !r.excludeWkt {
+		t := proto.MessageType(messageName)
+		if t != nil && isWellKnownType(t) {
+			return t
 		}
 	}
 
-	return msgType
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.types[messageName]
+}
+
+func isMessage(t reflect.Type) bool {
+	_, ok := reflect.Zero(t).Interface().(proto.Message)
+	return ok
 }

--- a/dynamic/message_factory_test.go
+++ b/dynamic/message_factory_test.go
@@ -66,6 +66,12 @@ func TestKnownTypeRegistry_WithDefaults(t *testing.T) {
 	checkKnownTypes(t, ktr, (*descriptor.DescriptorProto)(nil), (*descriptor.FileDescriptorProto)(nil), (*testprotos.TestMessage)(nil))
 }
 
+func TestKnownTypeRegistry_WithDefaults_MapEntry(t *testing.T) {
+	ktr := NewKnownTypeRegistryWithDefaults()
+	msgType := ktr.GetKnownType("testprotos.MapKeyFields.SEntry")
+	testutil.Require(t, msgType == nil, "should not be a known type for map entry but got %v", msgType)
+}
+
 func checkKnownTypes(t *testing.T, ktr *KnownTypeRegistry, knownTypes ...proto.Message) {
 	for _, kt := range knownTypes {
 		md, err := desc.LoadMessageDescriptorForMessage(kt)


### PR DESCRIPTION
Interestingly, if you use `proto.MessageType` and provide the name of a `map entry` (synthetic message), you get back a `reflect.Type` whose kind is `reflect.Map`, for example a `map[string]string`. So you basically get back the type of the associated map field. The problem is that this type _does not implement_ `proto.Message`. The docs for the `MessageType` function do not describe this behavior, so this is a bit of a surprise.

Unfortunately, the implementation of `dynamic.KnownTypeRegistry` relies on `proto.MessageType` to support knowledge of "default" types (generated messages that are linked into the calling program). And it is supposed to always return an actual message type (e.g. a type that implements `proto.Message`).

This patch addresses this issue: if `proto.MessageType` returns a map type, `knownTypeRegistry.GetKnownType` should return `nil`.

This fixes #503.

