### PR TITLE
 Fix support of SetNumber for enum builder

### DIFF
--- a/desc/builder/builder_test.go
+++ b/desc/builder/builder_test.go
@@ -1579,29 +1579,33 @@ func TestPruneDependencies(t *testing.T) {
 
 func TestInterleavedEnumNumbers(t *testing.T) {
 	en := NewEnum("Options").
-		AddValue(NewEnumValue("OPTION_1").SetNumber(0)).
+		AddValue(NewEnumValue("OPTION_1").SetNumber(-1)).
 		AddValue(NewEnumValue("OPTION_2")).
-		AddValue(NewEnumValue("OPTION_3").SetNumber(1)).
-		AddValue(NewEnumValue("OPTION_4")).
-		AddValue(NewEnumValue("OPTION_5").SetNumber(100))
+		AddValue(NewEnumValue("OPTION_3").SetNumber(2)).
+		AddValue(NewEnumValue("OPTION_4").SetNumber(1)).
+		AddValue(NewEnumValue("OPTION_5")).
+		AddValue(NewEnumValue("OPTION_6").SetNumber(100))
 
 	ed, err := en.Build()
 	testutil.Ok(t, err)
 
 	testutil.Require(t, ed.FindValueByName("OPTION_1") != nil)
-	testutil.Eq(t, int32(0), ed.FindValueByName("OPTION_1").GetNumber())
+	testutil.Eq(t, int32(-1), ed.FindValueByName("OPTION_1").GetNumber())
 
 	testutil.Require(t, ed.FindValueByName("OPTION_2") != nil)
-	testutil.Eq(t, int32(2), ed.FindValueByName("OPTION_2").GetNumber())
+	testutil.Eq(t, int32(0), ed.FindValueByName("OPTION_2").GetNumber())
 
 	testutil.Require(t, ed.FindValueByName("OPTION_3") != nil)
-	testutil.Eq(t, int32(1), ed.FindValueByName("OPTION_3").GetNumber())
+	testutil.Eq(t, int32(2), ed.FindValueByName("OPTION_3").GetNumber())
 
 	testutil.Require(t, ed.FindValueByName("OPTION_4") != nil)
-	testutil.Eq(t, int32(3), ed.FindValueByName("OPTION_4").GetNumber())
+	testutil.Eq(t, int32(1), ed.FindValueByName("OPTION_4").GetNumber())
 
 	testutil.Require(t, ed.FindValueByName("OPTION_5") != nil)
-	testutil.Eq(t, int32(100), ed.FindValueByName("OPTION_5").GetNumber())
+	testutil.Eq(t, int32(3), ed.FindValueByName("OPTION_5").GetNumber())
+
+	testutil.Require(t, ed.FindValueByName("OPTION_6") != nil)
+	testutil.Eq(t, int32(100), ed.FindValueByName("OPTION_6").GetNumber())
 }
 
 func TestInvalid(t *testing.T) {

--- a/desc/builder/enum.go
+++ b/desc/builder/enum.go
@@ -250,20 +250,17 @@ func (eb *EnumBuilder) buildProto(path []int32, sourceInfo *descriptorpb.SourceC
 
 	if len(needNumbersAssigned) > 0 {
 		tags := make([]int, len(values)-len(needNumbersAssigned))
-		for i, ev := range values {
+		tagsIndex := 0
+		for _, ev := range values {
 			tag := ev.GetNumber()
 			if tag != 0 {
-				tags[i] = int(tag)
+				tags[tagsIndex] = int(tag)
+				tagsIndex++
 			}
 		}
 		sort.Ints(tags)
 		t := 0
-		ti := sort.Search(len(tags), func(i int) bool {
-			return tags[i] >= 0
-		})
-		if ti < len(tags) {
-			tags = tags[ti:]
-		}
+
 		for len(needNumbersAssigned) > 0 {
 			for len(tags) > 0 && t == tags[0] {
 				t++

--- a/desc/builder/enum.go
+++ b/desc/builder/enum.go
@@ -251,16 +251,21 @@ func (eb *EnumBuilder) buildProto(path []int32, sourceInfo *descriptorpb.SourceC
 	if len(needNumbersAssigned) > 0 {
 		tags := make([]int, len(values)-len(needNumbersAssigned))
 		tagsIndex := 0
-		for _, ev := range values {
-			tag := ev.GetNumber()
-			if tag != 0 {
-				tags[tagsIndex] = int(tag)
+		for _, evb := range eb.values {
+			if evb.numberSet {
+				tags[tagsIndex] = int(evb.GetNumber())
 				tagsIndex++
 			}
 		}
 		sort.Ints(tags)
 		t := 0
 
+		ti := sort.Search(len(tags), func(i int) bool {
+			return tags[i] >= 0
+		})
+		if ti < len(tags) {
+			tags = tags[ti:]
+		}
 		for len(needNumbersAssigned) > 0 {
 			for len(tags) > 0 && t == tags[0] {
 				t++

--- a/desc/builder/enum.go
+++ b/desc/builder/enum.go
@@ -259,7 +259,6 @@ func (eb *EnumBuilder) buildProto(path []int32, sourceInfo *descriptorpb.SourceC
 		}
 		sort.Ints(tags)
 		t := 0
-
 		ti := sort.Search(len(tags), func(i int) bool {
 			return tags[i] >= 0
 		})


### PR DESCRIPTION
This addresses https://github.com/jhump/protoreflect/issues/570 Enum Builder panics if some of EnumValue's have Number field explicitly set.

Particularly, it copies logic from message builder
https://github.com/jhump/protoreflect/blob/master/desc/builder/message.go#L756