### PR TITLE
protoparse: fix panic in linker; handle synthetic oneofs

### DIFF
--- a/desc/builder/message.go
+++ b/desc/builder/message.go
@@ -819,7 +819,7 @@ func (mb *MessageBuilder) buildProto(path []int32, sourceInfo *dpb.SourceCodeInf
 	}
 
 	if mb.GetFile().IsProto3 {
-		internal.ProcessProto3OptionalFields(md)
+		internal.ProcessProto3OptionalFields(md, nil)
 	}
 
 	return md, nil

--- a/desc/protoparse/descriptor_protos.go
+++ b/desc/protoparse/descriptor_protos.go
@@ -477,7 +477,14 @@ func (r *parseResult) addMessageBody(msgd *dpb.DescriptorProto, body *ast.Messag
 
 	// process any proto3_optional fields
 	if isProto3 {
-		internal.ProcessProto3OptionalFields(msgd)
+		callback := func(fd *dpb.FieldDescriptorProto, ood *dpb.OneofDescriptorProto) {
+			node, ok := r.getFieldNode(fd).(*ast.FieldNode)
+			if ok {
+				r.putOneOfNode(ood, ast.NewSyntheticOneOf(node))
+			}
+			// TODO: the !ok case should really never happen... log an error?
+		}
+		internal.ProcessProto3OptionalFields(msgd, callback)
 	}
 }
 

--- a/desc/protoparse/linker.go
+++ b/desc/protoparse/linker.go
@@ -146,6 +146,12 @@ func (l *linker) createDescriptorPool() error {
 					desc1, desc2 = desc2, desc1
 				}
 				node := l.files[file2].getNode(desc2)
+				if node == nil {
+					// TODO: this should never happen, but in case there is a bug where
+					// we get back a nil node, we'd rather fail to report line+column
+					// info than panic with a nil dereference below
+					node = ast.NewNoSourceNode(file2)
+				}
 				if err := l.errs.handleErrorWithPos(node.Start(), "duplicate symbol %s: already defined as %s in %q", k, descriptorType(desc1), file1); err != nil {
 					return err
 				}

--- a/desc/protoparse/parser.go
+++ b/desc/protoparse/parser.go
@@ -739,7 +739,7 @@ func (r *parseResult) putFieldNode(f *dpb.FieldDescriptorProto, n ast.FieldDeclN
 	r.nodes[f] = n
 }
 
-func (r *parseResult) putOneOfNode(o *dpb.OneofDescriptorProto, n *ast.OneOfNode) {
+func (r *parseResult) putOneOfNode(o *dpb.OneofDescriptorProto, n ast.OneOfDeclNode) {
 	r.nodes[o] = n
 }
 


### PR DESCRIPTION
Resolves #508 

The only case I could find, through code inspection, that could cause the nil dereference described in the bug is related to symbol collisions for synthetic oneofs (which are created on behalf of "proto3 optional" fields). The test case reproduces the panic.

The fix is two-fold:
1. Address the shortcoming related to synthetic oneofs: we need to be able to lookup an AST node for the synthetic oneof, so that we can correctly report its source position.
2. Add a check so if for any other reason we fail to lookup an AST node, we can proceed without panic'ing. Instead of a panic, the error message will fail to include location information. (Strictly better than a panic; if we see such errors reported in the future, we can fix those underlying issues as they are discovered.)
