### PR TITLE
SIGSEGV: panic: runtime error: invalid memory address or nil pointer dereference

### DIFF
--- a/desc/protoparse/parser.go
+++ b/desc/protoparse/parser.go
@@ -386,6 +386,10 @@ func parseToProtoRecursive(res protocompile.Resolver, filename string, rep *repo
 	}
 	results[filename] = parseResult
 
+	if astRoot == nil {
+		return
+	}
+
 	for _, decl := range astRoot.Decls {
 		imp, ok := decl.(*ast2.ImportNode)
 		if !ok {

--- a/desc/protoparse/parser_test.go
+++ b/desc/protoparse/parser_test.go
@@ -422,3 +422,27 @@ message Foo {
 	comment := fds[0].GetMessageTypes()[0].GetFields()[0].GetSourceInfo().GetLeadingComments()
 	testutil.Eq(t, " leading comments\n", comment)
 }
+
+func TestParseWithInferImportPaths(t *testing.T) {
+	accessor := FileContentsFromMap(map[string]string{
+		"test.proto": `
+syntax = "proto3";
+import "google/protobuf/struct.proto";
+message Foo {
+  // leading comments
+  .Foo foo = 1;
+}
+`,
+	})
+
+	p := Parser{
+		Accessor:              accessor,
+		IncludeSourceCodeInfo: true,
+		InferImportPaths:      true,
+	}
+	fds, err := p.ParseFiles("test.proto")
+	testutil.Ok(t, err)
+
+	comment := fds[0].GetMessageTypes()[0].GetFields()[0].GetSourceInfo().GetLeadingComments()
+	testutil.Eq(t, " leading comments\n", comment)
+}


### PR DESCRIPTION
This PR addresses issue #572 by adding a nil check when the parser is recursing to infer import paths.