### PR TITLE
protoparse: enforce unique JSON names

### DIFF
--- a/desc/protoparse/descriptor_protos.go
+++ b/desc/protoparse/descriptor_protos.go
@@ -33,7 +33,7 @@ func (r *parseResult) createFileDescriptor(filename string, file *ast.FileNode) 
 			fd.Syntax = proto.String(file.Syntax.Syntax.AsString())
 		}
 	} else {
-		r.errs.warn(file.Start(), ErrNoSyntax)
+		r.errs.warnWithPos(file.Start(), ErrNoSyntax)
 	}
 
 	for _, decl := range file.Decls {

--- a/desc/protoparse/errors.go
+++ b/desc/protoparse/errors.go
@@ -76,9 +76,15 @@ func (h *errorHandler) handleError(err error) error {
 	return err
 }
 
-func (h *errorHandler) warn(pos *SourcePos, err error) {
+func (h *errorHandler) warnWithPos(pos *SourcePos, err error) {
 	if h.warnReporter != nil {
 		h.warnReporter(ErrorWithSourcePos{Pos: pos, Underlying: err})
+	}
+}
+
+func (h *errorHandler) warn(err ErrorWithSourcePos) {
+	if h.warnReporter != nil {
+		h.warnReporter(err)
 	}
 }
 
@@ -138,7 +144,7 @@ func (e ErrorWithSourcePos) Unwrap() error {
 
 var _ ErrorWithPos = ErrorWithSourcePos{}
 
-func errorWithPos(pos *SourcePos, format string, args ...interface{}) ErrorWithPos {
+func errorWithPos(pos *SourcePos, format string, args ...interface{}) ErrorWithSourcePos {
 	return ErrorWithSourcePos{Pos: pos, Underlying: fmt.Errorf(format, args...)}
 }
 

--- a/desc/protoparse/linker.go
+++ b/desc/protoparse/linker.go
@@ -1206,7 +1206,6 @@ func hasCustomJsonName(res *parseResult, fd *desc.FieldDescriptor) bool {
 		if len(opt.Name.Parts) == 1 &&
 			opt.Name.Parts[0].Name.AsIdentifier() == "json_name" &&
 			!opt.Name.Parts[0].IsExtension() {
-			// found it
 			return true
 		}
 	}


### PR DESCRIPTION
Fixes #358 

This is done in a case-insensitive way, just as `protoc` does it. However, I wish I knew _why_ the protobuf team chose to make it case-insensitive. Case-sensitivity issues should generally be warnings or linter errors, not compile errors. 🤷 