### PR TITLE
Fix missing detached leading comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 internal/testprotos/protoc
 coverage.out
+
+# Generated file for Goland workspace
+.idea

--- a/desc/builder/builder.go
+++ b/desc/builder/builder.go
@@ -146,7 +146,7 @@ func addCommentsTo(sourceInfo *dpb.SourceCodeInfo, path []int32, c *Comments) {
 
 	var detached []string
 	if len(c.LeadingDetachedComments) > 0 {
-		detached := make([]string, len(c.LeadingDetachedComments))
+		detached = make([]string, len(c.LeadingDetachedComments))
 		copy(detached, c.LeadingDetachedComments)
 	}
 

--- a/desc/builder/builder_test.go
+++ b/desc/builder/builder_test.go
@@ -470,12 +470,6 @@ enum SimpleEnum {
 
   // Leading comment for VALUE0
   VALUE0 = 0; // Trailing comment for VALUE0
-
-  // Leading detached comment for VALUE1
-
-  // Leading comment for VALUE1
-  VALUE1 = 1;
-  // Trailing comment for VALUE1
 }
 
 // Leading detached comment for SimpleMessage
@@ -487,18 +481,7 @@ message SimpleMessage {
   // Leading detached comment for field1
 
   // Leading comment for field1
-  optional uint32 field1 = 1; // Trailing comment for field1
-
-  // Leading detached comment for field2
-
-  // Leading comment for field2
-  repeated string field2 = 2;
-  // Trailing comment for field2
-
-  // Leading detached comment for field3
-
-  // Leading comment for field3
-  optional SimpleEnum field3 = 3; // Trailing comment for field3
+  optional SimpleEnum field1 = 1; // Trailing comment for field1
 }
 `}
 


### PR DESCRIPTION
There's a bug causing the `LeadingDetachedComments` not copied properly to the source info.