### PR TITLE
Allow grpcreflect to fall back to provided resolvers

### DIFF
--- a/grpcreflect/adapt.go
+++ b/grpcreflect/adapt.go
@@ -83,48 +83,48 @@ func toV1AlphaRequest(v1 *refv1.ServerReflectionRequest) *refv1alpha.ServerRefle
 	return &v1alpha
 }
 
-func toV1AlphaResponse(v1 *refv1.ServerReflectionResponse) *refv1alpha.ServerReflectionResponse {
-	var v1alpha refv1alpha.ServerReflectionResponse
-	v1alpha.ValidHost = v1.ValidHost
-	if v1.OriginalRequest != nil {
-		v1alpha.OriginalRequest = toV1AlphaRequest(v1.OriginalRequest)
+func toV1Response(v1alpha *refv1alpha.ServerReflectionResponse) *refv1.ServerReflectionResponse {
+	var v1 refv1.ServerReflectionResponse
+	v1.ValidHost = v1alpha.ValidHost
+	if v1alpha.OriginalRequest != nil {
+		v1.OriginalRequest = toV1Request(v1alpha.OriginalRequest)
 	}
-	switch mr := v1.MessageResponse.(type) {
-	case *refv1.ServerReflectionResponse_FileDescriptorResponse:
+	switch mr := v1alpha.MessageResponse.(type) {
+	case *refv1alpha.ServerReflectionResponse_FileDescriptorResponse:
 		if mr != nil {
-			v1alpha.MessageResponse = &refv1alpha.ServerReflectionResponse_FileDescriptorResponse{
-				FileDescriptorResponse: &refv1alpha.FileDescriptorResponse{
+			v1.MessageResponse = &refv1.ServerReflectionResponse_FileDescriptorResponse{
+				FileDescriptorResponse: &refv1.FileDescriptorResponse{
 					FileDescriptorProto: mr.FileDescriptorResponse.GetFileDescriptorProto(),
 				},
 			}
 		}
-	case *refv1.ServerReflectionResponse_AllExtensionNumbersResponse:
+	case *refv1alpha.ServerReflectionResponse_AllExtensionNumbersResponse:
 		if mr != nil {
-			v1alpha.MessageResponse = &refv1alpha.ServerReflectionResponse_AllExtensionNumbersResponse{
-				AllExtensionNumbersResponse: &refv1alpha.ExtensionNumberResponse{
+			v1.MessageResponse = &refv1.ServerReflectionResponse_AllExtensionNumbersResponse{
+				AllExtensionNumbersResponse: &refv1.ExtensionNumberResponse{
 					BaseTypeName:    mr.AllExtensionNumbersResponse.GetBaseTypeName(),
 					ExtensionNumber: mr.AllExtensionNumbersResponse.GetExtensionNumber(),
 				},
 			}
 		}
-	case *refv1.ServerReflectionResponse_ListServicesResponse:
+	case *refv1alpha.ServerReflectionResponse_ListServicesResponse:
 		if mr != nil {
-			svcs := make([]*refv1alpha.ServiceResponse, len(mr.ListServicesResponse.GetService()))
+			svcs := make([]*refv1.ServiceResponse, len(mr.ListServicesResponse.GetService()))
 			for i, svc := range mr.ListServicesResponse.GetService() {
-				svcs[i] = &refv1alpha.ServiceResponse{
+				svcs[i] = &refv1.ServiceResponse{
 					Name: svc.GetName(),
 				}
 			}
-			v1alpha.MessageResponse = &refv1alpha.ServerReflectionResponse_ListServicesResponse{
-				ListServicesResponse: &refv1alpha.ListServiceResponse{
+			v1.MessageResponse = &refv1.ServerReflectionResponse_ListServicesResponse{
+				ListServicesResponse: &refv1.ListServiceResponse{
 					Service: svcs,
 				},
 			}
 		}
-	case *refv1.ServerReflectionResponse_ErrorResponse:
+	case *refv1alpha.ServerReflectionResponse_ErrorResponse:
 		if mr != nil {
-			v1alpha.MessageResponse = &refv1alpha.ServerReflectionResponse_ErrorResponse{
-				ErrorResponse: &refv1alpha.ErrorResponse{
+			v1.MessageResponse = &refv1.ServerReflectionResponse_ErrorResponse{
+				ErrorResponse: &refv1.ErrorResponse{
 					ErrorCode:    mr.ErrorResponse.GetErrorCode(),
 					ErrorMessage: mr.ErrorResponse.GetErrorMessage(),
 				},
@@ -133,5 +133,5 @@ func toV1AlphaResponse(v1 *refv1.ServerReflectionResponse) *refv1alpha.ServerRef
 	default:
 		// no value set
 	}
-	return &v1alpha
+	return &v1
 }

--- a/grpcreflect/client_test.go
+++ b/grpcreflect/client_test.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/reflection"
+	reflectv1 "google.golang.org/grpc/reflection/grpc_reflection_v1"
 	reflectv1alpha "google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/reflect/protodesc"
@@ -208,8 +209,9 @@ func TestAllExtensionNumbersForType(t *testing.T) {
 	sort.Ints(inums)
 	testutil.Eq(t, []int{100, 101, 102, 103, 200}, inums)
 
-	_, err = client.AllExtensionNumbersForType("does not exist")
-	testutil.Require(t, IsElementNotFoundError(err))
+	nums, err = client.AllExtensionNumbersForType("does not exist")
+	testutil.Ok(t, err)
+	testutil.Eq(t, 0, len(nums))
 }
 
 func TestListServices(t *testing.T) {
@@ -287,7 +289,7 @@ func TestMultipleFiles(t *testing.T) {
 	dialCtx, dialCancel := context.WithTimeout(ctx, 3*time.Second)
 	defer dialCancel()
 	cc, err := grpc.DialContext(dialCtx, l.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
-	testutil.Ok(t, err, "failed ot dial %v", l.Addr().String())
+	testutil.Ok(t, err, "failed to dial %v", l.Addr().String())
 	cl := reflectv1alpha.NewServerReflectionClient(cc)
 
 	client := NewClientV1Alpha(ctx, cl)
@@ -331,7 +333,7 @@ func TestAllowMissingFileDescriptors(t *testing.T) {
 	dialCtx, dialCancel := context.WithTimeout(ctx, 3*time.Second)
 	defer dialCancel()
 	cc, err := grpc.DialContext(dialCtx, l.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
-	testutil.Ok(t, err, "failed ot dial %v", l.Addr().String())
+	testutil.Ok(t, err, "failed to dial %v", l.Addr().String())
 	cl := reflectv1alpha.NewServerReflectionClient(cc)
 
 	client := NewClientV1Alpha(ctx, cl)
@@ -351,24 +353,19 @@ func TestAllowMissingFileDescriptors(t *testing.T) {
 	testutil.Ok(t, err)
 	testutil.Require(t, file != nil)
 	testutil.Eq(t, "foo/bar/this.proto", file.GetName())
-	_, err = client.FileContainingSymbol("foo.bar.Bar")
+	file, err = client.FileContainingSymbol("foo.bar.Bar")
 	testutil.Ok(t, err)
 	testutil.Require(t, file != nil)
 	testutil.Eq(t, "foo/bar/this.proto", file.GetName())
-	_, err = client.FileContainingExtension("google.protobuf.MessageOptions", 10101)
+	file, err = client.FileContainingExtension("google.protobuf.MessageOptions", 10101)
 	testutil.Ok(t, err)
 	testutil.Require(t, file != nil)
-	testutil.Eq(t, "foo/bar/this.proto", file.GetName())
+	testutil.Eq(t, "test/imported.proto", file.GetName())
 }
 
 func TestAllowFallbackResolver(t *testing.T) {
 	svr := grpc.NewServer()
-	files := createFilesWithMissingDeps(t)
-	reflectionSvc := reflection.NewServer(reflection.ServerOptions{
-		DescriptorResolver: files,
-		ExtensionResolver:  files,
-	})
-	reflectv1alpha.RegisterServerReflectionServer(svr, reflectionSvc)
+	reflection.RegisterV1(svr)
 
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	testutil.Ok(t, err, "failed to listen")
@@ -389,34 +386,73 @@ func TestAllowFallbackResolver(t *testing.T) {
 	dialCtx, dialCancel := context.WithTimeout(ctx, 3*time.Second)
 	defer dialCancel()
 	cc, err := grpc.DialContext(dialCtx, l.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
-	testutil.Ok(t, err, "failed ot dial %v", l.Addr().String())
-	cl := reflectv1alpha.NewServerReflectionClient(cc)
+	testutil.Ok(t, err, "failed to dial %v", l.Addr().String())
+	cl := reflectv1.NewServerReflectionClient(cc)
 
-	client := NewClientV1Alpha(ctx, cl)
+	client := NewClientV1(ctx, cl)
 	defer client.Reset()
 
-	// First we try some things that should fail due to missing descriptors.
+	// First sanity-check that the well-known types are there.
+	file, err := client.FileByFilename("google/protobuf/descriptor.proto")
+	testutil.Ok(t, err)
+	testutil.Eq(t, "google/protobuf/descriptor.proto", file.GetName())
+	// Now we try some things that should fail due to missing descriptors.
 	_, err = client.FileByFilename("foo/bar/this.proto")
 	testutil.Nok(t, err)
 	_, err = client.FileContainingSymbol("foo.bar.Bar")
 	testutil.Nok(t, err)
-	_, err = client.FileContainingExtension("google.protobuf.MessageOptions", 10101)
+	file, err = client.FileContainingExtension("google.protobuf.MessageOptions", 23456)
 	testutil.Nok(t, err)
+	nums, err := client.AllExtensionNumbersForType("google.protobuf.MessageOptions")
+	testutil.Ok(t, err)
+	withoutFallbackExts := len(nums)
 
-	client.AllowMissingFileDescriptors()
-	// Now the above queries should succeed.
-	file, err := client.FileByFilename("foo/bar/this.proto")
+	// Now we configure a fallback.
+	fdp := &descriptorpb.FileDescriptorProto{
+		Name:       proto.String("foo/bar/this.proto"),
+		Package:    proto.String("foo.bar"),
+		Dependency: []string{"google/protobuf/descriptor.proto"},
+		MessageType: []*descriptorpb.DescriptorProto{
+			{
+				Name: proto.String("Bar"),
+			},
+		},
+		Extension: []*descriptorpb.FieldDescriptorProto{
+			{
+				Name:     proto.String("opt"),
+				Extendee: proto.String(".google.protobuf.MessageOptions"),
+				Label:    descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+				Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+				TypeName: proto.String(".foo.bar.Bar"),
+				Number:   proto.Int32(23456),
+			},
+		},
+	}
+	fd, err := protodesc.NewFile(fdp, protoregistry.GlobalFiles)
+	testutil.Ok(t, err)
+	var files files
+	err = files.RegisterFile(fd)
+	testutil.Ok(t, err)
+
+	client.AllowFallbackResolver(&files, &files)
+
+	// The above queries should now succeed.
+	file, err = client.FileByFilename("foo/bar/this.proto")
 	testutil.Ok(t, err)
 	testutil.Require(t, file != nil)
 	testutil.Eq(t, "foo/bar/this.proto", file.GetName())
-	_, err = client.FileContainingSymbol("foo.bar.Bar")
+	file, err = client.FileContainingSymbol("foo.bar.Bar")
 	testutil.Ok(t, err)
 	testutil.Require(t, file != nil)
 	testutil.Eq(t, "foo/bar/this.proto", file.GetName())
-	_, err = client.FileContainingExtension("google.protobuf.MessageOptions", 10101)
+	file, err = client.FileContainingExtension("google.protobuf.MessageOptions", 23456)
 	testutil.Ok(t, err)
 	testutil.Require(t, file != nil)
 	testutil.Eq(t, "foo/bar/this.proto", file.GetName())
+	nums, err = client.AllExtensionNumbersForType("google.protobuf.MessageOptions")
+	testutil.Ok(t, err)
+	// The same extensions as before, plus an extra one provided by the fallback.
+	testutil.Eq(t, withoutFallbackExts+1, len(nums))
 }
 
 func TestFileWithoutDeps(t *testing.T) {


### PR DESCRIPTION
If given `protoregistry.GlobalFiles` and `protoregistry.GlobalTypes`, this allows it to fallback to locally known descriptors if a server is unable to provide part of the schema.