### PR TITLE
Qualify types when sub-package begins with a proto keyword

### DIFF
--- a/protoprint/field_type_keyword_test.go
+++ b/protoprint/field_type_keyword_test.go
@@ -48,6 +48,33 @@ message Foo {
 		})
 	}
 
+	// "export" and "local" are visibility modifiers introduced in edition
+	// 2024; protoc rejects the relative form there. Test inputs use edition
+	// 2023 (which accepts the relative form) because protocompile does not
+	// yet support 2024, so these subtests detect the bug only via the
+	// substring assertion.
+	//
+	// TODO: Update to use newer protocompile which supports edition 2024.
+	for _, kw := range []string{"export", "local"} {
+		t.Run("editions_message_field_type_in_subpackage_"+kw, func(t *testing.T) {
+			t.Parallel()
+			files := map[string]string{
+				fmt.Sprintf("pkg/%s/dep.proto", kw): fmt.Sprintf(`edition = "2023";
+package pkg.%s;
+message X {
+  string name = 1;
+}`, kw),
+				"pkg/root.proto": fmt.Sprintf(`edition = "2023";
+package pkg;
+import "pkg/%[1]s/dep.proto";
+message Foo {
+  pkg.%[1]s.X v = 1;
+}`, kw),
+			}
+			runPrintTest(t, files, "pkg/root.proto", fmt.Sprintf(".pkg.%s.X", kw))
+		})
+	}
+
 	t.Run("rpc_type_in_subpackage_stream", func(t *testing.T) {
 		t.Parallel()
 		files := map[string]string{
@@ -102,9 +129,6 @@ func runPrintTest(t *testing.T, files map[string]string, entry, wantTypeRef stri
 	require.NoError(t, err, "PrintProtoFile returned error")
 	printed := buf.String()
 
-	require.Contains(t, printed, wantTypeRef,
-		"printed output uses the relative form instead of leading-dot FQN")
-
 	roundTripFiles := maps.Clone(files)
 	roundTripFiles[entry] = printed
 
@@ -115,4 +139,7 @@ func runPrintTest(t *testing.T, files map[string]string, entry, wantTypeRef stri
 	}
 	_, err = roundTrip.Compile(t.Context(), entry)
 	require.NoError(t, err, "round-trip compile failed; printed output is not valid proto:\n%s", printed)
+
+	require.Contains(t, printed, wantTypeRef,
+		"printed output uses the relative form instead of leading-dot FQN")
 }

--- a/protoprint/field_type_keyword_test.go
+++ b/protoprint/field_type_keyword_test.go
@@ -48,6 +48,24 @@ message Foo {
 		})
 	}
 
+	t.Run("rpc_type_in_subpackage_stream", func(t *testing.T) {
+		t.Parallel()
+		files := map[string]string{
+			"pkg/stream/dep.proto": `syntax = "proto3";
+package pkg.stream;
+message X {
+  string name = 1;
+}`,
+			"pkg/root.proto": `syntax = "proto3";
+package pkg;
+import "pkg/stream/dep.proto";
+service S {
+  rpc Foo (.pkg.stream.X) returns (.pkg.stream.X);
+}`,
+		}
+		runPrintTest(t, files, "pkg/root.proto", ".pkg.stream.X")
+	})
+
 	t.Run("extendee_in_subpackage_group", func(t *testing.T) {
 		t.Parallel()
 		files := map[string]string{

--- a/protoprint/field_type_keyword_test.go
+++ b/protoprint/field_type_keyword_test.go
@@ -1,0 +1,100 @@
+package protoprint
+
+import (
+	"bytes"
+	"fmt"
+	"maps"
+	"testing"
+
+	"github.com/bufbuild/protocompile"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPrintTypeNameStartingWithFieldKeyword exercises the case where the
+// relative form of a printed type reference would begin with a proto keyword
+// that takes a different grammar branch at the start of a field declaration.
+// Each subtest covers a keyword the spec excludes from field-type
+// identifiers in regular, oneof, or extension field declarations, and
+// asserts the printed type uses the leading-dot fully-qualified form.
+func TestPrintTypeNameStartingWithFieldKeyword(t *testing.T) {
+	t.Parallel()
+
+	keywords := []string{
+		"group",
+		"optional", "required", "repeated",
+		"map",
+		"message", "enum", "oneof",
+		"reserved", "extensions", "extend",
+		"option",
+	}
+
+	for _, kw := range keywords {
+		t.Run("message_field_type_in_subpackage_"+kw, func(t *testing.T) {
+			t.Parallel()
+			files := map[string]string{
+				fmt.Sprintf("pkg/%s/dep.proto", kw): fmt.Sprintf(`syntax = "proto3";
+package pkg.%s;
+message X {
+  string name = 1;
+}`, kw),
+				"pkg/root.proto": fmt.Sprintf(`syntax = "proto3";
+package pkg;
+import "pkg/%[1]s/dep.proto";
+message Foo {
+  pkg.%[1]s.X v = 1;
+}`, kw),
+			}
+			runPrintTest(t, files, "pkg/root.proto", fmt.Sprintf(".pkg.%s.X", kw))
+		})
+	}
+
+	t.Run("extendee_in_subpackage_group", func(t *testing.T) {
+		t.Parallel()
+		files := map[string]string{
+			"pkg/group/dep.proto": `syntax = "proto2";
+package pkg.group;
+message Opts {
+  extensions 50000 to 60000;
+}`,
+			"pkg/root.proto": `syntax = "proto2";
+package pkg;
+import "pkg/group/dep.proto";
+extend pkg.group.Opts {
+  optional string label = 50001;
+}`,
+		}
+		runPrintTest(t, files, "pkg/root.proto", ".pkg.group.Opts")
+	})
+}
+
+// runPrintTest compiles files, prints entry with protoprint, asserts the
+// printed output contains wantTypeRef, and re-parses the printed output to
+// catch other regressions.
+func runPrintTest(t *testing.T, files map[string]string, entry, wantTypeRef string) {
+	compiler := protocompile.Compiler{
+		Resolver: protocompile.WithStandardImports(&protocompile.SourceResolver{
+			Accessor: protocompile.SourceAccessorFromMap(files),
+		}),
+	}
+	fds, err := compiler.Compile(t.Context(), entry)
+	require.NoError(t, err, "input proto did not compile")
+
+	var buf bytes.Buffer
+	err = (&Printer{}).PrintProtoFile(fds[0], &buf)
+	require.NoError(t, err, "PrintProtoFile returned error")
+	printed := buf.String()
+
+	require.Contains(t, printed, wantTypeRef,
+		"printed output uses the relative form instead of leading-dot FQN")
+
+	roundTripFiles := maps.Clone(files)
+	roundTripFiles[entry] = printed
+
+	roundTrip := protocompile.Compiler{
+		Resolver: protocompile.WithStandardImports(&protocompile.SourceResolver{
+			Accessor: protocompile.SourceAccessorFromMap(roundTripFiles),
+		}),
+	}
+	_, err = roundTrip.Compile(t.Context(), entry)
+	require.NoError(t, err, "round-trip compile failed; printed output is not valid proto:\n%s", printed)
+}

--- a/protoprint/print.go
+++ b/protoprint/print.go
@@ -696,9 +696,10 @@ func (p *Printer) qualifyElementName(pkg, scope, fqn protoreflect.FullName, requ
 // qualifyTypeName is like qualifyName but falls back to a fully-qualified
 // leading-dot form if the relative result would begin with a proto keyword
 // that takes a different grammar branch at the start of a field
-// declaration or extend block. The keyword set is the union of the
-// keywords the spec excludes from field-type identifiers in regular,
-// oneof, and extension field declarations.
+// declaration, extend block, or RPC method type. The keyword set is the
+// union of the keywords the spec excludes from field-type identifiers in
+// regular, oneof, and extension field declarations and from RPC method
+// type identifiers.
 func (p *Printer) qualifyTypeName(pkg, scope, fqn protoreflect.FullName) string {
 	name := p.qualifyName(pkg, scope, fqn)
 	if p.ForceFullyQualifiedNames || strings.HasPrefix(name, ".") {
@@ -711,7 +712,8 @@ func (p *Printer) qualifyTypeName(pkg, scope, fqn protoreflect.FullName) string 
 		"map",
 		"message", "enum", "oneof",
 		"reserved", "extensions", "extend",
-		"option":
+		"option",
+		"stream":
 		if fqn[0] != '.' {
 			return "." + string(fqn)
 		}
@@ -1512,7 +1514,7 @@ func (p *Printer) printMethod(
 
 		_, _ = fmt.Fprint(w, "( ")
 		inSi := sourceInfo.ByPath(append(path, internal.MethodInputTag))
-		inName := p.qualifyName(pkg, pkg, mtd.Input().FullName())
+		inName := p.qualifyTypeName(pkg, pkg, mtd.Input().FullName())
 		if mtd.IsStreamingClient() {
 			inName = "stream " + inName
 		}
@@ -1521,7 +1523,7 @@ func (p *Printer) printMethod(
 		_, _ = fmt.Fprint(w, ") returns ( ")
 
 		outSi := sourceInfo.ByPath(append(path, internal.MethodOutputTag))
-		outName := p.qualifyName(pkg, pkg, mtd.Output().FullName())
+		outName := p.qualifyTypeName(pkg, pkg, mtd.Output().FullName())
 		if mtd.IsStreamingServer() {
 			outName = "stream " + outName
 		}

--- a/protoprint/print.go
+++ b/protoprint/print.go
@@ -699,8 +699,9 @@ func (p *Printer) qualifyElementName(pkg, scope, fqn protoreflect.FullName, requ
 // that takes a different grammar branch at the start of a field
 // declaration, extend block, or RPC method type. The keyword set is the
 // union of the keywords the spec excludes from field-type identifiers in
-// regular, oneof, and extension field declarations and from RPC method
-// type identifiers.
+// regular, oneof, and extension field declarations, from RPC method type
+// identifiers, and from the visibility-modifier position introduced by
+// editions.
 func (p *Printer) qualifyTypeName(pkg, scope, fqn protoreflect.FullName) string {
 	name := p.qualifyName(pkg, scope, fqn)
 	if p.ForceFullyQualifiedNames || strings.HasPrefix(name, ".") {
@@ -714,7 +715,9 @@ func (p *Printer) qualifyTypeName(pkg, scope, fqn protoreflect.FullName) string 
 		"message", "enum", "oneof",
 		"reserved", "extensions", "extend",
 		"option",
-		"stream":
+		"stream",
+		// Added in edition 2024.
+		"export", "local":
 		if fqn[0] != '.' {
 			return "." + string(fqn)
 		}

--- a/protoprint/print.go
+++ b/protoprint/print.go
@@ -656,6 +656,7 @@ func (p *Printer) qualifyExtensionLiteralName(pkg, scope, fqn protoreflect.FullN
 	return p.qualifyElementName(pkg, scope, fqn, -1)
 }
 
+// TODO: Neeeds to be reconciled with https://protobuf.com/docs/language-spec#reference-resolution.
 func (p *Printer) qualifyName(pkg, scope, fqn protoreflect.FullName) string {
 	return p.qualifyElementName(pkg, scope, fqn, 0)
 }

--- a/protoprint/print.go
+++ b/protoprint/print.go
@@ -335,7 +335,7 @@ func (p *Printer) printProto(dsc protoreflect.Descriptor, out io.Writer) error {
 		if d.IsExtension() {
 			_, _ = fmt.Fprint(w, "extend ")
 			extNameSi := sourceInfo.ByPath(append(path, internal.FieldExtendeeTag))
-			p.printElementString(extNameSi, w, 0, p.qualifyName(d.ParentFile().Package(), scope, d.ContainingMessage().FullName()))
+			p.printElementString(extNameSi, w, 0, p.qualifyTypeName(d.ParentFile().Package(), scope, d.ContainingMessage().FullName()))
 			_, _ = fmt.Fprintln(w, "{")
 
 			p.printField(d, &reg, w, sourceInfo, path, scope, 1)
@@ -693,20 +693,47 @@ func (p *Printer) qualifyElementName(pkg, scope, fqn protoreflect.FullName, requ
 	return string(fqn)
 }
 
+// qualifyTypeName is like qualifyName but falls back to a fully-qualified
+// leading-dot form if the relative result would begin with a proto keyword
+// that takes a different grammar branch at the start of a field
+// declaration or extend block. The keyword set is the union of the
+// keywords the spec excludes from field-type identifiers in regular,
+// oneof, and extension field declarations.
+func (p *Printer) qualifyTypeName(pkg, scope, fqn protoreflect.FullName) string {
+	name := p.qualifyName(pkg, scope, fqn)
+	if p.ForceFullyQualifiedNames || strings.HasPrefix(name, ".") {
+		return name
+	}
+	first, _, _ := strings.Cut(name, ".")
+	switch first {
+	case "group",
+		"optional", "required", "repeated",
+		"map",
+		"message", "enum", "oneof",
+		"reserved", "extensions", "extend",
+		"option":
+		if fqn[0] != '.' {
+			return "." + string(fqn)
+		}
+		return string(fqn)
+	}
+	return name
+}
+
 func (p *Printer) typeString(fld protoreflect.FieldDescriptor, scope protoreflect.FullName) string {
 	if fld.IsMap() {
 		return fmt.Sprintf("map<%s, %s>", p.typeString(fld.MapKey(), scope), p.typeString(fld.MapValue(), scope))
 	}
 	switch fld.Kind() {
 	case protoreflect.EnumKind:
-		return p.qualifyName(fld.ParentFile().Package(), scope, fld.Enum().FullName())
+		return p.qualifyTypeName(fld.ParentFile().Package(), scope, fld.Enum().FullName())
 	case protoreflect.GroupKind:
 		if isGroup(fld) {
 			return string(fld.Message().Name())
 		}
 		fallthrough
 	case protoreflect.MessageKind:
-		return p.qualifyName(fld.ParentFile().Package(), scope, fld.Message().FullName())
+		return p.qualifyTypeName(fld.ParentFile().Package(), scope, fld.Message().FullName())
 	default:
 		return fld.Kind().String()
 	}
@@ -1135,7 +1162,7 @@ func (p *Printer) printExtensions(
 	p.indent(w, indent)
 	_, _ = fmt.Fprint(w, "extend ")
 	extNameSi := sourceInfo.ByPath(append(path, 0, internal.FieldExtendeeTag))
-	p.printElementString(extNameSi, w, indent, p.qualifyName(pkg, scope, exts.extendee))
+	p.printElementString(extNameSi, w, indent, p.qualifyTypeName(pkg, scope, exts.extendee))
 	_, _ = fmt.Fprintln(w, "{")
 
 	if p.printTrailingComments(exts.sourceInfo, w, indent+1) && !p.Compact {


### PR DESCRIPTION
protoprint qualifies type references relative to the current scope. If a field's type lives in a sub-package whose name is a proto keyword (for example, a field of type `pkg.group.X` printed in package `pkg`), the relative form is `group.X`. Both protoc and protocompile reject this because the leading group token is consumed as a group keyword instead of as a type identifier.

Qualify type names with a leading dot when the relative name's first segment is one of the keywords the spec excludes from field-type identifiers.