### PR TITLE
Update to work with latest v0.8.0 release of protocompile

### DIFF
--- a/desc/protoparse/ast.go
+++ b/desc/protoparse/ast.go
@@ -515,8 +515,6 @@ func convertASTValue(f *ast.FileNode, v ast.ValueNode) ast2.ValueNode {
 		return convertASTCompoundStringLiteral(f, v)
 	case *ast.UintLiteralNode:
 		return convertASTUintLiteral(f, v)
-	case *ast.PositiveUintLiteralNode:
-		return convertASTPositiveUintLiteral(f, v)
 	case *ast.NegativeIntLiteralNode:
 		return convertASTNegativeIntLiteral(f, v)
 	case *ast.FloatLiteralNode:
@@ -593,8 +591,6 @@ func convertASTInt(f *ast.FileNode, n ast.IntValueNode) ast2.IntValueNode {
 	switch n := n.(type) {
 	case *ast.UintLiteralNode:
 		return convertASTUintLiteral(f, n)
-	case *ast.PositiveUintLiteralNode:
-		return convertASTPositiveUintLiteral(f, n)
 	case *ast.NegativeIntLiteralNode:
 		return convertASTNegativeIntLiteral(f, n)
 	default:
@@ -604,10 +600,6 @@ func convertASTInt(f *ast.FileNode, n ast.IntValueNode) ast2.IntValueNode {
 
 func convertASTUintLiteral(f *ast.FileNode, n *ast.UintLiteralNode) *ast2.UintLiteralNode {
 	return ast2.NewUintLiteralNode(n.Val, convertASTTokenInfo(f, n.Token()))
-}
-
-func convertASTPositiveUintLiteral(f *ast.FileNode, n *ast.PositiveUintLiteralNode) *ast2.PositiveUintLiteralNode {
-	return ast2.NewPositiveUintLiteralNode(convertASTRune(f, n.Plus), convertASTUintLiteral(f, n.Uint))
 }
 
 func convertASTNegativeIntLiteral(f *ast.FileNode, n *ast.NegativeIntLiteralNode) *ast2.NegativeIntLiteralNode {

--- a/desc/protoparse/ast/file.go
+++ b/desc/protoparse/ast/file.go
@@ -19,6 +19,8 @@ type FileNode struct {
 	Syntax *SyntaxNode // nil if file has no syntax declaration
 	Decls  []FileElement
 
+	// TODO: add Edition *EditionNode
+
 	// Any comments that follow the last token in the file.
 	FinalComments []Comment
 	// Any whitespace at the end of the file (after the last token or

--- a/desc/protoparse/ast/values.go
+++ b/desc/protoparse/ast/values.go
@@ -175,6 +175,10 @@ func (n *UintLiteralNode) AsFloat() float64 {
 }
 
 // PositiveUintLiteralNode represents an integer literal with a positive (+) sign.
+//
+// Deprecated: A valid AST will not contain a node of this type. The Protobuf
+// language does not actually allow a numeric literal to have a leading "+"
+// positive sign.
 type PositiveUintLiteralNode struct {
 	compositeNode
 	Plus *RuneNode
@@ -184,6 +188,8 @@ type PositiveUintLiteralNode struct {
 
 // NewPositiveUintLiteralNode creates a new *PositiveUintLiteralNode. Both
 // arguments must be non-nil.
+//
+// Deprecated: The ast.PositiveUintLiteralNode node type should not be used.
 func NewPositiveUintLiteralNode(sign *RuneNode, i *UintLiteralNode) *PositiveUintLiteralNode {
 	if sign == nil {
 		panic("sign is nil")

--- a/desc/protoparse/ast/walk.go
+++ b/desc/protoparse/ast/walk.go
@@ -59,6 +59,9 @@ type Visitor struct {
 	VisitFileNode func(*FileNode) (bool, *Visitor)
 	// VisitSyntaxNode is invoked when visiting a *SyntaxNode in the AST.
 	VisitSyntaxNode func(*SyntaxNode) (bool, *Visitor)
+
+	// TODO: add VisitEditionNode
+
 	// VisitPackageNode is invoked when visiting a *PackageNode in the AST.
 	VisitPackageNode func(*PackageNode) (bool, *Visitor)
 	// VisitImportNode is invoked when visiting an *ImportNode in the AST.
@@ -112,6 +115,8 @@ type Visitor struct {
 	// VisitUintLiteralNode is invoked when visiting a *UintLiteralNode in the AST.
 	VisitUintLiteralNode func(*UintLiteralNode) (bool, *Visitor)
 	// VisitPositiveUintLiteralNode is invoked when visiting a *PositiveUintLiteralNode in the AST.
+	//
+	// Deprecated: this node type will not actually be present in an AST.
 	VisitPositiveUintLiteralNode func(*PositiveUintLiteralNode) (bool, *Visitor)
 	// VisitNegativeIntLiteralNode is invoked when visiting a *NegativeIntLiteralNode in the AST.
 	VisitNegativeIntLiteralNode func(*NegativeIntLiteralNode) (bool, *Visitor)

--- a/desc/protoparse/reporting_test.go
+++ b/desc/protoparse/reporting_test.go
@@ -57,7 +57,7 @@ func TestErrorReporting(t *testing.T) {
 					`,
 			},
 			expectedErrs: []string{
-				"test.proto:5:41: expected ';'",
+				"test.proto:5:41: syntax error: expecting ';'",
 				"test.proto:5:69: syntax error: unexpected ';', expecting '='",
 				"test.proto:7:53: syntax error: unexpected '='",
 			},

--- a/desc/protoparse/validate_test.go
+++ b/desc/protoparse/validate_test.go
@@ -291,7 +291,7 @@ func TestBasicValidation(t *testing.T) {
 		},
 		{
 			contents: `syntax = "proto3"; enum reserved { unset = 0; } message Foo { reserved bar = 1; }`,
-			errMsg:   `test.proto:1:76: expected ';'`,
+			errMsg:   `test.proto:1:76: syntax error: expecting ';'`,
 		},
 		{
 			contents: `syntax = "proto3"; enum extend { unset = 0; } message Foo { extend bar = 1; }`,

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/jhump/protoreflect
 go 1.18
 
 require (
-	github.com/bufbuild/protocompile v0.7.1
+	github.com/bufbuild/protocompile v0.8.0
 	github.com/golang/protobuf v1.5.3
 	github.com/jhump/gopoet v0.1.0
 	github.com/jhump/goprotoc v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/bufbuild/protocompile v0.7.1 h1:Kd8fb6EshOHXNNRtYAmLAwy/PotlyFoN0iMbuwGNh0M=
-github.com/bufbuild/protocompile v0.7.1/go.mod h1:+Etjg4guZoAqzVk2czwEQP12yaxLJ8DxuqCJ9qHdH94=
+github.com/bufbuild/protocompile v0.8.0 h1:9Kp1q6OkS9L4nM3FYbr8vlJnEwtbpDPQlQOVXfR+78s=
+github.com/bufbuild/protocompile v0.8.0/go.mod h1:+Etjg4guZoAqzVk2czwEQP12yaxLJ8DxuqCJ9qHdH94=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=


### PR DESCRIPTION
Version 0.8.0 of protocompile includes another minor backwards-incompatible change that causes an issue with this repo. This branch fixes that change to restore compatibility.