### PR TITLE
fix: fix slice init length

### DIFF
--- a/protoresolve/remotereg/converter.go
+++ b/protoresolve/remotereg/converter.go
@@ -449,7 +449,7 @@ func defaultValueString(k protoreflect.Kind, v protoreflect.Value, evd protorefl
 		return v.String()
 	case protoreflect.BytesKind:
 		b := v.Bytes()
-		s := make([]byte, len(b))
+		s := make([]byte, 0, len(b))
 		for _, c := range b {
 			switch c {
 			case '\n':


### PR DESCRIPTION
The intention here should be to initialize a slice with a capacity of   `len(b)` rather than initializing the length of this slice. 

The online demo: https://go.dev/play/p/q1BcVCmvidW