### PR TITLE
desc/protoparse: fix recently identified regressions from v1.14

### DIFF
--- a/desc/protoparse/parser.go
+++ b/desc/protoparse/parser.go
@@ -556,16 +556,9 @@ func (p Parser) getResolver(filenames []string) (protocompile.Resolver, *ast2.So
 		}))
 	}
 	backupResolver := protocompile.WithStandardImports(importResolver)
-	mustBeSource := make(map[string]struct{}, len(filenames))
-	for _, name := range filenames {
-		mustBeSource[name] = struct{}{}
-	}
 	return protocompile.CompositeResolver{
 		sourceResolver,
 		protocompile.ResolverFunc(func(path string) (protocompile.SearchResult, error) {
-			if _, ok := mustBeSource[path]; ok {
-				return protocompile.SearchResult{}, os.ErrNotExist
-			}
 			return backupResolver.FindFileByPath(path)
 		}),
 	}, &srcSpan

--- a/desc/protoparse/parser.go
+++ b/desc/protoparse/parser.go
@@ -241,6 +241,7 @@ func (r noCloneParseResult) Clone() parser.Result {
 // ErrorReporter always returns nil, the parse fails with ErrInvalidSource.
 func (p Parser) ParseFilesButDoNotLink(filenames ...string) ([]*descriptorpb.FileDescriptorProto, error) {
 	rep := newReporter(p.ErrorReporter, p.WarningReporter)
+	p.ImportPaths = nil // not used for this "do not link" operation.
 	res, _ := p.getResolver(filenames)
 	results, err := parseToProtos(res, filenames, reporter.NewHandler(rep), p.ValidateUnlinkedFiles)
 	if err != nil {

--- a/desc/protoparse/parser_test.go
+++ b/desc/protoparse/parser_test.go
@@ -525,3 +525,22 @@ func TestParseInferImportPaths_FixesNestedPaths(t *testing.T) {
 		})
 	}
 }
+
+func TestParseFilesButDoNotLink_DoesNotUseImportPaths(t *testing.T) {
+	tempdir, err := os.MkdirTemp("", "protoparse")
+	testutil.Ok(t, err)
+	defer func() {
+		_ = os.RemoveAll(tempdir)
+	}()
+	err = os.WriteFile(filepath.Join(tempdir, "extra.proto"), []byte("package extra;"), 0644)
+	testutil.Ok(t, err)
+	mainPath := filepath.Join(tempdir, "main.proto")
+	err = os.WriteFile(mainPath, []byte("package main; import \"extra.proto\";"), 0644)
+	testutil.Ok(t, err)
+	p := Parser{
+		ImportPaths: []string{tempdir},
+	}
+	fds, err := p.ParseFilesButDoNotLink(mainPath)
+	testutil.Ok(t, err)
+	testutil.Eq(t, 1, len(fds))
+}


### PR DESCRIPTION
Fixes #590 and #591.

When v1.15 was implemented, which replaces `desc/protoparse` with thin veneer on top of the `github.com/bufbuild/protocompile` module, a new constraint was inadvertently added, requiring that files explicitly named in `parser.Parse` had to be provided as source and could not be provided as descriptors. But this constraint was not present in v1.14.1 and thus a regression for any code that took advantage of the lack of that constraint.

Similarly, when the `Parser.ParseFilesButDoNotLink` method was re-implemented, it was incorrectly using `Parser.ImportPaths`, despite the Go docs for that field saying they are unused for the "do not link" operation.

This PR fixes both of these regressions, so more code that uses v1.14 can correctly be upgraded to use v1.15.