### PR TITLE
More follow-up for editions in protoprint

### DIFF
--- a/desc/protoprint/print_test.go
+++ b/desc/protoprint/print_test.go
@@ -77,6 +77,7 @@ func TestPrinter(t *testing.T) {
 	files := []string{
 		"../../internal/testprotos/desc_test_comments.protoset",
 		"../../internal/testprotos/desc_test_complex_source_info.protoset",
+		"../../internal/testprotos/desc_test_editions.protoset",
 		"../../internal/testprotos/descriptor.protoset",
 		"../../internal/testprotos/desc_test1.protoset",
 		"../../internal/testprotos/proto3_optional/desc_test_proto3_optional.protoset",
@@ -225,13 +226,6 @@ message SomeMessage {
 	testutil.Ok(t, err)
 
 	checkFile(t, &Printer{}, fd, "test-uninterpreted-options.proto")
-}
-
-func TestPrintEditions(t *testing.T) {
-	fd, err := loadProtoset("../../internal/testprotos/desc_test_editions.protoset")
-	testutil.Ok(t, err)
-
-	checkFile(t, &Printer{}, fd, "desc_test_editions-default.proto")
 }
 
 func TestPrintNonFileDescriptors(t *testing.T) {

--- a/desc/protoprint/testfiles/check-protos.sh
+++ b/desc/protoprint/testfiles/check-protos.sh
@@ -6,8 +6,6 @@ cd $(dirname $0)
 
 for f in *.proto; do
   echo -n "Checking $f..."
-  ../../../internal/testprotos/protoc/bin/protoc $f --experimental_editions -o tmp.protoset -I ../../../internal/testprotos -I .
+  ../../../internal/testprotos/protoc/bin/protoc $f --experimental_editions -o /dev/null -I ../../../internal/testprotos -I .
   echo "  good"
 done
-
-rm tmp.protoset

--- a/desc/protoprint/testfiles/desc_test_editions-compact.proto
+++ b/desc/protoprint/testfiles/desc_test_editions-compact.proto
@@ -1,0 +1,25 @@
+edition = "2023";
+package testprotos;
+option features = { enum_type: CLOSED };
+option go_package = "github.com/jhump/protoreflect/internal/testprotos";
+message Foo {
+  reserved reserved_field;
+  int32 a = 1;
+  int32 required_field = 2 [features = { field_presence: LEGACY_REQUIRED }];
+  int32 default_field = 3 [default = 99];
+  DelimitedField delimitedfield = 4 [features = { message_encoding: DELIMITED }];
+  message DelimitedField {
+    int32 b = 1;
+  }
+}
+enum Closed {
+  CLOSED_C = 1;
+  CLOSED_A = 2;
+  reserved CLOSED_E, CLOSED_F;
+}
+enum Open {
+  option features = { enum_type: OPEN };
+  OPEN_B = 0;
+  OPEN_C = -1;
+  OPEN_A = 2;
+}

--- a/desc/protoprint/testfiles/desc_test_editions-custom-sort.proto
+++ b/desc/protoprint/testfiles/desc_test_editions-custom-sort.proto
@@ -1,0 +1,41 @@
+edition = "2023";
+
+enum Open {
+  OPEN_B = 0;
+
+  OPEN_C = -1;
+
+  OPEN_A = 2;
+
+  option features = { enum_type: OPEN };
+}
+
+enum Closed {
+  CLOSED_C = 1;
+
+  CLOSED_A = 2;
+
+  reserved CLOSED_F, CLOSED_E;
+}
+
+message Foo {
+  reserved reserved_field;
+
+  message DelimitedField {
+    int32 b = 1;
+  }
+
+  int32 required_field = 2 [features = { field_presence: LEGACY_REQUIRED }];
+
+  DelimitedField delimitedfield = 4 [features = { message_encoding: DELIMITED }];
+
+  int32 default_field = 3 [default = 99];
+
+  int32 a = 1;
+}
+
+option go_package = "github.com/jhump/protoreflect/internal/testprotos";
+
+option features = { enum_type: CLOSED };
+
+package testprotos;

--- a/desc/protoprint/testfiles/desc_test_editions-multiline-style-comments.proto
+++ b/desc/protoprint/testfiles/desc_test_editions-multiline-style-comments.proto
@@ -1,0 +1,41 @@
+edition = "2023";
+
+package testprotos;
+
+option features = { enum_type: CLOSED };
+
+option go_package = "github.com/jhump/protoreflect/internal/testprotos";
+
+message Foo {
+	reserved reserved_field;
+
+	int32 a = 1;
+
+	int32 required_field = 2 [features = { field_presence: LEGACY_REQUIRED }];
+
+	int32 default_field = 3 [default = 99];
+
+	DelimitedField delimitedfield = 4 [features = { message_encoding: DELIMITED }];
+
+	message DelimitedField {
+		int32 b = 1;
+	}
+}
+
+enum Closed {
+	CLOSED_C = 1;
+
+	CLOSED_A = 2;
+
+	reserved CLOSED_E, CLOSED_F;
+}
+
+enum Open {
+	option features = { enum_type: OPEN };
+
+	OPEN_B = 0;
+
+	OPEN_C = -1;
+
+	OPEN_A = 2;
+}

--- a/desc/protoprint/testfiles/desc_test_editions-no-trailing-comments.proto
+++ b/desc/protoprint/testfiles/desc_test_editions-no-trailing-comments.proto
@@ -1,0 +1,41 @@
+edition = "2023";
+
+package testprotos;
+
+option features = { enum_type: CLOSED };
+
+option go_package = "github.com/jhump/protoreflect/internal/testprotos";
+
+message Foo {
+  reserved reserved_field;
+
+  int32 a = 1;
+
+  int32 required_field = 2 [features = { field_presence: LEGACY_REQUIRED }];
+
+  int32 default_field = 3 [default = 99];
+
+  DelimitedField delimitedfield = 4 [features = { message_encoding: DELIMITED }];
+
+  message DelimitedField {
+    int32 b = 1;
+  }
+}
+
+enum Closed {
+  CLOSED_C = 1;
+
+  CLOSED_A = 2;
+
+  reserved CLOSED_E, CLOSED_F;
+}
+
+enum Open {
+  option features = { enum_type: OPEN };
+
+  OPEN_B = 0;
+
+  OPEN_C = -1;
+
+  OPEN_A = 2;
+}

--- a/desc/protoprint/testfiles/desc_test_editions-only-doc-comments.proto
+++ b/desc/protoprint/testfiles/desc_test_editions-only-doc-comments.proto
@@ -1,0 +1,41 @@
+edition = "2023";
+
+package testprotos;
+
+option features = { enum_type: CLOSED };
+
+option go_package = "github.com/jhump/protoreflect/internal/testprotos";
+
+message Foo {
+  reserved reserved_field;
+
+  int32 a = 1;
+
+  int32 required_field = 2 [features = { field_presence: LEGACY_REQUIRED }];
+
+  int32 default_field = 3 [default = 99];
+
+  DelimitedField delimitedfield = 4 [features = { message_encoding: DELIMITED }];
+
+  message DelimitedField {
+    int32 b = 1;
+  }
+}
+
+enum Closed {
+  CLOSED_C = 1;
+
+  CLOSED_A = 2;
+
+  reserved CLOSED_E, CLOSED_F;
+}
+
+enum Open {
+  option features = { enum_type: OPEN };
+
+  OPEN_B = 0;
+
+  OPEN_C = -1;
+
+  OPEN_A = 2;
+}

--- a/desc/protoprint/testfiles/desc_test_editions-sorted-AND-multiline-style-comments.proto
+++ b/desc/protoprint/testfiles/desc_test_editions-sorted-AND-multiline-style-comments.proto
@@ -1,0 +1,41 @@
+edition = "2023";
+
+package testprotos;
+
+option features = { enum_type: CLOSED };
+
+option go_package = "github.com/jhump/protoreflect/internal/testprotos";
+
+message Foo {
+  int32 a = 1;
+
+  int32 required_field = 2 [features = { field_presence: LEGACY_REQUIRED }];
+
+  int32 default_field = 3 [default = 99];
+
+  DelimitedField delimitedfield = 4 [features = { message_encoding: DELIMITED }];
+
+  message DelimitedField {
+    int32 b = 1;
+  }
+
+  reserved reserved_field;
+}
+
+enum Closed {
+  CLOSED_C = 1;
+
+  CLOSED_A = 2;
+
+  reserved CLOSED_E, CLOSED_F;
+}
+
+enum Open {
+  option features = { enum_type: OPEN };
+
+  OPEN_B = 0;
+
+  OPEN_C = -1;
+
+  OPEN_A = 2;
+}

--- a/desc/protoprint/testfiles/desc_test_editions-sorted.proto
+++ b/desc/protoprint/testfiles/desc_test_editions-sorted.proto
@@ -1,0 +1,41 @@
+edition = "2023";
+
+package testprotos;
+
+option features = { enum_type: CLOSED };
+
+option go_package = "github.com/jhump/protoreflect/internal/testprotos";
+
+message Foo {
+   int32 a = 1;
+
+   int32 required_field = 2 [features = { field_presence: LEGACY_REQUIRED }];
+
+   int32 default_field = 3 [default = 99];
+
+   DelimitedField delimitedfield = 4 [features = { message_encoding: DELIMITED }];
+
+   message DelimitedField {
+      int32 b = 1;
+   }
+
+   reserved reserved_field;
+}
+
+enum Closed {
+   CLOSED_C = 1;
+
+   CLOSED_A = 2;
+
+   reserved CLOSED_E, CLOSED_F;
+}
+
+enum Open {
+   option features = { enum_type: OPEN };
+
+   OPEN_B = 0;
+
+   OPEN_C = -1;
+
+   OPEN_A = 2;
+}

--- a/desc/protoprint/testfiles/desc_test_editions-trailing-on-next-line.proto
+++ b/desc/protoprint/testfiles/desc_test_editions-trailing-on-next-line.proto
@@ -1,0 +1,41 @@
+edition = "2023";
+
+package testprotos;
+
+option features = { enum_type: CLOSED };
+
+option go_package = "github.com/jhump/protoreflect/internal/testprotos";
+
+message Foo {
+  reserved reserved_field;
+
+  int32 a = 1;
+
+  int32 required_field = 2 [features = { field_presence: LEGACY_REQUIRED }];
+
+  int32 default_field = 3 [default = 99];
+
+  DelimitedField delimitedfield = 4 [features = { message_encoding: DELIMITED }];
+
+  message DelimitedField {
+    int32 b = 1;
+  }
+}
+
+enum Closed {
+  CLOSED_C = 1;
+
+  CLOSED_A = 2;
+
+  reserved CLOSED_E, CLOSED_F;
+}
+
+enum Open {
+  option features = { enum_type: OPEN };
+
+  OPEN_B = 0;
+
+  OPEN_C = -1;
+
+  OPEN_A = 2;
+}


### PR DESCRIPTION
This expands test coverage to use various permutations of printer options, which uncovered an issue w/ custom sort order.