### PR TITLE
grpcreflect: add flag to make Client try to be lenient in the face of missing dependencies

### DIFF
--- a/grpcreflect/client.go
+++ b/grpcreflect/client.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/golang/protobuf/proto"
@@ -62,14 +63,31 @@ const (
 )
 
 func symbolNotFound(symbol string, symType symbolType, cause *elementNotFoundError) error {
+	if cause != nil && cause.kind == elementKindSymbol && cause.name == symbol {
+		// no need to wrap
+		if symType != symbolTypeUnknown && cause.symType == symbolTypeUnknown {
+			// We previously didn't know symbol type but now do?
+			// Create a new error that has the right symbol type.
+			return &elementNotFoundError{name: symbol, symType: symType, kind: elementKindSymbol}
+		}
+		return cause
+	}
 	return &elementNotFoundError{name: symbol, symType: symType, kind: elementKindSymbol, cause: cause}
 }
 
 func extensionNotFound(extendee string, tag int32, cause *elementNotFoundError) error {
+	if cause != nil && cause.kind == elementKindExtension && cause.name == extendee && cause.tag == tag {
+		// no need to wrap
+		return cause
+	}
 	return &elementNotFoundError{name: extendee, tag: tag, kind: elementKindExtension, cause: cause}
 }
 
 func fileNotFound(file string, cause *elementNotFoundError) error {
+	if cause != nil && cause.kind == elementKindFile && cause.name == file {
+		// no need to wrap
+		return cause
+	}
 	return &elementNotFoundError{name: file, kind: elementKindFile, cause: cause}
 }
 
@@ -80,15 +98,15 @@ func (e *elementNotFoundError) Error() string {
 		if first {
 			first = false
 		} else {
-			fmt.Fprint(&b, "\ncaused by: ")
+			_, _ = fmt.Fprint(&b, "\ncaused by: ")
 		}
 		switch e.kind {
 		case elementKindSymbol:
-			fmt.Fprintf(&b, "%s not found: %s", e.symType, e.name)
+			_, _ = fmt.Fprintf(&b, "%s not found: %s", e.symType, e.name)
 		case elementKindExtension:
-			fmt.Fprintf(&b, "Extension not found: tag %d for %s", e.tag, e.name)
+			_, _ = fmt.Fprintf(&b, "Extension not found: tag %d for %s", e.tag, e.name)
 		default:
-			fmt.Fprintf(&b, "File not found: %s", e.name)
+			_, _ = fmt.Fprintf(&b, "File not found: %s", e.name)
 		}
 	}
 	return b.String()
