### PR TITLE
Fix issue with imports in desc/builder

### DIFF
--- a/desc/builder/resolver.go
+++ b/desc/builder/resolver.go
@@ -33,7 +33,7 @@ func (d *dependencies) add(fd *desc.FileDescriptor) {
 		return
 	}
 	d.descs[fd] = struct{}{}
-	internal.RegisterExtensionsForFile(&d.res, fd.UnwrapFile())
+	internal.RegisterExtensionsFromImportedFile(&d.res, fd.UnwrapFile())
 }
 
 // dependencyResolver is the work-horse for converting a tree of builders into a
@@ -150,7 +150,6 @@ func (r *dependencyResolver) resolveFile(fb *FileBuilder, root Builder, seen []B
 	fileNames := map[string]struct{}{}
 	for _, d := range depSlice {
 		addFileNames(d, fileNames)
-		fileNames[d.GetName()] = struct{}{}
 	}
 	unique := makeUnique(fp.GetName(), fileNames)
 	if unique != fp.GetName() {
@@ -481,7 +480,7 @@ func (r *dependencyResolver) resolveTypesInOptions(root Builder, fileExts *dynam
 			continue
 		}
 		// see if configured extension registry knows about it
-		if extd := r.opts.Extensions.FindExtension(string(msgName), int32(tag)); extd != nil {
+		if extd := r.opts.Extensions.FindExtension(msgName, tag); extd != nil {
 			// extension registry recognized it!
 			deps.add(extd.GetFile())
 			continue

--- a/desc/internal/registry.go
+++ b/desc/internal/registry.go
@@ -6,11 +6,30 @@ import (
 	"google.golang.org/protobuf/types/dynamicpb"
 )
 
-func RegisterExtensionsForFile(reg *protoregistry.Types, fd protoreflect.FileDescriptor) {
+// RegisterExtensionsFromImportedFile registers extensions in the given file as well
+// as those in its public imports. So if another file imports the given fd, this adds
+// all extensions made visible to that importing file.
+//
+// All extensions in the given file are made visible to the importing file, and so are
+// extensions in any public imports in the given file.
+func RegisterExtensionsFromImportedFile(reg *protoregistry.Types, fd protoreflect.FileDescriptor) {
+	registerTypesForFile(reg, fd, true, true)
+}
+
+// RegisterExtensionsVisibleToFile registers all extensions visible to the given file.
+// This includes all extensions defined in fd and as well as extensions defined in the
+// files that it imports (and any public imports thereof, etc).
+//
+// This is effectively the same as registering the extensions in fd and then calling
+// RegisterExtensionsFromImportedFile for each file imported by fd.
+func RegisterExtensionsVisibleToFile(reg *protoregistry.Types, fd protoreflect.FileDescriptor) {
 	registerTypesForFile(reg, fd, true, false)
 }
 
-func RegisterTypesForFile(reg *protoregistry.Types, fd protoreflect.FileDescriptor) {
+// RegisterTypesVisibleToFile registers all types visible to the given file.
+// This is the same as RegisterExtensionsVisibleToFile but it also registers
+// message and enum types, not just extensions.
+func RegisterTypesVisibleToFile(reg *protoregistry.Types, fd protoreflect.FileDescriptor) {
 	registerTypesForFile(reg, fd, false, false)
 }
 

--- a/desc/protoparse/source_code_info_test.go
+++ b/desc/protoparse/source_code_info_test.go
@@ -37,9 +37,9 @@ func TestSourceCodeInfo(t *testing.T) {
 	// (human readable so diffs in source control are comprehensible)
 	var buf bytes.Buffer
 	for _, fd := range fds {
-		printSourceCodeInfo(t, fd, &buf)
+		printSourceCodeInfo(fd, &buf)
 	}
-	printSourceCodeInfo(t, importedFd, &buf)
+	printSourceCodeInfo(importedFd, &buf)
 	actual := buf.String()
 
 	if regenerateMode {
@@ -58,11 +58,11 @@ func TestSourceCodeInfo(t *testing.T) {
 // NB: this function can be used to manually inspect the source code info for a
 // descriptor, in a manner that is much easier to read and check than raw
 // descriptor form.
-func printSourceCodeInfo(t *testing.T, fd *desc.FileDescriptor, out io.Writer) {
+func printSourceCodeInfo(fd *desc.FileDescriptor, out io.Writer) {
 	_, _ = fmt.Fprintf(out, "---- %s ----\n", fd.GetName())
 	msg := fd.AsFileDescriptorProto().ProtoReflect()
 	var reg protoregistry.Types
-	internal.RegisterExtensionsForFile(&reg, fd.UnwrapFile())
+	internal.RegisterExtensionsVisibleToFile(&reg, fd.UnwrapFile())
 
 	for _, loc := range fd.AsFileDescriptorProto().GetSourceCodeInfo().GetLocation() {
 		var buf bytes.Buffer

--- a/desc/protoprint/print.go
+++ b/desc/protoprint/print.go
@@ -319,7 +319,7 @@ func (p *Printer) printProto(dsc desc.Descriptor, out io.Writer) error {
 	extendOptionLocations(sourceInfo, fdp.GetSourceCodeInfo().GetLocation())
 
 	var reg protoregistry.Types
-	internal.RegisterTypesForFile(&reg, dsc.GetFile().UnwrapFile())
+	internal.RegisterTypesVisibleToFile(&reg, dsc.GetFile().UnwrapFile())
 	reparseUnknown(&reg, fdp.ProtoReflect())
 
 	path := findElement(dsc)


### PR DESCRIPTION
When adding extensions to the type resolver that the builder used, the logic was adding too many. For a given import, it was incorrectly adding all extensions visible to that imported file, instead of just the extensions made visible to the _importing_ file.

Fixes #589 