### PR TITLE
protoparse: fix scoping issue for extendees and field type names; also fix articles in error messages

### DIFF
--- a/desc/protoparse/reporting_test.go
+++ b/desc/protoparse/reporting_test.go
@@ -104,9 +104,9 @@ func TestErrorReporting(t *testing.T) {
 					`,
 			},
 			expectedErrs: []string{
-				"test.proto:8:49: duplicate symbol BAZ: already defined as enum value; protobuf uses C++ scoping rules for enum values, so they exist in the scope enclosing the enum",
-				"test.proto:10:41: duplicate symbol Bar: already defined as enum",
-				"test.proto:12:49: duplicate symbol Bar.Foobar: already defined as method",
+				"test.proto:8:49: duplicate symbol BAZ: already defined as an enum value; protobuf uses C++ scoping rules for enum values, so they exist in the scope enclosing the enum",
+				"test.proto:10:41: duplicate symbol Bar: already defined as an enum",
+				"test.proto:12:49: duplicate symbol Bar.Foobar: already defined as a method",
 				"test.proto:12:61: method Bar.Foobar: unknown request type Frob",
 				"test.proto:12:76: method Bar.Foobar: unknown response type Nitz",
 			},
@@ -168,8 +168,8 @@ func TestErrorReporting(t *testing.T) {
 					`,
 			},
 			expectedErrs: []string{
-				"test2.proto:4:41: duplicate symbol Bar: already defined as service in \"test1.proto\"",
-				"test2.proto:7:41: duplicate symbol Foo: already defined as message in \"test1.proto\"",
+				"test2.proto:4:41: duplicate symbol Bar: already defined as a service in \"test1.proto\"",
+				"test2.proto:7:41: duplicate symbol Foo: already defined as a message in \"test1.proto\"",
 				"test1.proto:8:75: method Bar.Frob: unknown response type Nitz",
 				"test2.proto:8:82: method Foo.DoSomething: invalid response type: Foo is a service, not a message",
 			},


### PR DESCRIPTION
There was a bug in the scoping rules, related to how relative references to type names in `extends` blocks and field types are resolved.

I've added more tests, which assert similar behavior as `protoc`. This required a one-line logic change. But while in here and editing tests, I noticed use of the wrong article in error messages, e.g. "a extension" instead of "an extension". So I figured I'd fix that, too. (Sadly, more of the changes in this branch are for the article fix than the scope fix.)