@@ -119,10 +137,11 @@ type extDesc struct {
 // Client is a client connection to a server for performing reflection calls
 // and resolving remote symbols.
 type Client struct {
-	ctx         context.Context
-	now         func() time.Time
-	stubV1      refv1.ServerReflectionClient
-	stubV1Alpha refv1alpha.ServerReflectionClient
+	ctx          context.Context
+	now          func() time.Time
+	stubV1       refv1.ServerReflectionClient
+	stubV1Alpha  refv1alpha.ServerReflectionClient
+	allowMissing atomic.Bool
 
 	connMu      sync.Mutex
 	cancel      context.CancelFunc
@@ -184,6 +203,15 @@ func NewClientAuto(ctx context.Context, cc grpc.ClientConnInterface) *Client {
 	stubv1 := refv1.NewServerReflectionClient(cc)
 	stubv1alpha := refv1alpha.NewServerReflectionClient(cc)
 	return newClient(ctx, stubv1, stubv1alpha)
+}
+
+// AllowMissingFileDescriptors configures the client to allow missing files
+// when building descriptors when possible. Missing files are often fatal
+// errors, but with this option they can sometimes be worked around. Building
+// a schema can only succeed with some files missing if the files in question
+// only provide custom options and/or other unused types.
+func (cr *Client) AllowMissingFileDescriptors() {
+	cr.allowMissing.Store(true)
 }
 
 // TODO: We should also have a NewClientV1. However that should not refer to internal
@@ -354,16 +382,34 @@ func (cr *Client) getAndCacheFileDescriptors(req *refv1alpha.ServerReflectionReq
 }
 
 func (cr *Client) descriptorFromProto(fd *descriptorpb.FileDescriptorProto) (*desc.FileDescriptor, error) {
-	deps := make([]*desc.FileDescriptor, len(fd.GetDependency()))
+	allowMissing := cr.allowMissing.Load()
+	deps := make([]*desc.FileDescriptor, 0, len(fd.GetDependency()))
+	var deferredErr error
+	var missingDeps []int
 	for i, depName := range fd.GetDependency() {
 		if dep, err := cr.FileByFilename(depName); err != nil {
-			return nil, err
+			if _, ok := err.(*elementNotFoundError); !ok || !allowMissing {
+				return nil, err
+			}
+			// We'll ignore for now to see if the file is really necessary.
+			// (If it only supplies custom options, we can get by without it.)
+			if deferredErr == nil {
+				deferredErr = err
+			}
+			missingDeps = append(missingDeps, i)
 		} else {
-			deps[i] = dep
+			deps = append(deps, dep)
 		}
+	}
+	if len(missingDeps) > 0 {
+		fd = fileWithoutDeps(fd, missingDeps)
 	}
 	d, err := desc.CreateFileDescriptor(fd, deps...)
 	if err != nil {
+		if deferredErr != nil {
+			// assume the issue is the missing dep
+			return nil, deferredErr
+		}
 		return nil, err
 	}
 	d = cr.cacheFile(d)
@@ -699,6 +745,46 @@ func (cr *Client) ResolveExtension(extendedType string, extensionNumber int32) (
 	} else {
 		return d, nil
 	}
+}
+
+func fileWithoutDeps(fd *descriptorpb.FileDescriptorProto, missingDeps []int) *descriptorpb.FileDescriptorProto {
+	// We need to rebuild the file without the missing deps.
+	fd = proto.Clone(fd).(*descriptorpb.FileDescriptorProto)
+	newNumDeps := len(fd.GetDependency()) - len(missingDeps)
+	newDeps := make([]string, 0, newNumDeps)
+	remapped := make(map[int]int, newNumDeps)
+	missingIdx := 0
+	for i, dep := range fd.GetDependency() {
+		if missingIdx < len(missingDeps) {
+			if i == missingDeps[missingIdx] {
+				// This dep was missing. Skip it.
+				missingIdx++
+				continue
+			}
+		}
+		remapped[i] = len(newDeps)
+		newDeps = append(newDeps, dep)
+	}
+	// Also rebuild public and weak import slices.
+	newPublic := make([]int32, 0, len(fd.GetPublicDependency()))
+	for _, idx := range fd.GetPublicDependency() {
+		newIdx, ok := remapped[int(idx)]
+		if ok {
+			newPublic = append(newPublic, int32(newIdx))
+		}
+	}
+	newWeak := make([]int32, 0, len(fd.GetWeakDependency()))
+	for _, idx := range fd.GetWeakDependency() {
+		newIdx, ok := remapped[int(idx)]
+		if ok {
+			newWeak = append(newWeak, int32(newIdx))
+		}
+	}
+
+	fd.Dependency = newDeps
+	fd.PublicDependency = newPublic
+	fd.WeakDependency = newWeak
+	return fd
 }
 
 func findExtension(extendedType string, extensionNumber int32, scope extensionScope) *desc.FieldDescriptor {


### PR DESCRIPTION
Ever since v1.15 was released, the `grpcreflect` package inadvertently became more strict:
1. It suddenly wraps the protobuf-go runtime's `protoreflect` descriptors, which means creating descriptors uses the protobuf-go runtime's `protodesc` package. That package is more strict and does more validation than this repo's `desc` package.
2. Before v1.61.0 of the grpc-go runtime, the reflection service would send back invalid file descriptors -- "placeholder" values that represent missing dependencies. Pre-v1.15 of this repo, if the file was actually unused or only provided custom options, no problem. The `desc` package was doing enough validation to realize the descriptor was junk. But starting with v1.15, this would result in an error.

So, if a file was imported only for custom options (for things like OpenAPI annotations, validation options, etc), it was previously allowed to be missing. But that is no longer the case.

This has actually caused some issues for users of `grpcurl`, which uses the `grpcreflect` package in this repo. See, for 
example, https://github.com/fullstorydev/grpcurl/issues/423, https://github.com/fullstorydev/grpcurl/issues/432, and https://github.com/fullstorydev/grpcurl/issues/451.

In these cases, prior to `grpcurl` pulling in v1.15 of this repo, things worked and the files that would later cause issues were effectively ignored (and okay to ignore because they were just providing custom options, not necessary for the descriptors to actually be linked). But since v1.15, they fail.

This branch adds a new method to `*grpcreflect.Client`, allowing callers to opt-in to lenient behavior that will effectively ignore "file not found" errors when downloading the schema from the server. If the missing file is not actually necessary to link the descriptors, the client will not complain about the missing file and instead return the requested schema (though any custom options provided by the missing files will be uninterpretable).
